### PR TITLE
fix: Correct hooks count from 92 to 90

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This document provides essential context for Claude Code when working with the S
 - **78 Skills**: Reusable knowledge modules covering AI/LLM, backend, frontend, testing, security, and DevOps
 - **20 Agents**: Specialized AI personas for product thinking, system architecture, code quality, and more
 - **12 Commands**: Pre-configured workflows for common development tasks
-- **92 Hooks**: Lifecycle automation for sessions, tools, permissions, and quality gates
+- **90 Hooks**: Lifecycle automation for sessions, tools, permissions, and quality gates
 - **Progressive Loading**: Semantic discovery system that loads skills on-demand based on task context
 
 **Purpose**: Enable AI-assisted development of production-grade applications with built-in best practices, security patterns, and quality gates.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  78 skills | 12 commands | 20 agents | 92 hooks | 4 tiers
+  78 skills | 12 commands | 20 agents | 90 hooks | 4 tiers
 </p>
 
 ---
@@ -340,7 +340,7 @@ mcp__context7__query-docs(
 
 ### Hook Auditing
 
-All 92 hooks have been security-audited and follow these standards:
+All 90 hooks have been security-audited and follow these standards:
 
 - **Strict mode enabled**: `set -euo pipefail` in all bash hooks
 - **Input validation**: All hook inputs are validated via JSON schema

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude-plugins.dev/schemas/plugin.schema.json",
   "name": "@skillforge/complete",
   "version": "4.6.3",
-  "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents (6 product + 14 technical), 92 hooks, progressive loading, and production-ready patterns for modern full-stack development",
+  "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents (6 product + 14 technical), 90 hooks, progressive loading, and production-ready patterns for modern full-stack development",
   "displayName": "SkillForge Complete",
   "author": {
     "name": "SkillForge Team",


### PR DESCRIPTION
## Summary
- Fixed hooks count from 92 to 90 across all documentation
- Actual count: 90 hooks (92 `.sh` files minus 2 library files in `_lib/`)
- Updated GitHub repo About description

## Files Changed
- `plugin.json` - description field
- `README.md` - header stats and security section
- `CLAUDE.md` - Project Overview section

## Test plan
- [x] Verified actual hook count via `ls .claude/hooks/**/*.sh`
- [x] Confirmed 90 hooks matches bundle definitions in plugin.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)