### PR TITLE
feat: Add marketplace plugin registry (v4.4.0)

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,48 @@
+# SkillForge Plugin Installation
+
+## Quick Start
+
+### From Marketplace
+
+```bash
+# Step 1: Add the marketplace
+/plugin marketplace add yonatangross/skillforge-claude-plugin
+
+# Step 2: Install (choose one)
+/plugin install skillforge-complete@complete         # Everything (61 skills)
+/plugin install skillforge-complete@ai-development   # AI/LLM skills (23 skills)
+/plugin install skillforge-complete@backend          # Backend skills (5 skills)
+/plugin install skillforge-complete@frontend         # Frontend skills (6 skills)
+/plugin install skillforge-complete@quality-testing  # Testing skills (14 skills)
+/plugin install skillforge-complete@devops-security  # DevOps skills (7 skills)
+/plugin install skillforge-complete@process-planning # Planning skills (6 skills)
+```
+
+### From GitHub
+
+```bash
+git clone https://github.com/yonatangross/skillforge-claude-plugin ~/.claude/plugins/skillforge
+```
+
+## Plugin Bundles
+
+| Bundle | Skills | Description |
+|--------|--------|-------------|
+| `complete` | 61 | Full toolkit with agents, commands, hooks |
+| `ai-development` | 23 | RAG, embeddings, LangGraph, caching |
+| `backend` | 5 | APIs, databases, streaming, resilience |
+| `frontend` | 6 | React 19, RSC, animations, edge |
+| `quality-testing` | 14 | Unit, E2E, mocking, golden datasets |
+| `devops-security` | 7 | CI/CD, observability, OWASP, auth |
+| `process-planning` | 6 | Brainstorming, ADRs, GitHub CLI |
+
+## Features
+
+- **Progressive Loading**: Skills use `capabilities.json` for token-efficient discovery
+- **20 Specialized Agents**: Product thinking + technical implementation
+- **11 Commands**: `/commit`, `/implement`, `/review-pr`, etc.
+- **29 Hooks**: Safety, auditing, auto-approval
+
+## More Information
+
+See the main [README.md](../README.md) for full documentation.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,131 @@
+{
+  "name": "skillforge-complete",
+  "displayName": "@skillforge/complete",
+  "owner": "yonatangross",
+  "version": "1.0.0",
+  "description": "The Complete AI Development Toolkit - 61 skills, 20 agents, 11 commands, 29 hooks",
+  "repository": "https://github.com/yonatangross/skillforge-claude-plugin",
+  "license": "MIT",
+  "strict": false,
+
+  "plugins": [
+    {
+      "name": "complete",
+      "description": "Full toolkit - all 61 skills, 20 agents, 11 commands, 29 hooks",
+      "skills": ["*"],
+      "includes_agents": true,
+      "includes_commands": true,
+      "includes_hooks": true
+    },
+    {
+      "name": "ai-development",
+      "description": "AI & LLM patterns: agents, RAG, embeddings, LangGraph, caching",
+      "skills": [
+        "agent-loops",
+        "cache-cost-tracking",
+        "context-compression",
+        "context-engineering",
+        "embeddings",
+        "function-calling",
+        "langfuse-observability",
+        "langgraph-checkpoints",
+        "langgraph-human-in-loop",
+        "langgraph-parallel",
+        "langgraph-routing",
+        "langgraph-state",
+        "langgraph-supervisor",
+        "llm-evaluation",
+        "llm-safety-patterns",
+        "llm-streaming",
+        "llm-testing",
+        "multi-agent-orchestration",
+        "ollama-local",
+        "pgvector-search",
+        "prompt-caching",
+        "rag-retrieval",
+        "semantic-caching"
+      ]
+    },
+    {
+      "name": "backend",
+      "description": "Backend patterns: APIs, databases, streaming, resilience",
+      "skills": [
+        "api-design-framework",
+        "database-schema-designer",
+        "resilience-patterns",
+        "streaming-api-patterns",
+        "type-safety-validation"
+      ]
+    },
+    {
+      "name": "frontend",
+      "description": "Frontend patterns: React 19, RSC, animations, i18n, edge",
+      "skills": [
+        "design-system-starter",
+        "edge-computing-patterns",
+        "i18n-date-patterns",
+        "motion-animation-patterns",
+        "performance-optimization",
+        "react-server-components-framework"
+      ]
+    },
+    {
+      "name": "quality-testing",
+      "description": "Testing patterns: unit, integration, E2E, mocking, golden datasets",
+      "skills": [
+        "code-review-playbook",
+        "e2e-testing",
+        "evidence-verification",
+        "golden-dataset-curation",
+        "golden-dataset-management",
+        "golden-dataset-validation",
+        "integration-testing",
+        "msw-mocking",
+        "performance-testing",
+        "quality-gates",
+        "test-data-management",
+        "unit-testing",
+        "vcr-http-recording",
+        "webapp-testing"
+      ]
+    },
+    {
+      "name": "devops-security",
+      "description": "DevOps & security: CI/CD, observability, OWASP, auth",
+      "skills": [
+        "auth-patterns",
+        "defense-in-depth",
+        "devops-deployment",
+        "input-validation",
+        "observability-monitoring",
+        "owasp-top-10",
+        "security-scanning"
+      ]
+    },
+    {
+      "name": "process-planning",
+      "description": "Planning patterns: brainstorming, ADRs, GitHub CLI",
+      "skills": [
+        "architecture-decision-record",
+        "ascii-visualizer",
+        "brainstorming",
+        "browser-content-capture",
+        "github-cli",
+        "system-design-interrogation"
+      ]
+    }
+  ],
+
+  "features": {
+    "agents": 20,
+    "commands": 11,
+    "hooks": 29,
+    "progressive_loading": true,
+    "capabilities_json": true
+  },
+
+  "installation": {
+    "full": "/plugin install skillforge-complete@complete",
+    "category": "/plugin install skillforge-complete@ai-development"
+  }
+}

--- a/.claude/schemas/marketplace.schema.json
+++ b/.claude/schemas/marketplace.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://skillforge.dev/schemas/marketplace.schema.json",
+  "title": "SkillForge Marketplace Plugin Schema",
+  "description": "Schema for validating marketplace.json plugin registry entries",
+  "type": "object",
+  "required": ["name", "version", "plugins"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Plugin package name",
+      "pattern": "^[a-z0-9-]+$"
+    },
+    "displayName": {
+      "type": "string",
+      "description": "Human-readable display name"
+    },
+    "owner": {
+      "type": "string",
+      "description": "GitHub username or organization"
+    },
+    "version": {
+      "type": "string",
+      "description": "Semantic version",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$"
+    },
+    "description": {
+      "type": "string",
+      "description": "Brief description of the plugin"
+    },
+    "repository": {
+      "type": "string",
+      "format": "uri",
+      "description": "GitHub repository URL"
+    },
+    "license": {
+      "type": "string",
+      "description": "SPDX license identifier"
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Whether to enforce strict skill matching",
+      "default": false
+    },
+    "plugins": {
+      "type": "array",
+      "description": "Available plugin bundles",
+      "items": {
+        "type": "object",
+        "required": ["name", "skills"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Bundle name for installation",
+            "pattern": "^[a-z0-9-]+$"
+          },
+          "description": {
+            "type": "string",
+            "description": "Bundle description"
+          },
+          "skills": {
+            "type": "array",
+            "description": "List of skill names or ['*'] for all",
+            "items": {
+              "type": "string"
+            }
+          },
+          "includes_agents": {
+            "type": "boolean",
+            "description": "Whether this bundle includes agents",
+            "default": false
+          },
+          "includes_commands": {
+            "type": "boolean",
+            "description": "Whether this bundle includes commands",
+            "default": false
+          },
+          "includes_hooks": {
+            "type": "boolean",
+            "description": "Whether this bundle includes hooks",
+            "default": false
+          }
+        }
+      }
+    },
+    "features": {
+      "type": "object",
+      "description": "Plugin feature summary",
+      "properties": {
+        "agents": {
+          "type": "integer",
+          "description": "Number of agents"
+        },
+        "commands": {
+          "type": "integer",
+          "description": "Number of commands"
+        },
+        "hooks": {
+          "type": "integer",
+          "description": "Number of hooks"
+        },
+        "progressive_loading": {
+          "type": "boolean",
+          "description": "Whether skills use progressive loading"
+        },
+        "capabilities_json": {
+          "type": "boolean",
+          "description": "Whether skills have capabilities.json"
+        }
+      }
+    },
+    "installation": {
+      "type": "object",
+      "description": "Example installation commands",
+      "properties": {
+        "full": {
+          "type": "string",
+          "description": "Command to install full plugin"
+        },
+        "category": {
+          "type": "string",
+          "description": "Example command to install a category"
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  61 skills | 11 commands | 20 agents | 29 hooks
+  61 skills | 11 commands | 20 agents | 29 hooks | 7 plugin bundles
 </p>
 
 ---
@@ -26,12 +26,34 @@
 
 ## Quick Start
 
-```bash
-# Install from Claude Plugin Registry
-claude plugin install @skillforge/complete
+### From Marketplace (Recommended)
 
-# Or clone from GitHub
-git clone https://github.com/yonatangross/skillforge-claude-plugin ~/.claude/plugins/skillforge-claude-plugin
+```bash
+# Step 1: Add the marketplace
+/plugin marketplace add yonatangross/skillforge-claude-plugin
+
+# Step 2: Install full toolkit or specific bundles
+/plugin install skillforge-complete@complete         # Everything (61 skills)
+
+# Or install specific categories:
+/plugin install skillforge-complete@ai-development   # AI/LLM skills (23 skills)
+/plugin install skillforge-complete@backend          # Backend skills (5 skills)
+/plugin install skillforge-complete@frontend         # Frontend skills (6 skills)
+/plugin install skillforge-complete@quality-testing  # Testing skills (14 skills)
+/plugin install skillforge-complete@devops-security  # DevOps skills (7 skills)
+/plugin install skillforge-complete@process-planning # Planning skills (6 skills)
+```
+
+### From GitHub (Manual)
+
+```bash
+git clone https://github.com/yonatangross/skillforge-claude-plugin ~/.claude/plugins/skillforge
+```
+
+### Project-Scoped (Copy to Project)
+
+```bash
+cp -r skillforge-claude-plugin/.claude your-project/.claude
 ```
 
 After installation, skills are automatically available when Claude Code detects relevant tasks.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: skillforge-complete
+description: Complete AI Development Toolkit for Claude Code
+version: 1.0.0
+owner: yonatangross
+license: MIT
+---
+
+# SkillForge Complete
+
+The Complete AI Development Toolkit - 61 skills, 20 agents, 11 commands, 29 hooks.
+
+## When to Activate
+
+- Building AI/LLM applications (RAG, agents, embeddings)
+- Full-stack development with React 19 / Next.js 15
+- Database design and query optimization
+- Security audits and penetration testing
+- DevOps pipelines and deployment
+- Code review and quality gates
+
+## Skill Categories
+
+### AI & LLM Development (23 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `agent-loops` | ReAct patterns, autonomous reasoning |
+| `rag-retrieval` | RAG pipelines, chunking, retrieval |
+| `embeddings` | Vector operations, similarity search |
+| `function-calling` | LLM tool use, structured output |
+| `langgraph-*` | Supervisor, routing, parallel, checkpoints, human-in-loop, state |
+| `llm-evaluation` | Quality metrics, benchmarks |
+| `llm-testing` | Mocking, deterministic tests |
+| `prompt-caching` | Anthropic/OpenAI cost reduction |
+| `semantic-caching` | Redis vector similarity cache |
+| `context-compression` | Token optimization |
+| `llm-safety-patterns` | Prompt injection prevention |
+
+### Backend Development (5 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `api-design-framework` | REST patterns, OpenAPI templates |
+| `database-schema-designer` | Normalization, indexing, migrations |
+| `streaming-api-patterns` | SSE, WebSockets, backpressure |
+| `type-safety-validation` | Zod + tRPC + Prisma |
+| `resilience-patterns` | Circuit breakers, retry logic |
+
+### Frontend Development (6 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `react-server-components-framework` | Next.js 15, RSC, Server Actions |
+| `design-system-starter` | Design tokens, accessibility |
+| `motion-animation-patterns` | Framer Motion, page transitions |
+| `i18n-date-patterns` | Internationalization, RTL |
+| `performance-optimization` | React 19, Core Web Vitals |
+| `edge-computing-patterns` | Cloudflare Workers, Vercel Edge |
+
+### Quality & Testing (14 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `unit-testing` | Mocking, coverage strategies |
+| `integration-testing` | Component interactions |
+| `e2e-testing` | Playwright patterns |
+| `webapp-testing` | Autonomous test agents |
+| `msw-mocking` | Mock Service Worker |
+| `vcr-http-recording` | HTTP recording/playback |
+| `code-review-playbook` | Conventional comments |
+| `quality-gates` | Automated enforcement |
+| `golden-dataset-*` | Curation, validation, management |
+
+### DevOps & Security (7 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `devops-deployment` | CI/CD, Docker, Kubernetes |
+| `observability-monitoring` | Logging, metrics, tracing |
+| `owasp-top-10` | Security mitigations |
+| `auth-patterns` | JWT, OAuth, sessions |
+| `security-scanning` | SAST, dependency audits |
+| `input-validation` | Sanitization, injection prevention |
+| `defense-in-depth` | 8-layer security architecture |
+
+### Process & Planning (6 skills)
+
+| Skill | Purpose |
+|-------|---------|
+| `brainstorming` | Socratic questioning, MVP scoping |
+| `architecture-decision-record` | ADR templates |
+| `ascii-visualizer` | ASCII diagrams |
+| `github-cli` | PR automation, issue management |
+| `browser-content-capture` | Web scraping, docs capture |
+| `system-design-interrogation` | Structured design questions |
+
+## Installation
+
+### From Marketplace
+
+```bash
+# Add marketplace
+/plugin marketplace add yonatangross/skillforge-claude-plugin
+
+# Install full toolkit
+/plugin install skillforge-complete@complete
+
+# Or install specific bundles
+/plugin install skillforge-complete@ai-development
+/plugin install skillforge-complete@backend
+/plugin install skillforge-complete@frontend
+/plugin install skillforge-complete@quality-testing
+/plugin install skillforge-complete@devops-security
+/plugin install skillforge-complete@process-planning
+```
+
+### From GitHub
+
+```bash
+git clone https://github.com/yonatangross/skillforge-claude-plugin ~/.claude/plugins/skillforge
+```
+
+## Progressive Loading
+
+Skills use `capabilities.json` for token-efficient discovery:
+
+1. **Tier 1 - Discovery** (~100 tokens): `capabilities.json` for relevance
+2. **Tier 2 - Overview** (~500 tokens): `SKILL.md` for patterns
+3. **Tier 3 - Specific** (~200 tokens): `references/*.md` for details
+4. **Tier 4 - Generate** (~300 tokens): `templates/*` for code
+
+See `.claude/skills/*/capabilities.json` for trigger patterns.
+
+## Additional Features
+
+- **20 Agents**: Product thinking (6) + technical implementation (14)
+- **11 Commands**: `/commit`, `/implement`, `/review-pr`, `/explore`, etc.
+- **29 Hooks**: Safety, auditing, auto-approval, lifecycle management
+
+## References
+
+- [Full README](README.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Agent Registry](.claude/agent-registry.json)


### PR DESCRIPTION
## Summary

Adds marketplace plugin registry compatibility for installable bundles while preserving SkillForge's architecture.

## Changes

### New Files
- `.claude-plugin/marketplace.json` - Marketplace registry with 7 plugin bundles
- `.claude-plugin/README.md` - Plugin installation documentation
- `SKILL.md` - Root collection manifest
- `.claude/schemas/marketplace.schema.json` - JSON schema for validation

### Modified Files
- `README.md` - Updated Quick Start with marketplace install commands

## Plugin Bundles

| Bundle | Skills | Description |
|--------|--------|-------------|
| `complete` | 61 | Full toolkit + agents/commands/hooks |
| `ai-development` | 23 | RAG, embeddings, LangGraph, caching |
| `backend` | 5 | APIs, databases, streaming, resilience |
| `frontend` | 6 | React 19, RSC, animations, edge |
| `quality-testing` | 14 | Unit, E2E, mocking, golden datasets |
| `devops-security` | 7 | CI/CD, observability, OWASP, auth |
| `process-planning` | 6 | Brainstorming, ADRs, GitHub CLI |

## Installation

```bash
/plugin marketplace add yonatangross/skillforge-claude-plugin
/plugin install skillforge-complete@complete
```

## Test Plan

- [x] Verified marketplace.json structure
- [x] Verified SKILL.md format
- [x] Updated external registry PRs (#86, #24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)