### PR TITLE
chore: Bump version to 4.6.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "skillforge",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "The Complete AI Development Toolkit - 78 skills, 20 agents, 12 commands, 90 hooks for full-stack development",
   "owner": {
     "name": "Yonatan Gross",
@@ -11,7 +11,7 @@
     {
       "name": "skf",
       "description": "Complete AI development toolkit with 78 skills covering AI/LLM, backend, frontend, security, and testing patterns. Includes 20 specialized agents, 12 commands, and 90 lifecycle hooks.",
-      "version": "4.6.6",
+      "version": "4.6.7",
       "author": {
         "name": "Yonatan Gross",
         "email": "yonatan2gross@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skf",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents, 90 hooks, progressive loading, and production-ready patterns for modern full-stack development",
   "author": {
     "name": "Yonatan Gross",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the SkillForge Claude Code Plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.6.7] - 2026-01-09
+
+### Changed
+
+**MCP Integrations Now Opt-in**
+- All MCPs disabled by default in `.mcp.json` (`"disabled": true`)
+- Added Step 5 to `/skf:configure` for MCP selection
+- Users explicitly choose which MCPs to enable via interactive wizard
+- No surprise package downloads on plugin install
+
+**Documentation Updates**
+- Updated README MCP section to mark integrations as optional
+- Updated CLAUDE.md MCP Integration line
+- Added MCP step to README configuration wizard list
+
+---
+
 ## [4.6.6] - 2026-01-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -510,4 +510,4 @@ tail -f .claude/hooks/logs/*.log
 
 ---
 
-**Last Updated**: 2026-01-09 (v4.6.6 - Fix skill template literal bash parsing)
+**Last Updated**: 2026-01-09 (v4.6.7 - MCPs opt-in via configure)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/yonatangross/skillforge-claude-plugin"><img src="https://img.shields.io/github/stars/yonatangross/skillforge-claude-plugin?style=flat-square" alt="GitHub Stars"></a>
-  <a href="https://github.com/yonatangross/skillforge-claude-plugin/releases"><img src="https://img.shields.io/badge/version-4.6.6-green?style=flat-square" alt="Version"></a>
+  <a href="https://github.com/yonatangross/skillforge-claude-plugin/releases"><img src="https://img.shields.io/badge/version-4.6.7-green?style=flat-square" alt="Version"></a>
   <a href="https://github.com/yonatangross/skillforge-claude-plugin/actions/workflows/ci.yml"><img src="https://github.com/yonatangross/skillforge-claude-plugin/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-purple?style=flat-square" alt="License"></a>
   <a href="https://github.com/anthropics/claude-plugins-official/pull/86"><img src="https://img.shields.io/badge/anthropic--official-pending-yellow?style=flat-square" alt="Anthropic Official"></a>

--- a/plugin-metadata.json
+++ b/plugin-metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://claude-plugins.dev/schemas/plugin.schema.json",
   "name": "@skillforge/complete",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents, 90 hooks, progressive loading, and production-ready patterns for modern full-stack development",
   "displayName": "SkillForge Complete",
   "author": {

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skf",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Comprehensive AI-assisted development toolkit with 78 skills, 12 commands, 20 agents, 90 hooks, progressive loading, and production-ready patterns for modern full-stack development",
   "author": {
     "name": "Yonatan Gross",


### PR DESCRIPTION
## Summary

Version bump to 4.6.7 documenting the MCP opt-in changes that were merged in PR #27.

## Changes

- Bump version 4.6.6 → 4.6.7
- Add CHANGELOG entry for v4.6.7 (MCP opt-in)
- Update version badge in README
- Update CLAUDE.md last updated line
- Add MCP step to README configuration wizard list

## Test plan

- [x] CI checks pass
- [x] Version bump and changelog present

🤖 Generated with [Claude Code](https://claude.com/claude-code)