### PR TITLE
fix(ci): skip version check for Dependabot PRs

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -49,6 +49,13 @@ jobs:
             exit 0
           fi
 
+          # Skip Dependabot PRs (dependency updates, no version bump needed)
+          if [[ "$BRANCH_NAME" =~ ^dependabot/ ]]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Skipping version check for Dependabot PR (automated dependency update)"
+            exit 0
+          fi
+
           # Check if only non-code files changed
           CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
           CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.(md|txt)$|^docs/' || true)


### PR DESCRIPTION
## Summary

- Dependabot PRs (`dependabot/github_actions/...`) only update action SHA pins — no code changes, no version bump needed
- All 4 Dependabot PRs (#753-#756) were blocked by `Check Version Bump & Changelog` failing
- Adds `^dependabot/` branch prefix to the skip list (alongside `release-please` and `docs/chore/ci/style/test`)

## After merge

Re-run checks on #753, #754, #755, #756 — they should pass and be mergeable.

## Test plan

- [x] Pre-commit validations pass
- [ ] Merge this, then merge Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)