### PR TITLE
fix(docs): update generated plugins-data version to 7.2.0

### DIFF
--- a/docs/site/lib/generated/plugins-data.ts
+++ b/docs/site/lib/generated/plugins-data.ts
@@ -9,7 +9,7 @@ export const PLUGINS: Plugin[] = [
     "description": "The complete AI development toolkit — 87 skills, 31 agents, 96 hooks.",
     "fullDescription": "The complete OrchestKit toolkit. Includes all workflow skills (implement, explore, verify, review-pr, commit), all memory skills (remember, memory, mem0, fabric), product/UX skills, accessibility, specialized patterns for Python (FastAPI, SQLAlchemy, Celery), React (RSC, TanStack, Zustand), LLM integration, RAG retrieval, and all specialized agents.",
     "category": "development",
-    "version": "7.1.14",
+    "version": "7.2.0",
     "skillCount": 87,
     "agentCount": 31,
     "hooks": 96,


### PR DESCRIPTION
## Summary
- Docs site was showing v7.1.14 because plugins-data.ts was generated before release-please bumped the version
- Regenerated with npm run build after v7.2.0 release

## Test plan
- [x] plugins-data.ts now shows version 7.2.0
- [ ] Vercel preview shows v7.2.0