### PR TITLE
fix(#213): Align marketplace plugin name with plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "orchestkit",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "engine": ">=2.1.19",
   "description": "Modular AI Development Toolkit — Install only what you need",
   "owner": {
@@ -13,9 +13,9 @@
   },
   "plugins": [
     {
-      "name": "orchestkit-complete",
-      "description": "Full OrchestKit toolkit — 161 skills, 34 agents, 147 hooks. Complete AI development powerhouse with Memory Fabric, progressive loading, and production patterns.",
-      "version": "5.1.3",
+      "name": "ork",
+      "description": "Full OrchestKit toolkit — 163 skills, 34 agents, 148 hooks. Complete AI development powerhouse with Memory Fabric, progressive loading, and production patterns.",
+      "version": "5.1.4",
       "author": {
         "name": "Yonatan Gross",
         "email": "yonatan2gross@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ork",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Comprehensive AI-assisted development toolkit with 163 skills (22 user-invocable, 141 internal), 34 agents, 148 hooks, Memory Fabric v2.1, and production-ready patterns for modern full-stack development including AI/ML Roadmap 2026",
   "author": {
     "name": "Yonatan Gross",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the OrchestKit Claude Code Plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.4] - 2026-01-24
+
+### Fixed
+
+- **Plugin update fails "not found in marketplace"**: Renamed root plugin from `orchestkit-complete` to `ork` in marketplace.json (#213)
+  - CC looks for plugin by name from plugin.json (`ork`) but marketplace listed `orchestkit-complete`
+  - Now both match, enabling proper update flow
+
+---
+
+
 ## [5.1.3] - 2026-01-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -972,7 +972,7 @@ ORCHESTKIT_SKIP_SETUP=1 claude  # Skip all setup hooks
 
 ## Version Information
 
-- **Current Version**: 5.1.3 (as of 2026-01-23)
+- **Current Version**: 5.1.4 (as of 2026-01-23)
 - **Claude Code Requirement**: >= 2.1.16
 - **Skills Structure**: CC 2.1.7 native flat (skills/<skill>/)
 - **Agent Format**: CC 2.1.6 native (skills array in frontmatter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orchestkit"
-version = "5.1.3"
+version = "5.1.4"
 description = "OrchestKit Complete - AI-assisted development toolkit for Claude Code with 159 skills, 32 agents, and 144 hooks"
 requires-python = ">=3.13"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Rename `orchestkit-complete` → `ork` in marketplace.json plugins[0].name
- Fixes "Plugin ork not found in marketplace" error when updating

## Problem
CC plugin manager looks up plugin by name from `plugin.json` (`"ork"`), but `marketplace.json` listed the root plugin as `"orchestkit-complete"`. This caused the update to fail.

## Test plan
- [x] JSON valid
- [x] Plugin name matches: `jq '.plugins[0].name' marketplace.json` = `"ork"`
- [ ] CI passes
- [ ] User can "Update now" in CC plugin manager

Closes #213

🤖 Generated with [Claude Code](https://claude.ai/code)