### PR TITLE
ci: restrict workflow-level permissions to read-all in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,9 +30,7 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Restricts workflow-level `permissions` from `contents: write` + `pull-requests: write` to `read-all`
- Job-level permissions on `release-please` job unchanged — still has required write access
- Resolves code scanning alerts #111 and #112 (OpenSSF Scorecard Token-Permissions, high severity)

## Context
GitHub Actions job-level permissions fully override workflow-level ([docs](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions)), so the release-please job retains its required `contents: write` and `pull-requests: write`.

Alert #113 (Pinned-Dependencies on `npm ci`) is a known Scorecard false positive — `npm ci` already uses the lockfile.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify Scorecard alerts #111 and #112 close after merge
- [ ] Merge a subsequent commit to main and confirm release-please still creates/updates release PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)