### PR TITLE
fix(docs): read version from manifest instead of hardcoding

### DIFF
--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -35,7 +35,7 @@ Expected output:
 ```
 OrchestKit Health Check
 =======================
-Plugin:     ork v6.0.6
+Plugin:     ork v6.0.7
 Skills:     60 loaded (23 commands, 37 reference)
 Agents:     36 registered
 Hooks:      86 active (63 global, 22 agent, 1 skill-scoped)

--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -1,9 +1,11 @@
 // Single source of truth for all site-wide values.
-// Update here once — every page picks it up.
+// Version is read from the root manifest (manifests/ork.json).
+
+import orkManifest from "../../../manifests/ork.json";
 
 export const SITE = {
   name: "OrchestKit",
-  version: "6.0.6",
+  version: orkManifest.version,
   domain: "https://orchestkit.vercel.app",
   github: "https://github.com/yonatangross/orchestkit",
   installCommand: "claude install orchestkit/ork",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchestkit",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "OrchestKit Claude Plugin - AI-assisted development toolkit",
   "scripts": {
     "build": "bash scripts/build-plugins.sh",


### PR DESCRIPTION
## Summary
- `docs/site/lib/constants.ts` now imports version from `manifests/ork.json` instead of hardcoding it
- Fixes `package.json` version (was stuck at 6.0.6 while manifests were at 6.0.7)
- Updates installation.mdx example output to 6.0.7

No more version drift between docs site and releases.

## Test plan
- [ ] Verify Vercel preview shows v6.0.7 in banner
- [ ] TypeScript compiles cleanly (`resolveJsonModule` already enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)