### PR TITLE
feat(hooks): Add skill-auto-suggest prompt hook (#123)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skf",
-  "version": "4.20.0",
-  "description": "Comprehensive AI-assisted development toolkit with 135 skills (20 user-invocable commands, 115 internal knowledge), 27 agents, 128 hooks (CC 2.1.11 Setup hooks), progressive loading, Memory Fabric v2.1 (graph-first architecture, optional mem0 cloud enhancement), and production-ready patterns for modern full-stack development",
+  "version": "4.21.0",
+  "description": "Comprehensive AI-assisted development toolkit with 135 skills (20 user-invocable commands, 115 internal knowledge), 27 agents, 129 hooks (CC 2.1.11 Setup hooks), progressive loading, Memory Fabric v2.1 (graph-first architecture, optional mem0 cloud enhancement), and production-ready patterns for modern full-stack development",
   "author": {
     "name": "Yonatan Gross",
     "email": "yonatan2gross@gmail.com",
@@ -422,6 +422,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/prompt/antipattern-warning.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/prompt/skill-auto-suggest.sh"
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the SkillForge Claude Code Plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.21.0] - 2026-01-18
+
+### Added
+
+- **Skill Auto-Suggest Hook** (#123)
+  - `hooks/prompt/skill-auto-suggest.sh`: UserPromptSubmit hook for proactive skill suggestions
+  - Analyzes prompts for 100+ keywords across domains (API, database, auth, testing, frontend, AI/LLM, DevOps)
+  - Injects relevant skill suggestions via CC 2.1.9 additionalContext
+  - Confidence scoring with max 3 suggestions per prompt
+  - 25 unit tests for comprehensive coverage
+
+### Changed
+
+- Hook count: 128 → 129
+
+---
+
 ## [4.20.0] - 2026-01-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This document provides essential context for Claude Code when working with the S
 - **135 skills**: Reusable knowledge modules in flat structure (including 6 git/GitHub workflow skills)
 - **27 agents**: Specialized AI personas with native skill injection (CC 2.1.6)
 - **20 user-invocable skills**: Pre-configured workflows (CC 2.1.3 unified skills/commands with `user-invocable: true`)
-- **128 hooks**: Lifecycle automation via CC 2.1.11 Setup hooks + CC 2.1.7 native parallel execution
+- **129 hooks**: Lifecycle automation via CC 2.1.11 Setup hooks + CC 2.1.7 native parallel execution
 - **Progressive Loading**: Semantic discovery system that loads skills on-demand based on task context
 - **Context Window HUD**: Real-time context usage monitoring with CC 2.1.6 statusline integration
 
@@ -723,11 +723,11 @@ SKILLFORGE_SKIP_SETUP=1 claude  # Skip all setup hooks
 
 ## Version Information
 
-- **Current Version**: 4.20.0 (as of 2026-01-17)
+- **Current Version**: 4.21.0 (as of 2026-01-18)
 - **Claude Code Requirement**: >= 2.1.11
 - **Skills Structure**: CC 2.1.7 native flat (skills/<skill>/)
 - **Agent Format**: CC 2.1.6 native (skills array in frontmatter)
-- **Hook Architecture**: CC 2.1.11 Setup hooks + CC 2.1.9 additionalContext + CC 2.1.7 native parallel (128 hooks)
+- **Hook Architecture**: CC 2.1.11 Setup hooks + CC 2.1.9 additionalContext + CC 2.1.7 native parallel (129 hooks)
 - **Context Protocol**: 2.0.0 (tiered, attention-aware)
 - **Memory Fabric**: v2.1.0 (graph-first architecture, knowledge graph PRIMARY, mem0 optional enhancement)
 - **Coordination System**: Multi-worktree support added in v4.6.0

--- a/README.md
+++ b/README.md
@@ -33,12 +33,18 @@ Built for teams building modern full-stack applications with FastAPI, React 19, 
 
 ---
 
-## What's New in v4.20.0 (Memory Fabric & Frontend Skills)
+## What's New in v4.21.0 (Skill Auto-Suggest)
+
+- **Skill Auto-Suggest Hook** (#123): Proactive skill suggestions based on prompt analysis
+- Analyzes prompts for 100+ keywords across API, database, auth, testing, frontend, AI/LLM, DevOps domains
+- Uses CC 2.1.9 additionalContext for non-intrusive suggestions
+- **Total**: 135 skills, 27 agents, 129 hooks
+
+### Previous (v4.20.0 - Memory Fabric & Frontend Skills)
 
 - **Memory Fabric v2.1**: Graph-first architecture with optional Mem0 cloud enhancement
 - **10 Frontend Skills Expanded**: zustand-patterns, tanstack-query-advanced, form-state-patterns, core-web-vitals, image-optimization, render-optimization, shadcn-patterns, radix-primitives, vite-advanced, biome-linting
 - **2 New Commands**: `/load-context` (auto-load memories), `/mem0-sync` (sync to Mem0)
-- **Total**: 135 skills, 27 agents, 128 hooks
 
 ### Previous (v4.19.0 - CC 2.1.11 Setup Hooks)
 

--- a/docs/roadmap/hooks-agents-gap-analysis.md
+++ b/docs/roadmap/hooks-agents-gap-analysis.md
@@ -38,7 +38,7 @@
 ║  │   ✓ auto-approve-safe-bash           │  ✓ todo-enforcer                 │  ✓ coverage-threshold-gate│ ║
 ║  │   ✓ auto-approve-project-writes      │  ✓ antipattern-warning           │  ✓ design-decision-saver  │ ║
 ║  │   ✓ learning-tracker                 │  ✓ memory-context                │  ✓ duplicate-code-detector│ ║
-║  │                                      │  ✗ skill-suggestion              │  ✓ evidence-collector     │ ║
+║  │                                      │  ✓ skill-auto-suggest            │  ✓ evidence-collector     │ ║
 ║  │                                      │  ✗ context-budget-warning        │  ✓ merge-conflict-predict │ ║
 ║  │                                                                         │  ✓ pattern-consistency    │ ║
 ║  │   STOP (7 hooks)                     │  SUBAGENT-START (3 hooks)        │  ✓ security-summary       │ ║
@@ -79,7 +79,7 @@
 ║                               ║   Current: Basic context injection, antipattern warning                  ║
 ║                               ║                                                                          ║
 ║                               ║   Missing Hooks:                                                         ║
-║                               ║   - skill-auto-suggest       (suggest skills based on task context)      ║
+║                               ║   ✓ skill-auto-suggest       (suggest skills based on task context) [DONE]║
 ║                               ║   - similar-code-finder      (find existing implementations)             ║
 ║                               ║   - documentation-linker     (link to relevant docs automatically)       ║
 ║                               ║   - error-solution-suggester (suggest fixes for common errors)           ║

--- a/hooks/prompt/skill-auto-suggest.sh
+++ b/hooks/prompt/skill-auto-suggest.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# skill-auto-suggest.sh - Proactive skill suggestion based on prompt analysis
+# Issue #123: Skill Auto-Suggest Hook
+#
+# This hook analyzes user prompts for task keywords and suggests relevant skills
+# from the skills/ directory via CC 2.1.9 additionalContext injection.
+#
+# CC 2.1.9 Compliant: Uses hookSpecificOutput.additionalContext for suggestions
+# Version: 1.0.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$SCRIPT_DIR")")}"
+SKILLS_DIR="${PLUGIN_ROOT}/skills"
+
+# Source common library if available
+if [[ -f "${PLUGIN_ROOT}/hooks/_lib/common.sh" ]]; then
+    source "${PLUGIN_ROOT}/hooks/_lib/common.sh"
+fi
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+LOG_FILE="${CLAUDE_PROJECT_DIR:-.}/.claude/logs/skill-auto-suggest.log"
+
+# Ensure log directory exists
+mkdir -p "$(dirname "$LOG_FILE")" 2>/dev/null || true
+
+log() {
+    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] [skill-auto-suggest] $*" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# Maximum number of skills to suggest
+MAX_SUGGESTIONS=3
+
+# Minimum confidence score (0-100) to include a skill
+MIN_CONFIDENCE=30
+
+# -----------------------------------------------------------------------------
+# Keyword-to-Skill Mapping Database
+# Format: keyword|skill-name|confidence-boost (using | as delimiter for bash 3.2)
+# -----------------------------------------------------------------------------
+
+# Keywords are grouped by domain for better matching
+declare -a KEYWORD_MAPPINGS=(
+    # API & Backend
+    "api|api-design-framework|80"
+    "endpoint|api-design-framework|70"
+    "rest|api-design-framework|75"
+    "graphql|api-design-framework|75"
+    "route|api-design-framework|60"
+    "fastapi|fastapi-advanced|90"
+    "uvicorn|fastapi-advanced|70"
+    "starlette|fastapi-advanced|60"
+    "middleware|fastapi-advanced|50"
+    "pydantic|fastapi-advanced|60"
+
+    # Database
+    "database|database-schema-designer|80"
+    "schema|database-schema-designer|70"
+    "table|database-schema-designer|50"
+    "migration|alembic-migrations|85"
+    "alembic|alembic-migrations|95"
+    "sql|database-schema-designer|60"
+    "postgres|database-schema-designer|70"
+    "query|database-schema-designer|40"
+    "index|database-schema-designer|50"
+    "sqlalchemy|sqlalchemy-2-async|85"
+    "async.*database|sqlalchemy-2-async|80"
+    "orm|sqlalchemy-2-async|60"
+    "connection.*pool|connection-pooling|90"
+    "pool|connection-pooling|60"
+    "pgvector|pgvector-search|95"
+    "vector.*search|pgvector-search|85"
+    "embedding|embeddings|80"
+
+    # Authentication & Security
+    "auth|auth-patterns|85"
+    "login|auth-patterns|75"
+    "jwt|auth-patterns|80"
+    "oauth|auth-patterns|85"
+    "passkey|auth-patterns|90"
+    "webauthn|auth-patterns|90"
+    "session|auth-patterns|60"
+    "password|auth-patterns|70"
+    "security|owasp-top-10|75"
+    "owasp|owasp-top-10|95"
+    "xss|owasp-top-10|80"
+    "injection|owasp-top-10|80"
+    "csrf|owasp-top-10|80"
+    "validation|input-validation|70"
+    "sanitiz|input-validation|80"
+    "defense.*depth|defense-in-depth|95"
+
+    # Testing
+    "test|integration-testing|60"
+    "unit.*test|pytest-advanced|80"
+    "pytest|pytest-advanced|90"
+    "integration.*test|integration-testing|85"
+    "e2e|e2e-testing|90"
+    "playwright|e2e-testing|80"
+    "mock|msw-mocking|75"
+    "msw|msw-mocking|95"
+    "fixture|test-data-management|80"
+    "test.*data|test-data-management|85"
+    "coverage|pytest-advanced|60"
+    "property.*test|property-based-testing|90"
+    "hypothesis|property-based-testing|95"
+    "contract.*test|contract-testing|95"
+    "pact|contract-testing|95"
+    "golden.*dataset|golden-dataset-validation|90"
+    "performance.*test|performance-testing|90"
+    "load.*test|performance-testing|85"
+    "k6|performance-testing|95"
+    "locust|performance-testing|95"
+
+    # Frontend & React
+    "react|react-server-components-framework|70"
+    "component|react-server-components-framework|50"
+    "server.*component|react-server-components-framework|95"
+    "nextjs|react-server-components-framework|85"
+    "next\.js|react-server-components-framework|85"
+    "suspense|react-server-components-framework|70"
+    "streaming.*ssr|react-server-components-framework|90"
+    "form|form-state-patterns|70"
+    "react.*hook.*form|form-state-patterns|95"
+    "zod|form-state-patterns|60"
+    "zustand|zustand-patterns|95"
+    "state.*management|zustand-patterns|70"
+    "tanstack|tanstack-query-advanced|90"
+    "react.*query|tanstack-query-advanced|85"
+    "radix|radix-primitives|95"
+    "shadcn|radix-primitives|80"
+    "tailwind|design-system-starter|60"
+    "design.*system|design-system-starter|85"
+    "animation|motion-animation-patterns|80"
+    "framer|motion-animation-patterns|90"
+    "core.*web.*vital|core-web-vitals|95"
+    "lcp|core-web-vitals|80"
+    "cls|core-web-vitals|80"
+    "inp|core-web-vitals|80"
+    "i18n|i18n-date-patterns|90"
+    "internationalization|i18n-date-patterns|95"
+    "locale|i18n-date-patterns|70"
+
+    # Accessibility
+    "accessibility|a11y-testing|85"
+    "a11y|a11y-testing|95"
+    "wcag|a11y-testing|95"
+    "screen.*reader|focus-management|80"
+    "keyboard.*nav|focus-management|90"
+    "focus|focus-management|60"
+    "aria|focus-management|70"
+
+    # AI/LLM
+    "llm|function-calling|70"
+    "openai|function-calling|60"
+    "anthropic|function-calling|60"
+    "function.*call|function-calling|90"
+    "tool.*use|function-calling|85"
+    "stream|llm-streaming|70"
+    "rag|rag-retrieval|95"
+    "retrieval|rag-retrieval|75"
+    "context|contextual-retrieval|60"
+    "chunk|embeddings|70"
+    "vector|embeddings|75"
+    "semantic.*search|embeddings|85"
+    "langfuse|langfuse-observability|95"
+    "llm.*observ|langfuse-observability|90"
+    "langgraph|langgraph-state|85"
+    "agent|agent-loops|70"
+    "workflow|langgraph-state|60"
+    "supervisor|langgraph-supervisor|90"
+    "human.*in.*loop|langgraph-human-in-loop|95"
+    "checkpoint|langgraph-checkpoints|90"
+    "prompt.*cache|prompt-caching|95"
+    "cache.*llm|semantic-caching|85"
+    "eval|llm-evaluation|70"
+    "llm.*test|llm-testing|85"
+    "ollama|ollama-local|95"
+
+    # DevOps & Infrastructure
+    "deploy|devops-deployment|75"
+    "ci|devops-deployment|60"
+    "cd|devops-deployment|60"
+    "github.*action|github-operations|85"
+    "workflow|github-operations|50"
+    "release|release-management|80"
+    "changelog|release-management|70"
+    "version|release-management|50"
+    "observ|observability-monitoring|80"
+    "monitor|observability-monitoring|70"
+    "log|observability-monitoring|50"
+    "metric|observability-monitoring|60"
+    "trace|observability-monitoring|70"
+    "alert|observability-monitoring|60"
+
+    # Git & GitHub
+    "git|git-workflow|70"
+    "branch|git-workflow|60"
+    "commit|commit|80"
+    "rebase|git-workflow|70"
+    "stacked.*pr|stacked-prs|95"
+    "pr|create-pr|60"
+    "pull.*request|create-pr|75"
+    "recovery|git-recovery-command|80"
+    "reflog|git-recovery-command|95"
+    "milestone|github-operations|80"
+    "issue|github-operations|50"
+
+    # Event-Driven & Messaging
+    "event.*sourc|event-sourcing|95"
+    "kafka|message-queues|85"
+    "rabbitmq|message-queues|85"
+    "queue|message-queues|75"
+    "pub.*sub|message-queues|80"
+    "outbox|outbox-pattern|95"
+    "saga|event-sourcing|70"
+    "cqrs|event-sourcing|80"
+
+    # Async & Concurrency
+    "async|asyncio-advanced|70"
+    "asyncio|asyncio-advanced|90"
+    "taskgroup|asyncio-advanced|95"
+    "concurrent|asyncio-advanced|60"
+    "background.*job|background-jobs|90"
+    "celery|background-jobs|95"
+    "worker|background-jobs|60"
+    "distributed.*lock|distributed-locks|95"
+    "redis.*lock|distributed-locks|85"
+    "idempoten|idempotency-patterns|95"
+
+    # Architecture & Patterns
+    "clean.*architecture|clean-architecture|95"
+    "ddd|domain-driven-design|95"
+    "domain.*driven|domain-driven-design|90"
+    "aggregate|aggregate-patterns|90"
+    "adr|architecture-decision-record|95"
+    "decision.*record|architecture-decision-record|85"
+
+    # Code Quality
+    "lint|biome-linting|70"
+    "biome|biome-linting|95"
+    "eslint|biome-linting|60"
+    "format|biome-linting|50"
+    "code.*review|code-review-playbook|90"
+    "review|code-review-playbook|60"
+    "quality.*gate|quality-gates|90"
+
+    # Error Handling
+    "error.*handl|error-handling-rfc9457|85"
+    "rfc.*9457|error-handling-rfc9457|95"
+    "problem.*detail|error-handling-rfc9457|90"
+)
+
+# -----------------------------------------------------------------------------
+# Skill Matching Logic
+# -----------------------------------------------------------------------------
+
+# Extract skill suggestions based on prompt keywords
+# Returns: skill-name|confidence (sorted by confidence, highest first)
+find_matching_skills() {
+    local prompt="$1"
+    local prompt_lower
+    prompt_lower=$(echo "$prompt" | tr '[:upper:]' '[:lower:]')
+
+    declare -A skill_scores
+
+    # Check each keyword mapping
+    for mapping in "${KEYWORD_MAPPINGS[@]}"; do
+        local keyword="${mapping%%|*}"
+        local rest="${mapping#*|}"
+        local skill="${rest%%|*}"
+        local confidence="${rest#*|}"
+
+        # Check if keyword matches (supports basic regex)
+        if echo "$prompt_lower" | grep -qE "$keyword" 2>/dev/null; then
+            # Add or update skill score
+            local current_score="${skill_scores[$skill]:-0}"
+            if (( confidence > current_score )); then
+                skill_scores[$skill]=$confidence
+            fi
+        fi
+    done
+
+    # Output skills sorted by confidence
+    for skill in "${!skill_scores[@]}"; do
+        echo "${skill}|${skill_scores[$skill]}"
+    done | sort -t'|' -k2 -nr | head -n "$MAX_SUGGESTIONS"
+}
+
+# Get skill description from SKILL.md frontmatter
+get_skill_description() {
+    local skill_name="$1"
+    local skill_file="${SKILLS_DIR}/${skill_name}/SKILL.md"
+
+    if [[ -f "$skill_file" ]]; then
+        # Extract description from YAML frontmatter
+        sed -n '/^---$/,/^---$/p' "$skill_file" | grep -E "^description:" | sed 's/^description: *//' | head -1
+    fi
+}
+
+# Build suggestion message for Claude
+build_suggestion_message() {
+    local matches="$1"
+
+    if [[ -z "$matches" ]]; then
+        return
+    fi
+
+    local message="## Relevant Skills Detected
+
+Based on your prompt, the following skills may be helpful:
+
+"
+
+    while IFS='|' read -r skill confidence; do
+        if [[ -n "$skill" ]] && (( confidence >= MIN_CONFIDENCE )); then
+            local description
+            description=$(get_skill_description "$skill")
+            if [[ -n "$description" ]]; then
+                message+="- **${skill}** (${confidence}% match): ${description}
+"
+            else
+                message+="- **${skill}** (${confidence}% match)
+"
+            fi
+        fi
+    done <<< "$matches"
+
+    message+="
+Use \`/skf:<skill-name>\` to invoke a user-invocable skill, or read the skill with \`Read skills/<skill-name>/SKILL.md\` for patterns and guidance."
+
+    echo "$message"
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+
+# Output silent success JSON (used for early exits and error cases)
+output_silent_success() {
+    echo '{"continue": true, "suppressOutput": true}'
+}
+
+main() {
+    # Wrap everything in error handling to always output valid JSON
+    {
+        # Read prompt from stdin
+        local input=""
+        if [[ ! -t 0 ]]; then
+            input=$(cat 2>/dev/null) || true
+        fi
+
+        if [[ -z "$input" ]]; then
+            output_silent_success
+            exit 0
+        fi
+
+        # Extract prompt from hook input JSON
+        # Handle potential JSON parsing errors gracefully
+        local prompt=""
+        prompt=$(echo "$input" | jq -r '.prompt // .message // .content // ""' 2>/dev/null) || prompt=""
+
+        if [[ -z "$prompt" ]]; then
+            output_silent_success
+            exit 0
+        fi
+
+        log "Analyzing prompt for skill suggestions..."
+
+        # Find matching skills (wrap in subshell to catch errors)
+        local matches=""
+        matches=$(find_matching_skills "$prompt" 2>/dev/null) || matches=""
+
+        if [[ -z "$matches" ]]; then
+            log "No skill matches found"
+            output_silent_success
+            exit 0
+        fi
+
+        log "Found matches: $matches"
+
+        # Build suggestion message
+        local suggestion_message=""
+        suggestion_message=$(build_suggestion_message "$matches" 2>/dev/null) || suggestion_message=""
+
+        if [[ -n "$suggestion_message" ]]; then
+            log "Injecting skill suggestions via additionalContext"
+
+            # Inject via CC 2.1.9 additionalContext
+            jq -n \
+                --arg suggestion "$suggestion_message" \
+                '{
+                    "continue": true,
+                    "hookSpecificOutput": {
+                        "additionalContext": $suggestion
+                    }
+                }'
+        else
+            output_silent_success
+        fi
+    } || {
+        # If anything fails, output silent success to not block the prompt
+        output_silent_success
+    }
+}
+
+main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "skillforge-claude-plugin"
-version = "4.20.0"
-description = "SkillForge Complete - AI-assisted development toolkit for Claude Code with 135 skills, 27 agents, and 128 hooks"
+version = "4.21.0"
+description = "SkillForge Complete - AI-assisted development toolkit for Claude Code with 135 skills, 27 agents, and 129 hooks"
 requires-python = ">=3.13"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/unit/test-issue-progress-tracking.sh
+++ b/tests/unit/test-issue-progress-tracking.sh
@@ -349,7 +349,7 @@ test_plugin_counts_updated() {
     local plugin_content
     plugin_content=$(cat "$PROJECT_ROOT/.claude-plugin/plugin.json")
 
-    assert_contains "$plugin_content" "128 hooks" "Plugin description shows 128 hooks"
+    assert_contains "$plugin_content" "129 hooks" "Plugin description shows 129 hooks"
     assert_contains "$plugin_content" "135 skills" "Plugin description shows 135 skills"
 }
 

--- a/tests/unit/test-skill-auto-suggest.sh
+++ b/tests/unit/test-skill-auto-suggest.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Skill Auto-Suggest Hook Unit Tests
+# ============================================================================
+# Tests for hooks/prompt/skill-auto-suggest.sh
+# Issue #123: Skill Auto-Suggest Hook
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../fixtures/test-helpers.sh"
+
+HOOK="$PROJECT_ROOT/hooks/prompt/skill-auto-suggest.sh"
+
+# ============================================================================
+# BASIC FUNCTIONALITY TESTS
+# ============================================================================
+
+describe "Skill Auto-Suggest Hook Basic Functionality"
+
+test_hook_exists_and_executable() {
+    if [[ ! -f "$HOOK" ]]; then
+        fail "Hook file not found at $HOOK"
+    fi
+    if [[ ! -x "$HOOK" ]]; then
+        fail "Hook is not executable"
+    fi
+}
+
+test_empty_input_returns_silent_success() {
+    local output
+    output=$(echo "" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    assert_json_field "$output" ".continue" "true"
+    assert_json_field "$output" ".suppressOutput" "true"
+}
+
+test_no_prompt_returns_silent_success() {
+    local input='{}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    assert_json_field "$output" ".continue" "true"
+}
+
+# ============================================================================
+# KEYWORD MATCHING TESTS
+# ============================================================================
+
+describe "Keyword Matching"
+
+test_api_keywords_suggest_api_design() {
+    local input='{"prompt":"Help me design a REST API for user management"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    # Should have additionalContext with api-design-framework
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"api-design-framework"* ]]; then
+            return 0
+        fi
+        fail "Expected api-design-framework in suggestions, got: $context"
+    fi
+}
+
+test_database_keywords_suggest_schema_designer() {
+    local input='{"prompt":"I need to create a database schema for products"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"database-schema-designer"* ]]; then
+            return 0
+        fi
+        fail "Expected database-schema-designer in suggestions"
+    fi
+}
+
+test_auth_keywords_suggest_auth_patterns() {
+    local input='{"prompt":"Implement JWT authentication for the API"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"auth-patterns"* ]]; then
+            return 0
+        fi
+        fail "Expected auth-patterns in suggestions"
+    fi
+}
+
+test_testing_keywords_suggest_pytest() {
+    local input='{"prompt":"Write unit tests for the user service using pytest"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"pytest-advanced"* ]]; then
+            return 0
+        fi
+        fail "Expected pytest-advanced in suggestions"
+    fi
+}
+
+test_react_keywords_suggest_rsc_framework() {
+    local input='{"prompt":"Build a Next.js app with server components"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"react-server-components-framework"* ]]; then
+            return 0
+        fi
+        fail "Expected react-server-components-framework in suggestions"
+    fi
+}
+
+test_fastapi_keywords_suggest_fastapi_advanced() {
+    local input='{"prompt":"Set up FastAPI with dependency injection and middleware"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"fastapi-advanced"* ]]; then
+            return 0
+        fi
+        fail "Expected fastapi-advanced in suggestions"
+    fi
+}
+
+test_security_keywords_suggest_owasp() {
+    local input='{"prompt":"Check for OWASP vulnerabilities in the code"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"owasp-top-10"* ]]; then
+            return 0
+        fi
+        fail "Expected owasp-top-10 in suggestions"
+    fi
+}
+
+test_langgraph_keywords_suggest_langgraph_skills() {
+    local input='{"prompt":"Create a LangGraph workflow with human-in-the-loop"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"langgraph"* ]]; then
+            return 0
+        fi
+        fail "Expected langgraph skills in suggestions"
+    fi
+}
+
+# ============================================================================
+# CC 2.1.9 COMPLIANCE TESTS
+# ============================================================================
+
+describe "CC 2.1.9 Compliance"
+
+test_output_uses_additional_context() {
+    local input='{"prompt":"Help me with API design"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    # When skills are found, should use hookSpecificOutput.additionalContext
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        return 0
+    elif echo "$output" | jq -e '.suppressOutput' >/dev/null 2>&1; then
+        # No matches - also valid
+        return 0
+    fi
+    fail "Expected either additionalContext or suppressOutput"
+}
+
+test_always_returns_continue_true() {
+    local prompts=(
+        '{"prompt":"Help with API"}'
+        '{"prompt":"Random text without keywords"}'
+        '{"prompt":""}'
+        '{}'
+    )
+
+    for input in "${prompts[@]}"; do
+        local output
+        output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+        assert_valid_json "$output"
+        local continue_val
+        continue_val=$(echo "$output" | jq -r '.continue')
+        if [[ "$continue_val" != "true" ]]; then
+            fail "Expected continue:true for input: $input"
+        fi
+    done
+}
+
+test_suppress_output_when_no_matches() {
+    local input='{"prompt":"Hello world"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    # Should have suppressOutput:true when no skills match
+    if echo "$output" | jq -e '.suppressOutput == true' >/dev/null 2>&1; then
+        return 0
+    fi
+    # Or it might find some generic match - check for valid output
+    if echo "$output" | jq -e 'has("continue")' >/dev/null 2>&1; then
+        return 0
+    fi
+    fail "Expected valid output structure"
+}
+
+# ============================================================================
+# MULTIPLE SKILL MATCHING TESTS
+# ============================================================================
+
+describe "Multiple Skill Matching"
+
+test_multiple_keywords_multiple_skills() {
+    local input='{"prompt":"Create a FastAPI endpoint with JWT auth and write tests"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        # Should suggest multiple skills
+        local skill_count=0
+        [[ "$context" == *"fastapi"* ]] && ((skill_count++)) || true
+        [[ "$context" == *"auth"* ]] && ((skill_count++)) || true
+        [[ "$context" == *"test"* ]] && ((skill_count++)) || true
+
+        if (( skill_count >= 2 )); then
+            return 0
+        fi
+        fail "Expected at least 2 skill suggestions, got $skill_count"
+    fi
+}
+
+test_max_suggestions_limit() {
+    # Complex prompt that could match many skills
+    local input='{"prompt":"Create a FastAPI REST API with database schema, JWT auth, pytest tests, and deploy to kubernetes"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        # Count skill mentions (lines starting with "- **")
+        local skill_count
+        skill_count=$(echo "$context" | grep -c "^\- \*\*" || true)
+        if (( skill_count <= 3 )); then
+            return 0
+        fi
+        fail "Expected max 3 suggestions, got $skill_count"
+    fi
+}
+
+# ============================================================================
+# CASE INSENSITIVITY TESTS
+# ============================================================================
+
+describe "Case Insensitivity"
+
+test_uppercase_keywords_match() {
+    local input='{"prompt":"CREATE A REST API WITH JWT AUTH"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        return 0
+    fi
+}
+
+test_mixed_case_keywords_match() {
+    local input='{"prompt":"Build a FastAPI app with PyTest tests"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"fastapi"* ]] || [[ "$context" == *"pytest"* ]]; then
+            return 0
+        fi
+    fi
+}
+
+# ============================================================================
+# EDGE CASES
+# ============================================================================
+
+describe "Edge Cases"
+
+test_special_characters_in_prompt() {
+    local input='{"prompt":"How do I use @decorators and **kwargs in FastAPI?"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    # Should not crash on special characters
+    assert_json_field "$output" ".continue" "true"
+}
+
+test_very_long_prompt() {
+    # Generate a long prompt
+    local long_text
+    long_text=$(printf 'word%.0s ' {1..500})
+    local input="{\"prompt\":\"Help me build an API. $long_text\"}"
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    assert_json_field "$output" ".continue" "true"
+}
+
+test_prompt_with_newlines() {
+    local input='{"prompt":"Help me with:\n1. API design\n2. Database schema\n3. Testing"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    assert_json_field "$output" ".continue" "true"
+}
+
+test_alternative_json_field_names() {
+    # Test with 'message' instead of 'prompt'
+    local input='{"message":"Design a REST API"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+    # Should still find API-related skills
+    if echo "$output" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+        local context
+        context=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+        if [[ "$context" == *"api"* ]]; then
+            return 0
+        fi
+    fi
+}
+
+test_content_field_name() {
+    # Test with 'content' field
+    local input='{"content":"Create a database schema"}'
+    local output
+    output=$(echo "$input" | bash "$HOOK" 2>/dev/null) || true
+
+    assert_valid_json "$output"
+}
+
+# ============================================================================
+# PLUGIN.JSON REGISTRATION TEST
+# ============================================================================
+
+describe "Plugin Registration"
+
+test_hook_registered_in_plugin_json() {
+    local plugin_json="$PROJECT_ROOT/.claude-plugin/plugin.json"
+
+    if [[ ! -f "$plugin_json" ]]; then
+        fail "plugin.json not found"
+    fi
+
+    if grep -q "skill-auto-suggest.sh" "$plugin_json"; then
+        return 0
+    fi
+    fail "Hook not registered in plugin.json"
+}
+
+test_hook_in_user_prompt_submit_section() {
+    local plugin_json="$PROJECT_ROOT/.claude-plugin/plugin.json"
+
+    # Check that it's in the UserPromptSubmit hooks section
+    local in_section
+    in_section=$(jq '.hooks.UserPromptSubmit[0].hooks[] | select(.command | contains("skill-auto-suggest"))' "$plugin_json" 2>/dev/null)
+
+    if [[ -n "$in_section" ]]; then
+        return 0
+    fi
+    fail "Hook not in UserPromptSubmit section"
+}
+
+# ============================================================================
+# RUN TESTS
+# ============================================================================
+
+run_tests


### PR DESCRIPTION
## Summary
- Implements UserPromptSubmit hook that analyzes prompts for task keywords and suggests relevant skills
- Maps 100+ keywords to skills across domains (API, database, auth, testing, frontend, AI/LLM, DevOps)
- Uses CC 2.1.9 additionalContext for non-intrusive skill suggestions

## Test plan
- [x] Run unit tests: `./tests/unit/test-skill-auto-suggest.sh` (25 tests pass)
- [x] Verify hook is executable
- [x] Verify hook is registered in plugin.json
- [x] Test keyword matching for various prompts
- [x] Test edge cases (special characters, long prompts, empty input)

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)