### PR TITLE
fix: banner CC version alignment + release-please bootstrap-sha

### DIFF
--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -21,4 +21,4 @@ export const COUNTS = {
   commands: TOTALS.commands,
 } as const;
 
-export const BANNER_TEXT = `OrchestKit v${SITE.version} — ${COUNTS.skills} skills, ${COUNTS.agents} agents, ${COUNTS.hooks} hooks with Opus 4.6 support`;
+export const BANNER_TEXT = `OrchestKit v${SITE.version} — ${COUNTS.skills} skills, ${COUNTS.agents} agents, ${COUNTS.hooks} hooks · Claude Code ${SITE.ccVersion}`;


### PR DESCRIPTION
## Summary

- **Banner fix:** Replace stale "with Opus 4.6 support" with "Claude Code 2.1.69+" — references `SITE.ccVersion`, auto-updates from single source of truth
- **Release-please fix:** Add `bootstrap-sha` to `.release-please-config.json` — permanently fixes the recurring 8.0.0 major bump issue

### Release-please root cause

Release-please never created any release for this project (all were manual). Without an anchor, it scans the entire git history, finds ancient `BREAKING CHANGE` footers, and proposes 8.0.0. The `bootstrap-sha` pins it to current main HEAD so it only analyzes future commits.

**Before:** `OrchestKit v7.1.5 — 79 skills, 30 agents, 105 hooks with Opus 4.6 support`
**After:** `OrchestKit v7.1.6 — 79 skills, 30 agents, 105 hooks · Claude Code 2.1.69+`

## Test plan

- [ ] Verify banner renders correctly on Vercel preview
- [ ] After merge: close PR #994 (stale 8.0.0 release PR)
- [ ] After merge: verify release-please creates correct patch/minor PR (not 8.0.0)

Generated with [Claude Code](https://claude.com/claude-code)
