### PR TITLE
feat(config): add OrchestKit-branded spinner verbs (CC 2.1.23)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Orchestrating",
+      "Coordinating",
+      "Synthesizing",
+      "Analyzing",
+      "Reasoning",
+      "Crafting",
+      "Architecting",
+      "Validating",
+      "Dispatching",
+      "Assembling",
+      "Engineering",
+      "Composing"
+    ]
+  },
   "hooks": {}
 }

--- a/plugins/ork-core/commands/configure.md
+++ b/plugins/ork-core/commands/configure.md
@@ -172,7 +172,48 @@ Enable monorepo detection? [Y/n]: y
 
 Detects monorepo indicators and suggests `--add-dir` usage.
 
-## Step 8: Preview & Save
+## Step 8: CC 2.1.23 Settings
+
+Configure CC 2.1.23-specific features:
+
+### Spinner Verbs Customization
+
+Replace default Claude Code spinner verbs ("Thinking", "Working", etc.) with custom branding:
+
+```
+Customize spinner verbs? [Y/n]: y
+```
+
+Adds to `.claude/settings.json`:
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Orchestrating",
+      "Coordinating",
+      "Synthesizing",
+      "Analyzing",
+      "Reasoning",
+      "Crafting",
+      "Architecting",
+      "Validating",
+      "Dispatching",
+      "Assembling",
+      "Engineering",
+      "Composing"
+    ]
+  }
+}
+```
+
+**Options:**
+- `mode: "replace"` - Use only your custom verbs
+- `mode: "append"` - Add your verbs to the defaults
+
+**OrchestKit-themed verbs** focus on orchestration, architecture, and engineering actions.
+
+## Step 9: Preview & Save
 
 Save to: `~/.claude/plugins/orchestkit/config.json`
 

--- a/plugins/ork-core/skills/configure/SKILL.md
+++ b/plugins/ork-core/skills/configure/SKILL.md
@@ -174,7 +174,48 @@ Enable monorepo detection? [Y/n]: y
 
 Detects monorepo indicators and suggests `--add-dir` usage.
 
-## Step 8: Preview & Save
+## Step 8: CC 2.1.23 Settings
+
+Configure CC 2.1.23-specific features:
+
+### Spinner Verbs Customization
+
+Replace default Claude Code spinner verbs ("Thinking", "Working", etc.) with custom branding:
+
+```
+Customize spinner verbs? [Y/n]: y
+```
+
+Adds to `.claude/settings.json`:
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Orchestrating",
+      "Coordinating",
+      "Synthesizing",
+      "Analyzing",
+      "Reasoning",
+      "Crafting",
+      "Architecting",
+      "Validating",
+      "Dispatching",
+      "Assembling",
+      "Engineering",
+      "Composing"
+    ]
+  }
+}
+```
+
+**Options:**
+- `mode: "replace"` - Use only your custom verbs
+- `mode: "append"` - Add your verbs to the defaults
+
+**OrchestKit-themed verbs** focus on orchestration, architecture, and engineering actions.
+
+## Step 9: Preview & Save
 
 Save to: `~/.claude/plugins/orchestkit/config.json`
 

--- a/plugins/ork/commands/configure.md
+++ b/plugins/ork/commands/configure.md
@@ -172,7 +172,48 @@ Enable monorepo detection? [Y/n]: y
 
 Detects monorepo indicators and suggests `--add-dir` usage.
 
-## Step 8: Preview & Save
+## Step 8: CC 2.1.23 Settings
+
+Configure CC 2.1.23-specific features:
+
+### Spinner Verbs Customization
+
+Replace default Claude Code spinner verbs ("Thinking", "Working", etc.) with custom branding:
+
+```
+Customize spinner verbs? [Y/n]: y
+```
+
+Adds to `.claude/settings.json`:
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Orchestrating",
+      "Coordinating",
+      "Synthesizing",
+      "Analyzing",
+      "Reasoning",
+      "Crafting",
+      "Architecting",
+      "Validating",
+      "Dispatching",
+      "Assembling",
+      "Engineering",
+      "Composing"
+    ]
+  }
+}
+```
+
+**Options:**
+- `mode: "replace"` - Use only your custom verbs
+- `mode: "append"` - Add your verbs to the defaults
+
+**OrchestKit-themed verbs** focus on orchestration, architecture, and engineering actions.
+
+## Step 9: Preview & Save
 
 Save to: `~/.claude/plugins/orchestkit/config.json`
 

--- a/plugins/ork/skills/configure/SKILL.md
+++ b/plugins/ork/skills/configure/SKILL.md
@@ -174,7 +174,48 @@ Enable monorepo detection? [Y/n]: y
 
 Detects monorepo indicators and suggests `--add-dir` usage.
 
-## Step 8: Preview & Save
+## Step 8: CC 2.1.23 Settings
+
+Configure CC 2.1.23-specific features:
+
+### Spinner Verbs Customization
+
+Replace default Claude Code spinner verbs ("Thinking", "Working", etc.) with custom branding:
+
+```
+Customize spinner verbs? [Y/n]: y
+```
+
+Adds to `.claude/settings.json`:
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Orchestrating",
+      "Coordinating",
+      "Synthesizing",
+      "Analyzing",
+      "Reasoning",
+      "Crafting",
+      "Architecting",
+      "Validating",
+      "Dispatching",
+      "Assembling",
+      "Engineering",
+      "Composing"
+    ]
+  }
+}
+```
+
+**Options:**
+- `mode: "replace"` - Use only your custom verbs
+- `mode: "append"` - Add your verbs to the defaults
+
+**OrchestKit-themed verbs** focus on orchestration, architecture, and engineering actions.
+
+## Step 9: Preview & Save
 
 Save to: `~/.claude/plugins/orchestkit/config.json`
 

--- a/src/skills/configure/SKILL.md
+++ b/src/skills/configure/SKILL.md
@@ -174,7 +174,48 @@ Enable monorepo detection? [Y/n]: y
 
 Detects monorepo indicators and suggests `--add-dir` usage.
 
-## Step 8: Preview & Save
+## Step 8: CC 2.1.23 Settings
+
+Configure CC 2.1.23-specific features:
+
+### Spinner Verbs Customization
+
+Replace default Claude Code spinner verbs ("Thinking", "Working", etc.) with custom branding:
+
+```
+Customize spinner verbs? [Y/n]: y
+```
+
+Adds to `.claude/settings.json`:
+```json
+{
+  "spinnerVerbs": {
+    "mode": "replace",
+    "verbs": [
+      "Orchestrating",
+      "Coordinating",
+      "Synthesizing",
+      "Analyzing",
+      "Reasoning",
+      "Crafting",
+      "Architecting",
+      "Validating",
+      "Dispatching",
+      "Assembling",
+      "Engineering",
+      "Composing"
+    ]
+  }
+}
+```
+
+**Options:**
+- `mode: "replace"` - Use only your custom verbs
+- `mode: "append"` - Add your verbs to the defaults
+
+**OrchestKit-themed verbs** focus on orchestration, architecture, and engineering actions.
+
+## Step 9: Preview & Save
 
 Save to: `~/.claude/plugins/orchestkit/config.json`
 


### PR DESCRIPTION
## Summary
- Add `spinnerVerbs` configuration to `.claude/settings.json` with OrchestKit-themed verbs
- Document spinner verb customization in `/ork:configure` skill (new Step 8)
- Use orchestration-themed verbs: Orchestrating, Coordinating, Synthesizing, Architecting, Validating, Dispatching, etc.

## Changes
| File | Change |
|------|--------|
| `.claude/settings.json` | Added `spinnerVerbs` with 12 custom verbs |
| `src/skills/configure/SKILL.md` | Added Step 8 for CC 2.1.23 settings |

## Test plan
- [x] Spinner verbs display correctly in Claude Code CLI
- [x] Configuration documented in `/ork:configure` skill

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)