### PR TITLE
feat(agent-browser): Sync skill to upstream v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the OrchestKit Claude Code Plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2026-01-24
+
+### Changed
+
+- **agent-browser skill**: Synced to upstream v0.7.0
+  - Added Installation section (`install`, `install --with-deps`)
+  - Added `download` command and `wait --download`
+  - Added `connect` command for CDP WebSocket URLs
+  - Added `get styles` command
+  - Added `--profile` flag for persistent browser profiles
+  - Added `-p, --provider` flag for cloud browsers (Browserbase, Browser Use)
+  - Added `--args`, `--user-agent`, `--proxy-bypass` launch config flags
+  - Added `--executable-path`, `--debug`, `--cdp` flags
+  - Added new semantic locators: `placeholder`, `alt`, `title`, `testid`, `last`, `--exact`
+  - Added Selector Types section (refs, CSS, text=, xpath=)
+  - Added `storage session` commands (alongside `storage local`)
+  - Added command aliases (goto/navigate, quit/exit, key, scrollinto)
+  - Added `tab close <n>` for closing tabs by index
+  - Added complete environment variables (including `AGENT_BROWSER_STREAM_PORT`)
+  - New references: `persistent-profiles.md`, `cloud-providers.md`
+  - Updated `commands.md`, `proxy-support.md`, `protocol-alignment.md`
+  - Skill version bumped to 2.0.0
+
 ## [5.1.0] - 2026-01-23
 
 ### Added

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -3,7 +3,7 @@ name: agent-browser
 description: Vercel agent-browser CLI for headless browser automation. 93% less context than Playwright MCP. Snapshot + refs workflow with @e1 @e2 element references. Use when automating browser tasks, web scraping, form automation, or content capture.
 context: fork
 agent: test-generator
-version: 1.0.0
+version: 2.0.0
 author: OrchestKit AI Agent Hub
 tags: [browser, automation, headless, scraping, vercel, agent-browser, 2026]
 user-invocable: false
@@ -22,6 +22,14 @@ Automates browser interactions for web testing, form filling, screenshots, and d
 - E2E test generation and debugging
 - Content capture from authenticated pages
 - Browser-based automation tasks via CLI
+
+## Installation
+
+```bash
+npm install -g agent-browser      # Install CLI
+agent-browser install             # Download Chromium
+agent-browser install --with-deps # With system dependencies (Linux)
+```
 
 ## Quick Start
 
@@ -45,11 +53,12 @@ agent-browser close               # Close browser
 ### Navigation
 
 ```bash
-agent-browser open <url>          # Navigate to URL
+agent-browser open <url>          # Navigate to URL (aliases: goto, navigate)
+agent-browser connect <port>      # Connect to browser via CDP port
 agent-browser back                # Go back
 agent-browser forward             # Go forward
 agent-browser reload              # Reload page
-agent-browser close               # Close browser
+agent-browser close               # Close browser (aliases: quit, exit)
 ```
 
 ### Snapshot (Page Analysis)
@@ -70,7 +79,7 @@ agent-browser dblclick @e1        # Double-click
 agent-browser focus @e1           # Focus element
 agent-browser fill @e2 "text"     # Clear and type
 agent-browser type @e2 "text"     # Type without clearing
-agent-browser press Enter         # Press key
+agent-browser press Enter         # Press key (alias: key)
 agent-browser press Control+a     # Key combination
 agent-browser keydown Shift       # Hold key down
 agent-browser keyup Shift         # Release key
@@ -78,8 +87,9 @@ agent-browser hover @e1           # Hover
 agent-browser check @e1           # Check checkbox
 agent-browser uncheck @e1         # Uncheck checkbox
 agent-browser select @e1 "value"  # Select dropdown
+agent-browser select @e1 "a" "b"  # Multi-select (v0.7.0)
 agent-browser scroll down 500     # Scroll page
-agent-browser scrollintoview @e1  # Scroll element into view
+agent-browser scrollintoview @e1  # Scroll element into view (alias: scrollinto)
 agent-browser drag @e1 @e2        # Drag and drop
 agent-browser upload @e1 file.pdf # Upload files
 ```
@@ -91,6 +101,7 @@ agent-browser get text @e1        # Get element text
 agent-browser get html @e1        # Get innerHTML
 agent-browser get value @e1       # Get input value
 agent-browser get attr @e1 href   # Get attribute
+agent-browser get styles @e1      # Get computed styles
 agent-browser get title           # Get page title
 agent-browser get url             # Get current URL
 agent-browser get count ".item"   # Count matching elements
@@ -112,6 +123,13 @@ agent-browser screenshot          # Screenshot to stdout
 agent-browser screenshot path.png # Save to file
 agent-browser screenshot --full   # Full page
 agent-browser pdf output.pdf      # Save as PDF
+```
+
+### Downloads
+
+```bash
+agent-browser download @e1 ./file.pdf  # Click element and save download
+agent-browser wait --download [path]   # Wait for download to complete
 ```
 
 ### Video Recording
@@ -143,13 +161,37 @@ agent-browser mouse up left       # Release button
 agent-browser mouse wheel 100     # Scroll wheel
 ```
 
+### Selector Types
+
+```bash
+# Refs from snapshot (preferred)
+agent-browser click @e1           # Element ref
+agent-browser click @e2
+
+# CSS selectors
+agent-browser click "#submit-btn"
+agent-browser click ".nav > button"
+
+# Text selectors
+agent-browser click "text=Sign In"
+
+# XPath selectors
+agent-browser click "xpath=//button[@type='submit']"
+```
+
 ### Semantic Locators (Alternative to Refs)
 
 ```bash
 agent-browser find role button click --name "Submit"
 agent-browser find text "Sign In" click
+agent-browser find text "Sign In" click --exact    # Exact match (v0.7.0)
 agent-browser find label "Email" fill "user@test.com"
+agent-browser find placeholder "Search" type "query"  # By placeholder (v0.7.0)
+agent-browser find alt "Logo" click                   # By alt text (v0.7.0)
+agent-browser find title "Close" click                # By title attr (v0.7.0)
+agent-browser find testid "submit-btn" click          # By data-testid (v0.7.0)
 agent-browser find first ".item" click
+agent-browser find last ".item" click                 # Last match (v0.7.0)
 agent-browser find nth 2 "a" text
 ```
 
@@ -175,6 +217,10 @@ agent-browser storage local       # Get all localStorage
 agent-browser storage local key   # Get specific key
 agent-browser storage local set k v # Set value
 agent-browser storage local clear # Clear all
+agent-browser storage session     # Get all sessionStorage
+agent-browser storage session key # Get specific key
+agent-browser storage session set k v # Set value
+agent-browser storage session clear # Clear all
 ```
 
 ### Network
@@ -194,7 +240,8 @@ agent-browser network requests --filter api # Filter requests
 agent-browser tab                 # List tabs
 agent-browser tab new [url]       # New tab
 agent-browser tab 2               # Switch to tab
-agent-browser tab close           # Close tab
+agent-browser tab close           # Close current tab
+agent-browser tab close 2         # Close tab by index (v0.7.0)
 agent-browser window new          # New window
 ```
 
@@ -249,6 +296,46 @@ agent-browser trace stop trace.zip # Stop and save trace
 agent-browser --cdp 9222 snapshot # Connect via CDP
 ```
 
+## Global Options (v0.7.0)
+
+```bash
+agent-browser --session <name> ...       # Named session for isolation
+agent-browser --json ...                 # JSON output mode
+agent-browser --headed ...               # Visible browser window
+agent-browser --debug ...                # Debug logging
+agent-browser --profile <path> ...       # Persistent browser profile
+agent-browser -p, --provider <name> ...  # Cloud browser provider
+agent-browser --proxy <url> ...          # Proxy server
+agent-browser --args <args> ...          # Extra browser args
+agent-browser --user-agent <ua> ...      # Custom user agent
+agent-browser --proxy-bypass <list> ...  # Proxy bypass list
+agent-browser --executable-path <path> ...  # Custom browser binary
+agent-browser --extension <path> ...     # Load browser extension
+agent-browser --timeout <ms> ...         # Default timeout
+agent-browser --cdp <port> ...           # Connect via CDP
+```
+
+## Environment Variables (v0.7.0)
+
+```bash
+AGENT_BROWSER_SESSION="my-session"   # Default session name
+AGENT_BROWSER_PROFILE="/path"        # Default profile path
+AGENT_BROWSER_PROVIDER="browserbase" # Cloud provider
+AGENT_BROWSER_EXECUTABLE_PATH="/path/to/chrome"  # Custom browser
+AGENT_BROWSER_ARGS="--disable-gpu"   # Extra browser args
+AGENT_BROWSER_USER_AGENT="..."       # Default user agent
+AGENT_BROWSER_PROXY="http://proxy:8080"  # Proxy URL
+AGENT_BROWSER_PROXY_BYPASS="localhost,*.local"  # Bypass list
+AGENT_BROWSER_STREAM_PORT="9223"     # WebSocket streaming port
+AGENT_BROWSER_HEADED=1               # Run in headed mode
+NO_COLOR=1                           # Disable color output
+
+# Cloud provider credentials
+BROWSERBASE_API_KEY="..."            # Browserbase API key
+BROWSERBASE_PROJECT_ID="..."         # Browserbase project
+BROWSER_USE_API_KEY="..."            # Browser Use API key
+```
+
 ## Example: Form Submission
 
 ```bash
@@ -294,3 +381,17 @@ agent-browser open https://app.example.com/dashboard
 | Snapshot + Refs | @e1, @e2 pattern | 93% context reduction |
 | Rust + Node.js | Hybrid architecture | Fast CLI (~1-2ms) + stable browser control |
 | Session isolation | --session flag | Safe concurrent automation |
+
+## Deep-dive Documentation
+
+| Reference | Description |
+|-----------|-------------|
+| [references/snapshot-refs.md](references/snapshot-refs.md) | Ref lifecycle, invalidation, best practices |
+| [references/commands.md](references/commands.md) | Complete 60+ command reference |
+| [references/authentication.md](references/authentication.md) | Session persistence, login flows |
+| [references/session-management.md](references/session-management.md) | Parallel sessions, state management |
+| [references/video-recording.md](references/video-recording.md) | Recording workflows, format options |
+| [references/proxy-support.md](references/proxy-support.md) | Proxy configuration, authentication |
+| [references/persistent-profiles.md](references/persistent-profiles.md) | Browser profile persistence (v0.7.0) |
+| [references/cloud-providers.md](references/cloud-providers.md) | Browserbase, Browser Use setup (v0.7.0) |
+| [references/protocol-alignment.md](references/protocol-alignment.md) | Version compatibility, breaking changes |

--- a/skills/agent-browser/references/cloud-providers.md
+++ b/skills/agent-browser/references/cloud-providers.md
@@ -1,0 +1,229 @@
+# Cloud Browser Providers (v0.7.0)
+
+Run browser automation on cloud infrastructure for scalability, geo-distribution, and avoiding local resource constraints.
+
+## Supported Providers
+
+| Provider | Flag Value | Use Case |
+|----------|------------|----------|
+| Browserbase | `browserbase` | Production automation, scaling |
+| Browser Use | `browseruse` | AI-native browser automation |
+
+## Basic Usage
+
+```bash
+# Use Browserbase
+agent-browser -p browserbase open https://example.com
+
+# Use Browser Use
+agent-browser -p browseruse open https://example.com
+
+# Or with long flag
+agent-browser --provider browserbase open https://example.com
+```
+
+## Provider Configuration
+
+### Browserbase
+
+1. **Sign up** at [browserbase.com](https://browserbase.com)
+2. **Get API key** from dashboard
+3. **Configure environment**:
+
+```bash
+# Required
+export BROWSERBASE_API_KEY="your-api-key"
+
+# Optional - project ID
+export BROWSERBASE_PROJECT_ID="your-project-id"
+```
+
+4. **Use provider**:
+
+```bash
+agent-browser -p browserbase open https://example.com
+agent-browser snapshot -i
+agent-browser click @e1
+```
+
+### Browser Use
+
+1. **Sign up** at [browseruse.com](https://browseruse.com)
+2. **Get API key** from settings
+3. **Configure environment**:
+
+```bash
+export BROWSER_USE_API_KEY="your-api-key"
+```
+
+4. **Use provider**:
+
+```bash
+agent-browser -p browseruse open https://example.com
+```
+
+## Environment Variable Alternative
+
+Set default provider via environment:
+
+```bash
+# In shell profile
+export AGENT_BROWSER_PROVIDER="browserbase"
+
+# Now all commands use cloud provider
+agent-browser open https://example.com
+```
+
+## When to Use Cloud Providers
+
+### Use Cloud When:
+
+- **Scaling**: Running many parallel browser sessions
+- **Geo-testing**: Testing from different geographic regions
+- **Resource constraints**: Local machine lacks resources
+- **CI/CD**: Running in containers without display
+- **Long-running tasks**: Avoid local machine timeout/sleep issues
+- **Anonymity**: Need fresh IPs for each session
+
+### Use Local When:
+
+- **Development**: Fast iteration, debugging
+- **Low volume**: Single browser session
+- **Sensitive data**: Data must stay local
+- **Offline work**: No internet connectivity
+
+## Provider Features Comparison
+
+| Feature | Local | Browserbase | Browser Use |
+|---------|-------|-------------|-------------|
+| Cost | Free | Pay-per-use | Pay-per-use |
+| Scaling | Limited | High | High |
+| Geo-locations | Local only | Multiple | Multiple |
+| Session recording | Manual | Built-in | Built-in |
+| Stealth mode | Limited | Built-in | Built-in |
+| AI features | None | None | Native AI |
+
+## Example: Geo-Testing
+
+```bash
+#!/bin/bash
+# Test site from multiple regions using cloud provider
+
+export BROWSERBASE_API_KEY="..."
+
+REGIONS=("us-east" "eu-west" "ap-south")
+
+for region in "${REGIONS[@]}"; do
+    echo "Testing from $region..."
+
+    # Browserbase supports region selection
+    BROWSERBASE_REGION="$region" agent-browser -p browserbase \
+        open https://example.com
+
+    agent-browser screenshot "/tmp/screenshot-$region.png"
+    agent-browser get text body > "/tmp/content-$region.txt"
+    agent-browser close
+done
+```
+
+## Example: Parallel Scaling
+
+```bash
+#!/bin/bash
+# Run 10 parallel browser sessions in cloud
+
+export BROWSERBASE_API_KEY="..."
+
+for i in {1..10}; do
+    (
+        agent-browser -p browserbase --session "worker-$i" \
+            open "https://example.com/page-$i"
+        agent-browser --session "worker-$i" snapshot -i
+        agent-browser --session "worker-$i" get text body > "/tmp/page-$i.txt"
+        agent-browser --session "worker-$i" close
+    ) &
+done
+
+wait
+echo "All sessions complete"
+```
+
+## Combining with Other Options
+
+```bash
+# Cloud provider with profile persistence
+agent-browser -p browserbase --profile ~/.agent-browser/cloud-profile \
+    open https://example.com
+
+# Cloud provider with proxy
+agent-browser -p browserbase --proxy http://proxy:8080 \
+    open https://example.com
+
+# Cloud provider with custom user agent
+agent-browser -p browserbase --user-agent "Custom Agent/1.0" \
+    open https://example.com
+```
+
+## Cost Optimization
+
+### 1. Reuse Sessions
+
+```bash
+# Don't close between operations
+agent-browser -p browserbase --session reused open https://example.com
+agent-browser --session reused snapshot -i
+agent-browser --session reused click @e1
+# ...more operations...
+agent-browser --session reused close  # Close when done
+```
+
+### 2. Use Local for Development
+
+```bash
+# Development - local
+agent-browser open https://localhost:3000
+
+# Production - cloud
+agent-browser -p browserbase open https://production.example.com
+```
+
+### 3. Batch Operations
+
+```bash
+# Combine operations before close
+agent-browser -p browserbase open https://example.com
+agent-browser snapshot -i
+agent-browser click @e1
+agent-browser wait --load networkidle
+agent-browser screenshot /tmp/result.png
+agent-browser get text body
+agent-browser close  # Single session for all operations
+```
+
+## Troubleshooting
+
+### Authentication Failed
+
+```bash
+# Verify API key
+echo $BROWSERBASE_API_KEY
+
+# Test with curl
+curl -H "Authorization: Bearer $BROWSERBASE_API_KEY" \
+    https://api.browserbase.com/v1/sessions
+```
+
+### Connection Timeout
+
+```bash
+# Increase timeout for cloud latency
+agent-browser -p browserbase --timeout 60000 open https://example.com
+```
+
+### Session Not Found
+
+```bash
+# Cloud sessions may expire - always handle gracefully
+agent-browser -p browserbase --session my-session open https://example.com || \
+    agent-browser -p browserbase --session my-session-new open https://example.com
+```

--- a/skills/agent-browser/references/commands.md
+++ b/skills/agent-browser/references/commands.md
@@ -1,13 +1,18 @@
 # agent-browser Command Reference
 
-Complete reference for all 60+ agent-browser CLI commands.
+Complete reference for all 60+ agent-browser CLI commands. Updated for v0.7.0.
 
 ## Navigation Commands
 
 ```bash
 # Open URL (starts browser if needed)
+# Aliases: goto, navigate
 agent-browser open <url>
 agent-browser open https://example.com
+
+# Connect to existing browser via CDP (v0.7.0)
+agent-browser connect <port>
+agent-browser connect 9222
 
 # Navigation history
 agent-browser back
@@ -53,7 +58,7 @@ agent-browser type @e2 "additional text"
 agent-browser select @e3 "Option Text"
 agent-browser select @e3 --value "option_value"
 
-# Press keyboard keys
+# Press keyboard keys (alias: key)
 agent-browser press Enter
 agent-browser press Tab
 agent-browser press "Control+a"
@@ -109,6 +114,20 @@ agent-browser record stop
 agent-browser record restart /path/to/new-recording.webm
 ```
 
+## Download Commands (v0.7.0)
+
+```bash
+# Click element and save download
+agent-browser download @e1 /path/to/file.pdf
+
+# Wait for download to complete
+agent-browser wait --download
+agent-browser wait --download /path/to/expected-file.pdf
+
+# Download with timeout
+agent-browser download @e1 /path/to/file.zip --timeout 60000
+```
+
 ## Wait Commands
 
 ```bash
@@ -162,8 +181,9 @@ agent-browser tab switch 2
 # Close current tab
 agent-browser tab close
 
-# Close specific tab
+# Close specific tab by index (v0.7.0)
 agent-browser tab close 1
+agent-browser tab close 2
 ```
 
 ## Session Management
@@ -291,9 +311,52 @@ agent-browser close --force
 # Timeout (ms)
 --timeout <ms>
 
+# JSON output mode
+--json
+
 # Headful mode (visible browser)
-AGENT_BROWSER_HEADED=1 agent-browser open https://example.com
+--headed
+
+# Persistent browser profile (v0.7.0)
+--profile <path>
+
+# Cloud browser provider (v0.7.0)
+-p, --provider <name>
+
+# Extra browser arguments (v0.7.0)
+--args <args>
+
+# Custom user agent (v0.7.0)
+--user-agent <ua>
+
+# Proxy bypass list (v0.7.0)
+--proxy-bypass <domains>
+
+# Load browser extension
+--extension <path>
+```
+
+## Environment Variables
+
+```bash
+# Persistent profile path (v0.7.0)
+AGENT_BROWSER_PROFILE="/path/to/profile"
+
+# Cloud provider (v0.7.0)
+AGENT_BROWSER_PROVIDER="browserbase"
+
+# Extra browser args (v0.7.0)
+AGENT_BROWSER_ARGS="--disable-gpu"
+
+# Custom user agent (v0.7.0)
+AGENT_BROWSER_USER_AGENT="Custom/1.0"
+
+# Proxy bypass list (v0.7.0)
+AGENT_BROWSER_PROXY_BYPASS="localhost,*.local"
+
+# Headful mode (visible browser)
+AGENT_BROWSER_HEADED=1
 
 # No color output
-NO_COLOR=1 agent-browser snapshot
+NO_COLOR=1
 ```

--- a/skills/agent-browser/references/persistent-profiles.md
+++ b/skills/agent-browser/references/persistent-profiles.md
@@ -1,0 +1,173 @@
+# Persistent Browser Profiles (v0.7.0)
+
+Maintain browser state across sessions with persistent profiles.
+
+## Overview
+
+The `--profile` flag stores browser data (cookies, localStorage, cache, extensions) in a persistent directory. Unlike `state save/load` which requires explicit commands, profiles automatically persist all browser state.
+
+## Basic Usage
+
+```bash
+# First session - login and interactions are automatically saved
+agent-browser --profile ~/.agent-browser/my-project open https://app.example.com
+agent-browser snapshot -i
+agent-browser fill @e1 "username"
+agent-browser fill @e2 "password"
+agent-browser click @e3
+agent-browser close
+
+# Later session - authentication persists automatically
+agent-browser --profile ~/.agent-browser/my-project open https://app.example.com/dashboard
+# Already logged in!
+```
+
+## Environment Variable
+
+Set a default profile via environment variable:
+
+```bash
+# In shell profile (~/.bashrc, ~/.zshrc)
+export AGENT_BROWSER_PROFILE="$HOME/.agent-browser/default"
+
+# Now all commands use this profile automatically
+agent-browser open https://app.example.com
+```
+
+## Use Cases
+
+### 1. Multi-Project Isolation
+
+```bash
+# Project A profile
+agent-browser --profile ~/.agent-browser/project-a open https://app-a.example.com
+
+# Project B profile (separate cookies, storage)
+agent-browser --profile ~/.agent-browser/project-b open https://app-b.example.com
+```
+
+### 2. Authenticated Session Persistence
+
+```bash
+#!/bin/bash
+# login-once.sh - Run once to authenticate
+
+PROFILE=~/.agent-browser/my-app
+
+agent-browser --profile "$PROFILE" open https://app.example.com/login
+agent-browser snapshot -i
+agent-browser fill @e1 "$USERNAME"
+agent-browser fill @e2 "$PASSWORD"
+agent-browser click @e3
+agent-browser wait --url "**/dashboard"
+agent-browser close
+
+echo "Profile saved. Future sessions will be authenticated."
+```
+
+```bash
+#!/bin/bash
+# daily-task.sh - Uses saved authentication
+
+PROFILE=~/.agent-browser/my-app
+
+agent-browser --profile "$PROFILE" open https://app.example.com/dashboard
+# Already logged in - no login needed
+agent-browser snapshot -i
+agent-browser get text @e1
+agent-browser close
+```
+
+### 3. Extension Loading
+
+Profiles can include browser extensions:
+
+```bash
+# Extensions installed in profile persist
+agent-browser --profile ~/.agent-browser/with-extensions open https://example.com
+```
+
+## Profile vs State Save/Load
+
+| Feature | `--profile` | `state save/load` |
+|---------|-------------|-------------------|
+| Persistence | Automatic | Explicit command |
+| Scope | All browser data | Cookies + localStorage |
+| Storage | Directory | JSON file |
+| Extensions | Supported | Not supported |
+| Cache | Included | Not included |
+| Use case | Long-term sessions | Portable state |
+
+## Best Practices
+
+### 1. Use Project-Specific Profiles
+
+```bash
+# Good - isolated per project
+--profile ~/.agent-browser/project-name
+
+# Avoid - conflicts between projects
+--profile ~/.agent-browser/default
+```
+
+### 2. Combine with Sessions for Parallel Work
+
+```bash
+# Profile for persistent state + session for isolation
+agent-browser --profile ~/.agent-browser/app --session test1 open https://app.example.com
+agent-browser --profile ~/.agent-browser/app --session test2 open https://app.example.com
+```
+
+### 3. Clean Profiles Periodically
+
+```bash
+# Remove stale profiles
+rm -rf ~/.agent-browser/old-project
+
+# Keep profile size manageable
+du -sh ~/.agent-browser/*
+```
+
+## Profile Directory Structure
+
+```
+~/.agent-browser/my-project/
+├── Default/
+│   ├── Cookies
+│   ├── Local Storage/
+│   ├── Session Storage/
+│   └── ...
+├── Extensions/
+└── ...
+```
+
+## Troubleshooting
+
+### Profile Not Persisting
+
+```bash
+# Ensure proper close
+agent-browser close  # Flushes profile to disk
+
+# Check profile exists
+ls -la ~/.agent-browser/my-project/
+```
+
+### Profile Too Large
+
+```bash
+# Check size
+du -sh ~/.agent-browser/my-project/
+
+# Clear cache only (keeps cookies/storage)
+rm -rf ~/.agent-browser/my-project/Default/Cache/
+```
+
+### Corrupted Profile
+
+```bash
+# Delete and recreate
+rm -rf ~/.agent-browser/my-project/
+agent-browser --profile ~/.agent-browser/my-project open https://example.com
+# Re-authenticate as needed
+```

--- a/skills/agent-browser/references/protocol-alignment.md
+++ b/skills/agent-browser/references/protocol-alignment.md
@@ -1,6 +1,6 @@
-# Protocol Alignment (v0.6.0)
+# Protocol Alignment (v0.6.0 - v0.7.0)
 
-Breaking changes in v0.6.0 for protocol consistency. Update commands accordingly.
+Version compatibility notes and breaking changes. Update commands accordingly.
 
 ## Breaking Changes
 
@@ -153,6 +153,93 @@ agent-browser network
 agent-browser select @e1 "Option 1" "Option 2" "Option 3"
 ```
 
+## New Features in v0.7.0
+
+### Download Commands
+
+```bash
+# Click element and save download
+agent-browser download @e1 ./file.pdf
+
+# Wait for download to complete
+agent-browser wait --download [path]
+```
+
+### Persistent Browser Profiles
+
+```bash
+# Maintain browser state across sessions
+agent-browser --profile ~/.agent-browser/my-project open https://example.com
+
+# Environment variable
+AGENT_BROWSER_PROFILE="/path" agent-browser open https://example.com
+```
+
+### Cloud Browser Providers
+
+```bash
+# Use cloud browser infrastructure
+agent-browser -p browserbase open https://example.com
+agent-browser --provider browseruse open https://example.com
+
+# Environment variable
+AGENT_BROWSER_PROVIDER="browserbase" agent-browser open https://example.com
+```
+
+### New Semantic Locators
+
+```bash
+# Exact text match
+agent-browser find text "Sign In" click --exact
+
+# By placeholder
+agent-browser find placeholder "Search" type "query"
+
+# By alt text
+agent-browser find alt "Logo" click
+
+# By title attribute
+agent-browser find title "Close" click
+
+# By data-testid
+agent-browser find testid "submit-btn" click
+
+# Last match
+agent-browser find last ".item" click
+```
+
+### Proxy Bypass
+
+```bash
+# Bypass specific domains from proxy
+agent-browser --proxy http://proxy:8080 --proxy-bypass "localhost,*.local" \
+    open https://example.com
+```
+
+### Advanced Browser Configuration
+
+```bash
+# Custom user agent
+agent-browser --user-agent "Custom/1.0" open https://example.com
+
+# Extra browser args
+agent-browser --args "--disable-gpu" open https://example.com
+```
+
+### Tab Close by Index
+
+```bash
+# Close specific tab
+agent-browser tab close 2
+```
+
+### Connect to Existing Browser
+
+```bash
+# Connect via CDP port
+agent-browser connect 9222
+```
+
 ## Bug Fixes in v0.6.0
 
 | Issue | Fix |
@@ -187,14 +274,27 @@ agent-browser --version
 
 ## Compatibility Matrix
 
-| Feature | v0.5.x | v0.6.0 |
-|---------|--------|--------|
-| Basic navigation | ✓ | ✓ |
-| Snapshot + refs | ✓ | ✓ |
-| Sessions | ✓ | ✓ |
-| Video recording | ✗ | ✓ |
-| Proxy support | ✗ | ✓ |
-| CDP connect | ✗ | ✓ |
-| `mouse wheel` | ✗ | ✓ |
-| `set media` | ✗ | ✓ |
-| Multi-select | Partial | ✓ |
+| Feature | v0.5.x | v0.6.0 | v0.7.0 |
+|---------|--------|--------|--------|
+| Basic navigation | ✓ | ✓ | ✓ |
+| Snapshot + refs | ✓ | ✓ | ✓ |
+| Sessions | ✓ | ✓ | ✓ |
+| Video recording | ✗ | ✓ | ✓ |
+| Proxy support | ✗ | ✓ | ✓ |
+| CDP connect | ✗ | ✓ | ✓ |
+| `mouse wheel` | ✗ | ✓ | ✓ |
+| `set media` | ✗ | ✓ | ✓ |
+| Multi-select | Partial | ✓ | ✓ |
+| Download command | ✗ | ✗ | ✓ |
+| Persistent profiles | ✗ | ✗ | ✓ |
+| Cloud providers | ✗ | ✗ | ✓ |
+| Proxy bypass | ✗ | ✗ | ✓ |
+| New semantic locators | ✗ | ✗ | ✓ |
+| Tab close by index | ✗ | ✗ | ✓ |
+
+## Checking Version
+
+```bash
+agent-browser --version
+# Should output: 0.7.0 or higher for latest features
+```

--- a/skills/agent-browser/references/proxy-support.md
+++ b/skills/agent-browser/references/proxy-support.md
@@ -1,6 +1,6 @@
-# Proxy Support (v0.6.0)
+# Proxy Support (v0.6.0+)
 
-Route browser traffic through HTTP, HTTPS, or SOCKS proxies.
+Route browser traffic through HTTP, HTTPS, or SOCKS proxies. Updated for v0.7.0 with proxy bypass and advanced configuration.
 
 ## Basic Proxy Usage
 
@@ -143,14 +143,31 @@ agent-browser get text body
 # Should show proxy IP, not your real IP
 ```
 
-## Proxy Bypass
+## Proxy Bypass (v0.7.0)
 
-No built-in bypass list. For local/internal sites without proxy:
+Use `--proxy-bypass` to exclude domains from proxy routing:
+
+```bash
+# Bypass localhost and local domains
+agent-browser --proxy http://proxy:8080 --proxy-bypass "localhost,*.local" \
+    open https://external-site.com
+
+# Bypass multiple domains
+agent-browser --proxy http://proxy:8080 \
+    --proxy-bypass "localhost,*.internal.corp,192.168.*" \
+    open https://example.com
+
+# Environment variable alternative
+export AGENT_BROWSER_PROXY_BYPASS="localhost,*.local,*.corp"
+agent-browser --proxy http://proxy:8080 open https://example.com
+```
+
+### Legacy Pattern (Still Works)
+
+For complex scenarios, use different sessions:
 
 ```bash
 #!/bin/bash
-# Use different sessions for proxy/no-proxy
-
 # Proxied session for external sites
 agent-browser --session external --proxy http://proxy:8080 \
     open https://external-site.com
@@ -194,6 +211,52 @@ update-ca-certificates
 agent-browser --proxy http://slow-proxy:8080 \
     --timeout 60000 \
     open https://example.com
+```
+
+## Advanced Browser Configuration (v0.7.0)
+
+### Custom User Agent
+
+```bash
+# Set user agent for proxy detection evasion
+agent-browser --proxy http://proxy:8080 \
+    --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/120.0.0.0" \
+    open https://example.com
+
+# Environment variable
+export AGENT_BROWSER_USER_AGENT="Custom Agent/1.0"
+agent-browser --proxy http://proxy:8080 open https://example.com
+```
+
+### Extra Browser Arguments
+
+```bash
+# Disable features that might reveal proxy use
+agent-browser --proxy http://proxy:8080 \
+    --args "--disable-webrtc --disable-features=WebRTC" \
+    open https://example.com
+
+# Multiple arguments
+agent-browser --proxy http://proxy:8080 \
+    --args "--disable-gpu --no-sandbox --disable-dev-shm-usage" \
+    open https://example.com
+
+# Environment variable
+export AGENT_BROWSER_ARGS="--disable-webrtc"
+```
+
+### Combining Options
+
+```bash
+#!/bin/bash
+# Full stealth proxy configuration
+
+agent-browser \
+    --proxy http://residential-proxy:8080 \
+    --proxy-bypass "localhost,*.local" \
+    --user-agent "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)" \
+    --args "--disable-blink-features=AutomationControlled" \
+    open https://target-site.com
 ```
 
 ## Security Considerations


### PR DESCRIPTION
## Summary

- Sync agent-browser skill to upstream v0.7.0 release
- Add new commands, flags, and environment variables
- Create new reference documentation for cloud providers and persistent profiles
- Update existing references for v0.7.0 compatibility

## Changes

### New v0.7.0 Features
- Download commands (`download`, `wait --download`)
- Connect command for CDP WebSocket URLs
- Persistent browser profiles (`--profile` flag)
- Cloud providers (Browserbase, Browser Use)
- Launch config (`--args`, `--user-agent`, `--proxy-bypass`)
- New semantic locators (`placeholder`, `alt`, `title`, `testid`, `last`, `--exact`)
- Selector types section (refs, CSS, `text=`, `xpath=`)
- Storage session commands
- Complete environment variables

### New References
- `persistent-profiles.md` - Browser profile persistence
- `cloud-providers.md` - Browserbase, Browser Use setup

### Updated References
- `commands.md` - Download, connect, new flags
- `proxy-support.md` - `--proxy-bypass`, `--args`, `--user-agent`
- `protocol-alignment.md` - v0.7.0 compatibility matrix

## Test Plan

- [x] Skill validation tests pass (11/11)
- [x] Token count within budget (397 lines, ~1752 words)
- [x] All reference links valid
- [x] Feature coverage verified against upstream announcement

Closes #210

🤖 Generated with [Claude Code](https://claude.ai/code)