### PR TITLE
fix(docs): update generated plugins-data version to 7.4.0

### DIFF
--- a/docs/site/lib/generated/plugins-data.ts
+++ b/docs/site/lib/generated/plugins-data.ts
@@ -9,7 +9,7 @@ export const PLUGINS: Plugin[] = [
     "description": "The complete AI development toolkit — 89 skills, 31 agents, 99 hooks.",
     "fullDescription": "The complete OrchestKit toolkit. Includes all workflow skills (implement, explore, verify, review-pr, commit), all memory skills (remember, memory, mem0, fabric), product/UX skills, accessibility, specialized patterns for Python (FastAPI, SQLAlchemy, Celery), React (RSC, TanStack, Zustand), LLM integration, RAG retrieval, and all specialized agents.",
     "category": "development",
-    "version": "7.3.3",
+    "version": "7.4.0",
     "skillCount": 89,
     "agentCount": 31,
     "hooks": 99,


### PR DESCRIPTION
## Summary
- Regenerated `docs/site/lib/generated/plugins-data.ts` to reflect v7.4.0
- Release-please bumped core files but the generated docs data wasn't regenerated, leaving the website showing 7.3.3

## Test plan
- [ ] Verify docs site shows 7.4.0 after deploy
