### PR TITLE
fix(docs): force dark mode and disable theme switcher

### DIFF
--- a/docs/site/app/layout.config.tsx
+++ b/docs/site/app/layout.config.tsx
@@ -6,8 +6,7 @@ export const baseOptions: BaseLayoutProps = {
     title: SITE.name,
   },
   themeSwitch: {
-    enabled: true,
-    mode: "light-dark-system",
+    enabled: false,
   },
   githubUrl: SITE.github,
   links: [

--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning className={`${geist.variable} ${geistMono.variable}`}>
+    <html lang="en" suppressHydrationWarning className={`dark ${geist.variable} ${geistMono.variable}`}>
       <body className="flex min-h-screen flex-col font-[family-name:var(--font-geist)]">
         <a
           href="#main-content"


### PR DESCRIPTION
## Summary
- Disable light/dark/system theme switcher in docs site
- Lock to dark mode via `dark` class on `<html>` element
- Site was designed for dark mode — theme switching caused visual inconsistencies

## Changes
| File | Change |
|------|--------|
| `layout.config.tsx` | `themeSwitch.enabled: false` |
| `layout.tsx` | Add `dark` class to html element |

## Test plan
- [ ] Verify docs site renders in dark mode only
- [ ] Confirm no flash of light theme on initial load

🤖 Generated with [Claude Code](https://claude.com/claude-code)