### PR TITLE
docs: Update plugin.json to PostgreSQL 18+

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1327,7 +1327,7 @@
       "framework": "FastAPI",
       "language": "Python 3.11+",
       "orm": "SQLAlchemy 2.0",
-      "database": "PostgreSQL 15+ with pgvector",
+      "database": "PostgreSQL 18+ with pgvector",
       "workflows": "LangGraph 1.0",
       "validation": "Pydantic v2"
     },


### PR DESCRIPTION
## Summary
- Updates `tech_stack.backend.database` from PostgreSQL 15+ to PostgreSQL 18+
- Aligns plugin documentation with SkillForge's pg18 upgrade

## Test plan
- [x] Verify plugin.json references pg18

🤖 Generated with [Claude Code](https://claude.com/claude-code)