### PR TITLE
fix(agent-browser): Add discovery mode to templates for runnable out-of-box

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "skillforge",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "description": "The Complete AI Development Toolkit — 159 skills, 34 agents, 20 commands, 141 hooks for full-stack development",
   "owner": {
     "name": "Yonatan Gross",
@@ -11,7 +11,7 @@
     {
       "name": "skf",
       "description": "Complete AI development toolkit with 159 skills covering AI/LLM, backend, frontend, security, and testing patterns. Includes 34 specialized agents, 20 commands, and 144 lifecycle hooks.",
-      "version": "4.28.0",
+      "version": "4.28.1",
       "author": {
         "name": "Yonatan Gross",
         "email": "yonatan2gross@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skf",
-  "version": "4.28.0",
+  "version": "4.28.1",
   "description": "Comprehensive AI-assisted development toolkit with 160 skills (20 user-invocable commands, 140 internal knowledge), 34 agents, 141 hooks (CC 2.1.11 Setup hooks), progressive loading, Memory Fabric v2.1 (graph-first architecture, optional mem0 cloud enhancement), and production-ready patterns for modern full-stack development including AI/ML Roadmap 2026 (MCP security, guardrails, agentic RAG, inference optimization)",
   "author": {
     "name": "Yonatan Gross",

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ __pycache__/
 .claude/feedback/
 !.claude/feedback/.gitkeep
 .claude/.satisfaction-counter
+.setup-complete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the SkillForge Claude Code Plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.28.1] - 2026-01-19
+
+### Fixed
+
+- TODO: Describe your changes here
+
+---
+
+
 ## [4.28.0] - 2026-01-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -724,7 +724,7 @@ SKILLFORGE_SKIP_SETUP=1 claude  # Skip all setup hooks
 
 ## Version Information
 
-- **Current Version**: 4.28.0 (as of 2026-01-18)
+- **Current Version**: 4.28.1 (as of 2026-01-18)
 - **Claude Code Requirement**: >= 2.1.11
 - **Skills Structure**: CC 2.1.7 native flat (skills/<skill>/)
 - **Agent Format**: CC 2.1.6 native (skills array in frontmatter)
@@ -778,4 +778,4 @@ tail -f hooks/logs/*.log
 
 ---
 
-**Last Updated**: 2026-01-18 (v4.28.0)
+**Last Updated**: 2026-01-19 (v4.28.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "skillforge-claude-plugin"
-version = "4.28.0"
+version = "4.28.1"
 description = "SkillForge Complete - AI-assisted development toolkit for Claude Code with 159 skills, 32 agents, and 144 hooks"
 requires-python = ">=3.13"
 readme = "README.md"

--- a/skills/agent-browser/templates/authenticated-session.sh
+++ b/skills/agent-browser/templates/authenticated-session.sh
@@ -1,14 +1,53 @@
 #!/bin/bash
 # Template: Authenticated Session Management
 # Login once, save state, reuse for subsequent sessions
+#
+# Usage:
+#   ./authenticated-session.sh <app-url> [state-file]
+#
+# Setup:
+#   1. Run once to see your form structure
+#   2. Note the @refs for your fields
+#   3. Update FORM_REFS section and set DISCOVERY_MODE=false
 
 set -euo pipefail
 
 APP_URL="${1:?Usage: $0 <app-url> [state-file]}"
 STATE_FILE="${2:-$HOME/.config/agent-browser/auth-state.json}"
 
+# ══════════════════════════════════════════════════════════════
+# FORM_REFS: Update these after running discovery mode
+# ══════════════════════════════════════════════════════════════
+DISCOVERY_MODE=true        # Set to false after customizing refs
+USERNAME_REF="@e1"         # Email/username input ref
+PASSWORD_REF="@e2"         # Password input ref
+SUBMIT_REF="@e3"           # Login button ref
+SUCCESS_URL_PATTERN="**/dashboard"  # URL pattern after successful login
+# ══════════════════════════════════════════════════════════════
+
 # Ensure state directory exists
 mkdir -p "$(dirname "$STATE_FILE")"
+
+discover_form() {
+    echo "Opening login page for discovery..."
+    agent-browser open "$APP_URL/login"
+    agent-browser wait --load networkidle
+
+    echo ""
+    echo "┌─────────────────────────────────────────────────────────┐"
+    echo "│ LOGIN FORM STRUCTURE                                    │"
+    echo "├─────────────────────────────────────────────────────────┤"
+    agent-browser snapshot -i
+    echo "└─────────────────────────────────────────────────────────┘"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Note refs: @e? = username, @e? = password, @e? = submit"
+    echo "  2. Edit FORM_REFS section at top of this script"
+    echo "  3. Set DISCOVERY_MODE=false"
+    echo "  4. Set APP_USERNAME and APP_PASSWORD env vars"
+    echo ""
+    agent-browser close
+}
 
 login_flow() {
     echo "Performing login flow..."
@@ -26,13 +65,22 @@ login_flow() {
         exit 1
     fi
 
-    # Modify refs based on your app's login form
-    agent-browser fill @e1 "$APP_USERNAME"    # Username/email field
-    agent-browser fill @e2 "$APP_PASSWORD"    # Password field
-    agent-browser click @e3                    # Login button
+    # Fill form using configured refs
+    agent-browser fill "$USERNAME_REF" "$APP_USERNAME"
+    agent-browser fill "$PASSWORD_REF" "$APP_PASSWORD"
+    agent-browser click "$SUBMIT_REF"
 
     # Wait for successful login
-    agent-browser wait --url "**/dashboard" --timeout 10000
+    agent-browser wait --url "$SUCCESS_URL_PATTERN" --timeout 10000
+
+    # Verify not still on login page
+    CURRENT_URL=$(agent-browser get url)
+    if [[ "$CURRENT_URL" == *"/login"* ]] || [[ "$CURRENT_URL" == *"/signin"* ]]; then
+        echo "ERROR: Login failed - still on login page"
+        agent-browser screenshot /tmp/login-failed.png
+        agent-browser close
+        exit 1
+    fi
 
     # Save authenticated state
     agent-browser state save "$STATE_FILE"
@@ -58,7 +106,7 @@ use_saved_session() {
 
     # Verify still authenticated (check for login redirect)
     CURRENT_URL=$(agent-browser get url)
-    if [[ "$CURRENT_URL" == *"/login"* ]]; then
+    if [[ "$CURRENT_URL" == *"/login"* ]] || [[ "$CURRENT_URL" == *"/signin"* ]]; then
         echo "Session expired, re-authenticating..."
         rm -f "$STATE_FILE"
         return 1
@@ -68,7 +116,17 @@ use_saved_session() {
     return 0
 }
 
-# Main flow
+# ══════════════════════════════════════════════════════════════
+# MAIN FLOW
+# ══════════════════════════════════════════════════════════════
+
+# Discovery mode: run first to identify form refs
+if [[ "$DISCOVERY_MODE" == "true" ]]; then
+    discover_form
+    exit 0
+fi
+
+# Production mode: use saved session or login
 if ! use_saved_session; then
     login_flow
 fi

--- a/skills/agent-browser/templates/form-automation.sh
+++ b/skills/agent-browser/templates/form-automation.sh
@@ -1,64 +1,140 @@
 #!/bin/bash
 # Template: Form Automation Workflow
 # Fills and submits web forms with validation
+#
+# Usage:
+#   ./form-automation.sh <form-url>
+#
+# Setup:
+#   1. Run once to see your form structure
+#   2. Note the @refs for your fields
+#   3. Update FORM_CONFIG section and set DISCOVERY_MODE=false
 
 set -euo pipefail
 
 FORM_URL="${1:?Usage: $0 <form-url>}"
 
-echo "Automating form at: $FORM_URL"
+# ══════════════════════════════════════════════════════════════
+# FORM_CONFIG: Update these after running discovery mode
+# ══════════════════════════════════════════════════════════════
+DISCOVERY_MODE=true    # Set to false after customizing
 
-# Navigate to form page
-agent-browser open "$FORM_URL"
-agent-browser wait --load networkidle
+# Define your form fields (update refs after discovery)
+# Format: "ref|action|value" where action is: fill, select, check, click
+FORM_FIELDS=(
+    # "@e1|fill|John Doe"              # Name field
+    # "@e2|fill|user@example.com"       # Email field
+    # "@e3|fill|+1-555-123-4567"        # Phone field
+    # "@e4|select|Option Value"         # Dropdown
+    # "@e5|check|"                       # Checkbox
+    # "@e6|click|"                       # Radio button
+)
+SUBMIT_REF="@e10"      # Submit button ref
+SUCCESS_PATTERN=""     # Optional: URL pattern after success (e.g., "**/thank-you")
+# ══════════════════════════════════════════════════════════════
 
-# Get interactive snapshot to identify form fields
-echo "Analyzing form structure..."
-agent-browser snapshot -i
+discover_form() {
+    echo "Opening form page for discovery..."
+    agent-browser open "$FORM_URL"
+    agent-browser wait --load networkidle
 
-# Example: Fill common form fields
-# Uncomment and modify refs based on snapshot output
+    echo ""
+    echo "┌─────────────────────────────────────────────────────────┐"
+    echo "│ FORM STRUCTURE                                          │"
+    echo "├─────────────────────────────────────────────────────────┤"
+    agent-browser snapshot -i
+    echo "└─────────────────────────────────────────────────────────┘"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Note refs for each form field"
+    echo "  2. Edit FORM_CONFIG section at top of this script"
+    echo "  3. Add entries to FORM_FIELDS array"
+    echo "  4. Set SUBMIT_REF to your submit button"
+    echo "  5. Set DISCOVERY_MODE=false"
+    echo ""
+    agent-browser close
+}
 
-# Text inputs
-# agent-browser fill @e1 "John Doe"           # Name field
-# agent-browser fill @e2 "user@example.com"   # Email field
-# agent-browser fill @e3 "+1-555-123-4567"    # Phone field
+fill_form() {
+    echo "Automating form at: $FORM_URL"
 
-# Password fields
-# agent-browser fill @e4 "SecureP@ssw0rd!"
+    # Navigate to form page
+    agent-browser open "$FORM_URL"
+    agent-browser wait --load networkidle
 
-# Dropdowns
-# agent-browser select @e5 "Option Value"
+    # Show form structure
+    echo "Form structure:"
+    agent-browser snapshot -i
 
-# Checkboxes
-# agent-browser check @e6                      # Check
-# agent-browser uncheck @e7                    # Uncheck
+    # Process each field
+    for field in "${FORM_FIELDS[@]}"; do
+        [[ -z "$field" || "$field" == \#* ]] && continue
 
-# Radio buttons
-# agent-browser click @e8                      # Select radio option
+        IFS='|' read -r ref action value <<< "$field"
 
-# Text areas
-# agent-browser fill @e9 "Multi-line text content here"
+        case "$action" in
+            fill)
+                echo "Filling $ref with: $value"
+                agent-browser fill "$ref" "$value"
+                ;;
+            select)
+                echo "Selecting $ref: $value"
+                agent-browser select "$ref" "$value"
+                ;;
+            check)
+                echo "Checking $ref"
+                agent-browser check "$ref"
+                ;;
+            uncheck)
+                echo "Unchecking $ref"
+                agent-browser uncheck "$ref"
+                ;;
+            click)
+                echo "Clicking $ref"
+                agent-browser click "$ref"
+                ;;
+            upload)
+                echo "Uploading to $ref: $value"
+                agent-browser upload "$ref" "$value"
+                ;;
+            *)
+                echo "Unknown action: $action"
+                ;;
+        esac
+    done
 
-# File uploads
-# agent-browser upload @e10 /path/to/file.pdf
+    # Submit form
+    echo "Submitting form..."
+    agent-browser click "$SUBMIT_REF"
+    agent-browser wait --load networkidle
 
-# Submit form
-# agent-browser click @e11                     # Submit button
+    # Wait for success pattern if defined
+    if [[ -n "$SUCCESS_PATTERN" ]]; then
+        agent-browser wait --url "$SUCCESS_PATTERN" --timeout 10000
+    fi
 
-# Wait for response
-# agent-browser wait --load networkidle
-# agent-browser wait --url "**/success"        # Or wait for redirect
+    # Verify submission
+    echo ""
+    echo "Form submission result:"
+    agent-browser get url
+    agent-browser snapshot -i
 
-# Verify submission
-echo "Form submission result:"
-agent-browser get url
-agent-browser snapshot -i
+    # Take screenshot of result
+    agent-browser screenshot /tmp/form-result.png
+    echo "Screenshot saved: /tmp/form-result.png"
 
-# Take screenshot of result
-agent-browser screenshot /tmp/form-result.png
+    # Cleanup
+    agent-browser close
 
-# Cleanup
-agent-browser close
+    echo "Form automation complete"
+}
 
-echo "Form automation complete"
+# ══════════════════════════════════════════════════════════════
+# MAIN
+# ══════════════════════════════════════════════════════════════
+
+if [[ "$DISCOVERY_MODE" == "true" ]]; then
+    discover_form
+else
+    fill_form
+fi


### PR DESCRIPTION
## Summary

Templates previously had inconsistent commenting - form actions were commented but verification wasn't, causing scripts to fail when run as-is.

- Added `DISCOVERY_MODE` flag to both templates (default: `true`)
- Templates now work out-of-box in discovery mode
- Clear separation between discovery and production phases

## Changes

| File | Change |
|------|--------|
| `authenticated-session.sh` | Added discovery mode, configurable refs via variables |
| `form-automation.sh` | Added discovery mode, declarative FORM_FIELDS array |

## Pattern

```
┌─────────────────────────────────────────────────────────────┐
│ Run 1: DISCOVERY_MODE=true (default)                        │
│   → Shows form structure with refs                          │
│   → User notes @e1, @e2, @e3 for their fields              │
│   → exit 0 (clean)                                          │
├─────────────────────────────────────────────────────────────┤
│ Run 2+: DISCOVERY_MODE=false (after customizing)            │
│   → Uses configured refs                                    │
│   → Performs actual automation                              │
└─────────────────────────────────────────────────────────────┘
```

## Context

Addresses feedback from Vercel bot on upstream PR vercel-labs/agent-browser#157.

## Test plan

- [x] Templates pass shell syntax check
- [x] DISCOVERY_MODE=true exits cleanly
- [x] No uncommented code that depends on commented refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)