### PR TITLE
fix(docs): update stale counts to v6.0.6

### DIFF
--- a/docs/site/content/docs/foundations/choosing-a-plugin.mdx
+++ b/docs/site/content/docs/foundations/choosing-a-plugin.mdx
@@ -10,9 +10,9 @@ OrchestKit ships as three plugins. Both orkl and ork include **all 36 agents** a
 ```
 Do you use Python, React, LLM/RAG, or LangGraph?
   │
-  ├─ YES ──▶ Install ork (60 skills, full specialized)
+  ├─ YES ──▶ Install ork (61 skills, full specialized)
   │
-  └─ NO ───▶ Install orkl (43 skills, universal toolkit)
+  └─ NO ───▶ Install orkl (44 skills, universal toolkit)
               └─ Need video production? Add ork-creative (3 skills)
 ```
 

--- a/docs/site/content/docs/foundations/overview.mdx
+++ b/docs/site/content/docs/foundations/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is OrchestKit?
-description: The complete AI development toolkit for Claude Code — 60 skills, 36 agents, 86 hooks working together.
+description: The complete AI development toolkit for Claude Code — 61 skills, 36 agents, 86 hooks working together.
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
@@ -60,9 +60,9 @@ OrchestKit ships as three plugins so you install only what you need:
 
 | Plugin | Skills | Best For |
 |--------|--------|----------|
-| **orkl** | 43 | Any stack — workflows, memory, security, CI/CD |
-| **ork-creative** | 3 | Video production — demo recording, Remotion, storyboarding |
-| **ork** | 60 | orkl + creative + Python, React, LLM/RAG, LangGraph, MCP |
+| **orkl** | 44 | Any stack — workflows, memory, security, CI/CD |
+| **ork-creative** | 1 | Video production — demo recording |
+| **ork** | 61 | orkl + creative + Python, React, LLM/RAG, LangGraph, MCP |
 
 All include 86 hooks. orkl and ork include all 36 agents. The difference is skill coverage.
 

--- a/docs/site/content/docs/foundations/skills-agents-hooks.mdx
+++ b/docs/site/content/docs/foundations/skills-agents-hooks.mdx
@@ -13,7 +13,7 @@ A skill is a markdown file containing expert knowledge about a specific topic. T
 src/skills/fastapi-advanced/SKILL.md
 ```
 
-**60 skills** covering: FastAPI, React, SQLAlchemy, RAG, LangGraph, OWASP, Terraform, and more.
+**61 skills** covering: FastAPI, React, SQLAlchemy, RAG, LangGraph, OWASP, Terraform, and more.
 
 ### Two Types
 

--- a/docs/site/content/docs/getting-started/first-10-minutes.mdx
+++ b/docs/site/content/docs/getting-started/first-10-minutes.mdx
@@ -15,7 +15,7 @@ After installing, verify everything is working:
 /ork:doctor
 ```
 
-This runs diagnostics on all 60 skills, 36 agents, and 86 hooks. If anything is misconfigured, it tells you exactly what to fix.
+This runs diagnostics on all 61 skills, 36 agents, and 86 hooks. If anything is misconfigured, it tells you exactly what to fix.
 
 ## Step 2: Your First Command Skill
 

--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -9,10 +9,10 @@ import { SetupWizard } from '@/components/setup-wizard';
 ## From Claude Code Marketplace (Recommended)
 
 ```bash
-# Universal toolkit (43 skills)
+# Universal toolkit (44 skills)
 claude install orchestkit/orkl
 
-# Full toolkit (60 skills — includes Python, React, LLM/RAG)
+# Full toolkit (61 skills — includes Python, React, LLM/RAG)
 claude install orchestkit/ork
 ```
 
@@ -35,7 +35,7 @@ Expected output:
 ```
 OrchestKit Health Check
 =======================
-Plugin:     ork v6.0.3
+Plugin:     ork v6.0.6
 Skills:     60 loaded (23 commands, 37 reference)
 Agents:     36 registered
 Hooks:      86 active (63 global, 22 agent, 1 skill-scoped)

--- a/docs/site/content/docs/getting-started/navigating.mdx
+++ b/docs/site/content/docs/getting-started/navigating.mdx
@@ -5,7 +5,7 @@ description: Hub-and-spoke navigation — find the right skills and agents for y
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
 
-OrchestKit has 60 skills and 36 agents. You don't need to memorize them — this page helps you find exactly what you need.
+OrchestKit has 61 skills and 36 agents. You don't need to memorize them — this page helps you find exactly what you need.
 
 ## By Role
 

--- a/docs/site/content/docs/reference/index.mdx
+++ b/docs/site/content/docs/reference/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Reference
-description: "Complete reference for all 60 skills, 36 agents, and 86 hooks."
+description: "Complete reference for all 61 skills, 36 agents, and 86 hooks."
 full: true
 ---
 

--- a/docs/site/content/docs/troubleshooting/faq.mdx
+++ b/docs/site/content/docs/troubleshooting/faq.mdx
@@ -27,9 +27,9 @@ OrchestKit ships three plugin tiers:
 
 | Plugin | Skills | Description |
 |--------|--------|-------------|
-| `orkl` | 43 | Universal toolkit -- works for any stack |
-| `ork-creative` | 3 | Video production add-on -- demo recording, Remotion, storyboarding |
-| `ork` | 60 | Full specialized -- includes orkl + creative + Python, React, LLM/RAG, LangGraph, MCP skills |
+| `orkl` | 44 | Universal toolkit -- works for any stack |
+| `ork-creative` | 1 | Video production add-on -- demo recording |
+| `ork` | 61 | Full specialized -- includes orkl + creative + Python, React, LLM/RAG, LangGraph, MCP skills |
 
 Both tiers include all 36 agents, 86 hooks, and all memory skills. The difference is only in specialized reference skills. If you work with Python, React, or LLM pipelines, use `ork`. If you want a lighter install for general development, use `orkl`.
 

--- a/docs/site/content/docs/troubleshooting/index.mdx
+++ b/docs/site/content/docs/troubleshooting/index.mdx
@@ -206,7 +206,7 @@ Only use `--no-verify` for changes you are confident about. For substantial code
 
 ## 8. Count Drift After Adding Skills or Hooks
 
-**Symptom:** Tests fail with "expected 60 skills, found 62" or similar count mismatches.
+**Symptom:** Tests fail with "expected 61 skills, found 63" or similar count mismatches.
 
 **Cause:** Adding a skill or hook updates the source files but not the count references scattered across the codebase.
 

--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -3,7 +3,7 @@
 
 export const SITE = {
   name: "OrchestKit",
-  version: "6.0.5",
+  version: "6.0.6",
   domain: "https://orchestkit.vercel.app",
   github: "https://github.com/yonatangross/orchestkit",
   installCommand: "claude install orchestkit/ork",
@@ -11,7 +11,7 @@ export const SITE = {
 } as const;
 
 export const COUNTS = {
-  skills: 60,
+  skills: 61,
   agents: 36,
   hooks: 86,
 } as const;


### PR DESCRIPTION
## Summary

- Update docs site banner and 9 MDX files with correct component counts
- `ork`: 60 → 61 skills, `orkl`: 43 → 44 skills, `ork-creative`: 3 → 1 skill
- Version bump in constants.ts: 6.0.5 → 6.0.6
- GitHub repo About description also updated (61 skills)

## Test plan

- [ ] Verify banner shows "OrchestKit v6.0.6 — 61 skills, 36 agents, 86 hooks"
- [ ] Spot-check installation, FAQ, and overview pages for correct counts
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)