### PR TITLE
fix(#213): Cleanup marketplace naming and broken symlinks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "orchestkit",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "engine": ">=2.1.19",
   "description": "Modular AI Development Toolkit — Install only what you need",
   "owner": {
@@ -13,9 +13,9 @@
   },
   "plugins": [
     {
-      "name": "orchestkit-complete",
-      "description": "Full OrchestKit toolkit — 161 skills, 34 agents, 147 hooks. Complete AI development powerhouse with Memory Fabric, progressive loading, and production patterns.",
-      "version": "5.1.3",
+      "name": "ork",
+      "description": "Full OrchestKit toolkit — 163 skills, 34 agents, 148 hooks. Complete AI development powerhouse with Memory Fabric, progressive loading, and production patterns.",
+      "version": "5.1.4",
       "author": {
         "name": "Yonatan Gross",
         "email": "yonatan2gross@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ork",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Comprehensive AI-assisted development toolkit with 163 skills (22 user-invocable, 141 internal), 34 agents, 148 hooks, Memory Fabric v2.1, and production-ready patterns for modern full-stack development including AI/ML Roadmap 2026",
   "author": {
     "name": "Yonatan Gross",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the OrchestKit Claude Code Plugin will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.4] - 2026-01-24
+
+### Fixed
+
+- **Plugin update fails "not found in marketplace"**: Aligned marketplace plugin name with plugin.json (#213)
+  - Renamed `orchestkit-complete` → `ork` in marketplace.json plugins[0].name
+  - CC looks up plugin by name from plugin.json, now both match
+- **Broken symlinks in modular plugins**: Removed 21 broken symlinks pointing to non-existent `commands/` directory
+  - CC 2.1.7+ uses `user-invocable: true` in SKILL.md, not separate commands directory
+  - Removed legacy `commands` directory declaration from ork-core plugin.json
+
+---
+
+
 ## [5.1.3] - 2026-01-24
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -972,7 +972,7 @@ ORCHESTKIT_SKIP_SETUP=1 claude  # Skip all setup hooks
 
 ## Version Information
 
-- **Current Version**: 5.1.3 (as of 2026-01-23)
+- **Current Version**: 5.1.4 (as of 2026-01-23)
 - **Claude Code Requirement**: >= 2.1.16
 - **Skills Structure**: CC 2.1.7 native flat (skills/<skill>/)
 - **Agent Format**: CC 2.1.6 native (skills array in frontmatter)

--- a/plugins/ork-core/.claude-plugin/plugin.json
+++ b/plugins/ork-core/.claude-plugin/plugin.json
@@ -23,9 +23,6 @@
   "skills": {
     "directory": "skills"
   },
-  "commands": {
-    "directory": "commands"
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/plugins/ork-core/commands/assess-complexity.md
+++ b/plugins/ork-core/commands/assess-complexity.md
@@ -1,1 +1,0 @@
-../../../commands/assess-complexity.md

--- a/plugins/ork-core/commands/brainstorming.md
+++ b/plugins/ork-core/commands/brainstorming.md
@@ -1,1 +1,0 @@
-../../../commands/brainstorming.md

--- a/plugins/ork-core/commands/configure.md
+++ b/plugins/ork-core/commands/configure.md
@@ -1,1 +1,0 @@
-../../../commands/configure.md

--- a/plugins/ork-core/commands/doctor.md
+++ b/plugins/ork-core/commands/doctor.md
@@ -1,1 +1,0 @@
-../../../commands/doctor.md

--- a/plugins/ork-evaluation/commands/add-golden.md
+++ b/plugins/ork-evaluation/commands/add-golden.md
@@ -1,1 +1,0 @@
-../../../commands/add-golden.md

--- a/plugins/ork-git/commands/commit.md
+++ b/plugins/ork-git/commands/commit.md
@@ -1,1 +1,0 @@
-../../../commands/commit.md

--- a/plugins/ork-git/commands/create-pr.md
+++ b/plugins/ork-git/commands/create-pr.md
@@ -1,1 +1,0 @@
-../../../commands/create-pr.md

--- a/plugins/ork-git/commands/fix-issue.md
+++ b/plugins/ork-git/commands/fix-issue.md
@@ -1,1 +1,0 @@
-../../../commands/fix-issue.md

--- a/plugins/ork-git/commands/git-recovery-command.md
+++ b/plugins/ork-git/commands/git-recovery-command.md
@@ -1,1 +1,0 @@
-../../../commands/git-recovery-command.md

--- a/plugins/ork-memory/commands/load-context.md
+++ b/plugins/ork-memory/commands/load-context.md
@@ -1,1 +1,0 @@
-../../../commands/load-context.md

--- a/plugins/ork-memory/commands/mem0-sync.md
+++ b/plugins/ork-memory/commands/mem0-sync.md
@@ -1,1 +1,0 @@
-../../../commands/mem0-sync.md

--- a/plugins/ork-memory/commands/recall.md
+++ b/plugins/ork-memory/commands/recall.md
@@ -1,1 +1,0 @@
-../../../commands/recall.md

--- a/plugins/ork-memory/commands/remember.md
+++ b/plugins/ork-memory/commands/remember.md
@@ -1,1 +1,0 @@
-../../../commands/remember.md

--- a/plugins/ork-workflows-advanced/commands/claude-hud.md
+++ b/plugins/ork-workflows-advanced/commands/claude-hud.md
@@ -1,1 +1,0 @@
-../../../commands/claude-hud.md

--- a/plugins/ork-workflows-advanced/commands/feedback.md
+++ b/plugins/ork-workflows-advanced/commands/feedback.md
@@ -1,1 +1,0 @@
-../../../commands/feedback.md

--- a/plugins/ork-workflows-advanced/commands/worktree-coordination.md
+++ b/plugins/ork-workflows-advanced/commands/worktree-coordination.md
@@ -1,1 +1,0 @@
-../../../commands/worktree-coordination.md

--- a/plugins/ork-workflows-core/commands/explore.md
+++ b/plugins/ork-workflows-core/commands/explore.md
@@ -1,1 +1,0 @@
-../../../commands/explore.md

--- a/plugins/ork-workflows-core/commands/implement.md
+++ b/plugins/ork-workflows-core/commands/implement.md
@@ -1,1 +1,0 @@
-../../../commands/implement.md

--- a/plugins/ork-workflows-core/commands/review-pr.md
+++ b/plugins/ork-workflows-core/commands/review-pr.md
@@ -1,1 +1,0 @@
-../../../commands/review-pr.md

--- a/plugins/ork-workflows-core/commands/skill-evolution.md
+++ b/plugins/ork-workflows-core/commands/skill-evolution.md
@@ -1,1 +1,0 @@
-../../../commands/skill-evolution.md

--- a/plugins/ork-workflows-core/commands/verify.md
+++ b/plugins/ork-workflows-core/commands/verify.md
@@ -1,1 +1,0 @@
-../../../commands/verify.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orchestkit"
-version = "5.1.3"
+version = "5.1.4"
 description = "OrchestKit Complete - AI-assisted development toolkit for Claude Code with 159 skills, 32 agents, and 144 hooks"
 requires-python = ">=3.13"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Align marketplace plugin name with plugin.json (`orchestkit-complete` → `ork`)
- Remove 21 broken symlinks in `plugins/*/commands/`
- Remove legacy `commands` directory declaration

## Problem
1. **Plugin update fails**: CC looks up plugin by `plugin.json` name (`ork`) but marketplace listed `orchestkit-complete`
2. **Broken symlinks**: 21 symlinks pointed to non-existent `commands/` directory (legacy structure)

## Changes
| Change | Files |
|--------|-------|
| Rename marketplace plugin | `.claude-plugin/marketplace.json` |
| Remove broken symlinks | 21 files in `plugins/*/commands/` |
| Remove commands declaration | `plugins/ork-core/.claude-plugin/plugin.json` |

## Verification
```
Marketplace root plugin name: ork
Plugin.json name: ork
User-invocable skills: 22
All 34 plugins pass validation
```

## Test plan
- [x] `./tests/schemas/test-marketplace-schema.sh` passes
- [x] `./tests/schemas/test-plugin-schema.sh` passes  
- [x] No broken symlinks: `find plugins -type l ! -exec test -e {} \; -print`
- [ ] CI passes
- [ ] Plugin update works from other repos

Closes #213
Supersedes #217

🤖 Generated with [Claude Code](https://claude.ai/code)