### PR TITLE
fix(ci): use PAT for release-please to trigger CI on release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   # Sync version to manifest files after release
   post-release:


### PR DESCRIPTION
## Summary

- Release-please PRs created with `GITHUB_TOKEN` don't trigger CI workflows (GitHub's infinite loop prevention)
- This meant release PRs like #759 had zero CI checks, blocking merge due to required status checks
- Uses `RELEASE_PLEASE_TOKEN` (fine-grained PAT) so release PRs trigger full CI

## Test plan

- [x] Secret `RELEASE_PLEASE_TOKEN` verified in repo settings
- [ ] After merge, close and reopen #759 (or wait for next release-please run) to verify CI triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)