### PR TITLE
fix: Update component counts to match actual v4.6.3

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -23,7 +23,7 @@ Once PRs are merged, these commands will work:
 /plugin marketplace add yonatangross/skillforge-claude-plugin
 
 # Install (choose one)
-/plugin install skillforge-complete@complete         # Everything (72 skills)
+/plugin install skillforge-complete@complete         # Everything (78 skills)
 /plugin install skillforge-complete@ai-development   # AI/LLM skills (23 skills)
 /plugin install skillforge-complete@backend          # Backend skills (12 skills)
 /plugin install skillforge-complete@frontend         # Frontend skills (6 skills)
@@ -36,7 +36,7 @@ Once PRs are merged, these commands will work:
 
 | Bundle | Skills | Description |
 |--------|--------|-------------|
-| `complete` | 72 | Full toolkit with 20 agents, 11 commands, 89 hooks |
+| `complete` | 78 | Full toolkit with 20 agents, 12 commands, 92 hooks |
 | `ai-development` | 23 | RAG, embeddings, LangGraph, caching |
 | `backend` | 12 | APIs, databases, streaming, resilience |
 | `frontend` | 6 | React 19, RSC, animations, edge |
@@ -46,10 +46,10 @@ Once PRs are merged, these commands will work:
 
 ## Features
 
-- **72 Skills**: Progressive loading with `capabilities.json` for token-efficient discovery
+- **78 Skills**: Progressive loading with `capabilities.json` for token-efficient discovery
 - **20 Specialized Agents**: Product thinking (6) + technical implementation (14)
-- **11 Commands**: `/commit`, `/implement`, `/review-pr`, `/explore`, etc.
-- **89 Hooks**: Safety, auditing, auto-approval, quality gates
+- **12 Commands**: `/commit`, `/implement`, `/review-pr`, `/explore`, etc.
+- **92 Hooks**: Safety, auditing, auto-approval, quality gates
 
 ## More Information
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,8 +2,8 @@
   "name": "skillforge-complete",
   "displayName": "@skillforge/complete",
   "owner": "yonatangross",
-  "version": "4.6.1",
-  "description": "The Complete AI Development Toolkit - 72 skills, 20 agents, 11 commands, 89 hooks",
+  "version": "4.6.3",
+  "description": "The Complete AI Development Toolkit - 78 skills, 20 agents, 12 commands, 92 hooks",
   "repository": "https://github.com/yonatangross/skillforge-claude-plugin",
   "license": "MIT",
   "strict": false,
@@ -23,7 +23,7 @@
   "plugins": [
     {
       "name": "complete",
-      "description": "Full toolkit - all 72 skills, 20 agents, 11 commands, 89 hooks",
+      "description": "Full toolkit - all 78 skills, 20 agents, 12 commands, 92 hooks",
       "skills": ["*"],
       "includes_agents": true,
       "includes_commands": true,
@@ -136,10 +136,10 @@
   ],
 
   "features": {
-    "skills": 72,
+    "skills": 78,
     "agents": 20,
-    "commands": 11,
-    "hooks": 89,
+    "commands": 12,
+    "hooks": 92,
     "progressive_loading": true,
     "capabilities_json": true
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ This document provides essential context for Claude Code when working with the S
 
 **SkillForge Complete** is a comprehensive AI-assisted development toolkit that transforms Claude Code into a full-stack development powerhouse. It provides:
 
-- **72 Skills**: Reusable knowledge modules covering AI/LLM, backend, frontend, testing, security, and DevOps
+- **78 Skills**: Reusable knowledge modules covering AI/LLM, backend, frontend, testing, security, and DevOps
 - **20 Agents**: Specialized AI personas for product thinking, system architecture, code quality, and more
 - **12 Commands**: Pre-configured workflows for common development tasks
-- **90 Hooks**: Lifecycle automation for sessions, tools, permissions, and quality gates
+- **92 Hooks**: Lifecycle automation for sessions, tools, permissions, and quality gates
 - **Progressive Loading**: Semantic discovery system that loads skills on-demand based on task context
 
 **Purpose**: Enable AI-assisted development of production-grade applications with built-in best practices, security patterns, and quality gates.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  78 skills | 12 commands | 20 agents | 90 hooks | 4 tiers
+  78 skills | 12 commands | 20 agents | 92 hooks | 4 tiers
 </p>
 
 ---
@@ -340,7 +340,7 @@ mcp__context7__query-docs(
 
 ### Hook Auditing
 
-All 90 hooks have been security-audited and follow these standards:
+All 92 hooks have been security-audited and follow these standards:
 
 - **Strict mode enabled**: `set -euo pipefail` in all bash hooks
 - **Input validation**: All hook inputs are validated via JSON schema

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude-plugins.dev/schemas/plugin.schema.json",
   "name": "@skillforge/complete",
   "version": "4.6.3",
-  "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents (6 product + 14 technical), 90 hooks, progressive loading, and production-ready patterns for modern full-stack development",
+  "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents (6 product + 14 technical), 92 hooks, progressive loading, and production-ready patterns for modern full-stack development",
   "displayName": "SkillForge Complete",
   "author": {
     "name": "SkillForge Team",


### PR DESCRIPTION
## Summary

Updates all documentation and config files to reflect the actual component counts for v4.6.3:

| Component | Old | New |
|-----------|-----|-----|
| Skills | 72 | **78** |
| Commands | 11 | **12** |
| Hooks | 89/90 | **92** |

## Files Changed

- `README.md` - Header counts and hook auditing section
- `CLAUDE.md` - Project overview section
- `plugin.json` - Description field
- `.claude-plugin/README.md` - Installation and features sections
- `.claude-plugin/marketplace.json` - Version bumped to 4.6.3, all counts updated

## Related PRs

External marketplace PRs have already been updated:
- https://github.com/anthropics/claude-plugins-official/pull/86
- https://github.com/ananddtyagi/cc-marketplace/pull/24

## Test plan

- [x] Verified actual counts match: 78 skills, 20 agents, 12 commands, 92 hooks
- [x] No remaining references to old counts (grep verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)