### PR TITLE
fix(skills): add ExitWorktree + model override to Agent Teams paths

### DIFF
--- a/docs/site/content/docs/reference/skills/assess.mdx
+++ b/docs/site/content/docs/reference/skills/assess.mdx
@@ -460,7 +460,7 @@ Do NOT use Glob or Grep to discover additional files.
 """
 
 Agent(subagent_type="code-quality-reviewer", name="correctness-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess CORRECTNESS (0-10) and MAINTAINABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When you find issues that affect security, message security-assessor.
@@ -469,7 +469,7 @@ Agent(subagent_type="code-quality-reviewer", name="correctness-assessor",
      significantly (>2 points), discuss the disagreement.""")
 
 Agent(subagent_type="security-auditor", name="security-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess SECURITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When correctness-assessor flags security-relevant patterns, investigate deeper.
@@ -477,7 +477,7 @@ Agent(subagent_type="security-auditor", name="security-assessor",
      Share your score and flag any cross-dimension trade-offs.""")
 
 Agent(subagent_type="python-performance-engineer", name="perf-assessor",  # or frontend-performance-engineer for frontend
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess PERFORMANCE (0-10) and SCALABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When security-assessor flags performance trade-offs, evaluate the impact.
@@ -485,7 +485,7 @@ Agent(subagent_type="python-performance-engineer", name="perf-assessor",  # or f
      Share your scores with reasoning for the composite calculation.""")
 
 Agent(subagent_type="test-generator", name="test-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess TESTABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      Evaluate test coverage, test quality, and ease of testing.
@@ -500,6 +500,9 @@ SendMessage(type="shutdown_request", recipient="security-assessor", content="Ass
 SendMessage(type="shutdown_request", recipient="perf-assessor", content="Assessment complete")
 SendMessage(type="shutdown_request", recipient="test-assessor", content="Assessment complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback — Team Formation Failure:** If team formation fails, use standard Phase 2 Task spawns.

--- a/docs/site/content/docs/reference/skills/explore.mdx
+++ b/docs/site/content/docs/reference/skills/explore.mdx
@@ -247,6 +247,9 @@ SendMessage(type="shutdown_request", recipient="data-flow-explorer", content="Ex
 SendMessage(type="shutdown_request", recipient="backend-explorer", content="Exploration complete")
 SendMessage(type="shutdown_request", recipient="frontend-explorer", content="Exploration complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Task tool spawns. See [exploration-agents.md](exploration-agents.md).

--- a/docs/site/content/docs/reference/skills/fix-issue.mdx
+++ b/docs/site/content/docs/reference/skills/fix-issue.mdx
@@ -710,6 +710,9 @@ SendMessage(type="shutdown_request", recipient="backend-expert", content="Fix va
 SendMessage(type="shutdown_request", recipient="frontend-expert", content="Fix validated")
 SendMessage(type="shutdown_request", recipient="test-planner", content="Fix validated")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Phase 4 Task spawns.

--- a/docs/site/content/docs/reference/skills/implement.mdx
+++ b/docs/site/content/docs/reference/skills/implement.mdx
@@ -1471,16 +1471,9 @@ After all teammates complete (or when all tasks are done):
    SendMessage(type="shutdown_request", recipient="test-engineer")
    SendMessage(type="shutdown_request", recipient="code-reviewer")
    TeamDelete()
-   ```
 
-6. **Clean up worktrees:**
-   ```bash
-   git worktree remove ../{project}-backend
-   git worktree remove ../{project}-frontend
-   git worktree remove ../{project}-tests
-   git branch -d feat/{feature}/backend
-   git branch -d feat/{feature}/frontend
-   git branch -d feat/{feature}/tests
+   # Worktree cleanup (CC 2.1.72)
+   ExitWorktree(action="keep")  # Keep branch for PR
    ```
 
 ---
@@ -1530,19 +1523,19 @@ TeamCreate(team_name="implement-{feature-slug}", description="Architecture for {
 
 # Spawn 4 teammates (5th role — UX — is lead-managed or optional)
 Agent(subagent_type="backend-system-architect", name="backend-architect",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Design backend architecture. Message frontend-dev when API contract ready.")
 
 Agent(subagent_type="frontend-ui-developer", name="frontend-dev",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Design frontend architecture. Wait for API contract from backend-architect.")
 
 Agent(subagent_type="test-generator", name="test-engineer",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Plan test strategy. Start fixtures immediately, tests as contracts stabilize.")
 
 Agent(subagent_type="code-quality-reviewer", name="code-reviewer",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Review architecture decisions as they're shared. Flag issues to author directly.")
 ```
 
@@ -1632,11 +1625,8 @@ SendMessage(type="shutdown_request", recipient="code-reviewer",
 ```python
 TeamDelete()  # Remove team and shared task list
 
-# Clean up worktrees (if used)
-Bash("git worktree remove ../{project}-backend")
-Bash("git worktree remove ../{project}-frontend")
-Bash("git worktree remove ../{project}-tests")
-Bash("git branch -d feat/{feature}/backend feat/{feature}/frontend feat/{feature}/tests")
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")  # Keep branch for PR
 ```
 
 > Phases 7-10 (Scope Creep, E2E Verification, Documentation, Reflection) are the same in both modes — the team is already disbanded.

--- a/docs/site/content/docs/reference/skills/review-pr.mdx
+++ b/docs/site/content/docs/reference/skills/review-pr.mdx
@@ -445,6 +445,9 @@ SendMessage(type="shutdown_request", recipient="backend-reviewer", content="Revi
 # if HAS_FRONTEND:
 SendMessage(type="shutdown_request", recipient="frontend-reviewer", content="Review complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 **Incorrect — No team teardown:**
@@ -461,6 +464,7 @@ Agent(subagent_type="security-auditor", team_name="review-pr-$PR_NUMBER")
 SendMessage(type="shutdown_request", recipient="quality-reviewer", content="Review complete")
 SendMessage(type="shutdown_request", recipient="security-reviewer", content="Review complete")
 TeamDelete()  # Clean shutdown
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Task tool spawns from [agent-prompts-task-tool.md](agent-prompts-task-tool.md).

--- a/docs/site/content/docs/reference/skills/verify.mdx
+++ b/docs/site/content/docs/reference/skills/verify.mdx
@@ -1366,7 +1366,7 @@ In Agent Teams mode, form a verification team where agents share findings and co
 TeamCreate(team_name="verify-{feature}", description="Verify {feature}")
 
 Agent(subagent_type="code-quality-reviewer", name="quality-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify code quality. Score 0-10.
      When you find patterns that affect security, message security-verifier.
@@ -1375,7 +1375,7 @@ Agent(subagent_type="code-quality-reviewer", name="quality-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="security-auditor", name="security-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Security verification. Score 0-10.
      When quality-verifier flags security-relevant patterns, investigate deeper.
@@ -1384,7 +1384,7 @@ Agent(subagent_type="security-auditor", name="security-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="test-generator", name="test-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify test coverage. Score 0-10.
      When quality-verifier or security-verifier flag untested paths, quantify the gap.
@@ -1393,7 +1393,7 @@ Agent(subagent_type="test-generator", name="test-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="backend-system-architect", name="api-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify API design and backend patterns. Score 0-10.
      When security-verifier flags endpoint issues, validate and score.
@@ -1401,7 +1401,7 @@ Agent(subagent_type="backend-system-architect", name="api-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="frontend-ui-developer", name="ui-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify frontend implementation. Score 0-10.
      When api-verifier shares API patterns, verify frontend matches.
@@ -1412,7 +1412,7 @@ Agent(subagent_type="frontend-ui-developer", name="ui-verifier",
 # Conditional 6th agent — use python-performance-engineer for backend,
 # frontend-performance-engineer for frontend
 Agent(subagent_type="python-performance-engineer", name="perf-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify performance and scalability. Score 0-10.
      Assess latency, resource usage, caching, and scaling patterns.
@@ -1431,6 +1431,9 @@ SendMessage(type="shutdown_request", recipient="api-verifier", content="Verifica
 SendMessage(type="shutdown_request", recipient="ui-verifier", content="Verification complete")
 SendMessage(type="shutdown_request", recipient="perf-verifier", content="Verification complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Phase 2 Task spawns above.

--- a/plugins/ork/skills/assess/references/agent-teams-mode.md
+++ b/plugins/ork/skills/assess/references/agent-teams-mode.md
@@ -16,7 +16,7 @@ Do NOT use Glob or Grep to discover additional files.
 """
 
 Agent(subagent_type="code-quality-reviewer", name="correctness-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess CORRECTNESS (0-10) and MAINTAINABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When you find issues that affect security, message security-assessor.
@@ -25,7 +25,7 @@ Agent(subagent_type="code-quality-reviewer", name="correctness-assessor",
      significantly (>2 points), discuss the disagreement.""")
 
 Agent(subagent_type="security-auditor", name="security-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess SECURITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When correctness-assessor flags security-relevant patterns, investigate deeper.
@@ -33,7 +33,7 @@ Agent(subagent_type="security-auditor", name="security-assessor",
      Share your score and flag any cross-dimension trade-offs.""")
 
 Agent(subagent_type="python-performance-engineer", name="perf-assessor",  # or frontend-performance-engineer for frontend
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess PERFORMANCE (0-10) and SCALABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When security-assessor flags performance trade-offs, evaluate the impact.
@@ -41,7 +41,7 @@ Agent(subagent_type="python-performance-engineer", name="perf-assessor",  # or f
      Share your scores with reasoning for the composite calculation.""")
 
 Agent(subagent_type="test-generator", name="test-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess TESTABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      Evaluate test coverage, test quality, and ease of testing.
@@ -56,6 +56,9 @@ SendMessage(type="shutdown_request", recipient="security-assessor", content="Ass
 SendMessage(type="shutdown_request", recipient="perf-assessor", content="Assessment complete")
 SendMessage(type="shutdown_request", recipient="test-assessor", content="Assessment complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback — Team Formation Failure:** If team formation fails, use standard Phase 2 Task spawns.

--- a/plugins/ork/skills/explore/rules/agent-teams-mode.md
+++ b/plugins/ork/skills/explore/rules/agent-teams-mode.md
@@ -52,6 +52,9 @@ SendMessage(type="shutdown_request", recipient="data-flow-explorer", content="Ex
 SendMessage(type="shutdown_request", recipient="backend-explorer", content="Exploration complete")
 SendMessage(type="shutdown_request", recipient="frontend-explorer", content="Exploration complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Task tool spawns. See [exploration-agents.md](exploration-agents.md).

--- a/plugins/ork/skills/fix-issue/references/agent-teams-rca.md
+++ b/plugins/ork/skills/fix-issue/references/agent-teams-rca.md
@@ -50,6 +50,9 @@ SendMessage(type="shutdown_request", recipient="backend-expert", content="Fix va
 SendMessage(type="shutdown_request", recipient="frontend-expert", content="Fix validated")
 SendMessage(type="shutdown_request", recipient="test-planner", content="Fix validated")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Phase 4 Task spawns.

--- a/plugins/ork/skills/implement/references/agent-teams-full-stack.md
+++ b/plugins/ork/skills/implement/references/agent-teams-full-stack.md
@@ -282,16 +282,9 @@ After all teammates complete (or when all tasks are done):
    SendMessage(type="shutdown_request", recipient="test-engineer")
    SendMessage(type="shutdown_request", recipient="code-reviewer")
    TeamDelete()
-   ```
 
-6. **Clean up worktrees:**
-   ```bash
-   git worktree remove ../{project}-backend
-   git worktree remove ../{project}-frontend
-   git worktree remove ../{project}-tests
-   git branch -d feat/{feature}/backend
-   git branch -d feat/{feature}/frontend
-   git branch -d feat/{feature}/tests
+   # Worktree cleanup (CC 2.1.72)
+   ExitWorktree(action="keep")  # Keep branch for PR
    ```
 
 ---

--- a/plugins/ork/skills/implement/references/agent-teams-phases.md
+++ b/plugins/ork/skills/implement/references/agent-teams-phases.md
@@ -11,19 +11,19 @@ TeamCreate(team_name="implement-{feature-slug}", description="Architecture for {
 
 # Spawn 4 teammates (5th role — UX — is lead-managed or optional)
 Agent(subagent_type="backend-system-architect", name="backend-architect",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Design backend architecture. Message frontend-dev when API contract ready.")
 
 Agent(subagent_type="frontend-ui-developer", name="frontend-dev",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Design frontend architecture. Wait for API contract from backend-architect.")
 
 Agent(subagent_type="test-generator", name="test-engineer",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Plan test strategy. Start fixtures immediately, tests as contracts stabilize.")
 
 Agent(subagent_type="code-quality-reviewer", name="code-reviewer",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Review architecture decisions as they're shared. Flag issues to author directly.")
 ```
 
@@ -113,11 +113,8 @@ SendMessage(type="shutdown_request", recipient="code-reviewer",
 ```python
 TeamDelete()  # Remove team and shared task list
 
-# Clean up worktrees (if used)
-Bash("git worktree remove ../{project}-backend")
-Bash("git worktree remove ../{project}-frontend")
-Bash("git worktree remove ../{project}-tests")
-Bash("git branch -d feat/{feature}/backend feat/{feature}/frontend feat/{feature}/tests")
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")  # Keep branch for PR
 ```
 
 > Phases 7-10 (Scope Creep, E2E Verification, Documentation, Reflection) are the same in both modes — the team is already disbanded.

--- a/plugins/ork/skills/review-pr/rules/agent-prompts-agent-teams.md
+++ b/plugins/ork/skills/review-pr/rules/agent-prompts-agent-teams.md
@@ -137,6 +137,9 @@ SendMessage(type="shutdown_request", recipient="backend-reviewer", content="Revi
 # if HAS_FRONTEND:
 SendMessage(type="shutdown_request", recipient="frontend-reviewer", content="Review complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 **Incorrect — No team teardown:**
@@ -153,6 +156,7 @@ Agent(subagent_type="security-auditor", team_name="review-pr-$PR_NUMBER")
 SendMessage(type="shutdown_request", recipient="quality-reviewer", content="Review complete")
 SendMessage(type="shutdown_request", recipient="security-reviewer", content="Review complete")
 TeamDelete()  # Clean shutdown
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Task tool spawns from [agent-prompts-task-tool.md](agent-prompts-task-tool.md).

--- a/plugins/ork/skills/verify/references/verification-phases.md
+++ b/plugins/ork/skills/verify/references/verification-phases.md
@@ -115,7 +115,7 @@ In Agent Teams mode, form a verification team where agents share findings and co
 TeamCreate(team_name="verify-{feature}", description="Verify {feature}")
 
 Agent(subagent_type="code-quality-reviewer", name="quality-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify code quality. Score 0-10.
      When you find patterns that affect security, message security-verifier.
@@ -124,7 +124,7 @@ Agent(subagent_type="code-quality-reviewer", name="quality-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="security-auditor", name="security-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Security verification. Score 0-10.
      When quality-verifier flags security-relevant patterns, investigate deeper.
@@ -133,7 +133,7 @@ Agent(subagent_type="security-auditor", name="security-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="test-generator", name="test-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify test coverage. Score 0-10.
      When quality-verifier or security-verifier flag untested paths, quantify the gap.
@@ -142,7 +142,7 @@ Agent(subagent_type="test-generator", name="test-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="backend-system-architect", name="api-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify API design and backend patterns. Score 0-10.
      When security-verifier flags endpoint issues, validate and score.
@@ -150,7 +150,7 @@ Agent(subagent_type="backend-system-architect", name="api-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="frontend-ui-developer", name="ui-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify frontend implementation. Score 0-10.
      When api-verifier shares API patterns, verify frontend matches.
@@ -161,7 +161,7 @@ Agent(subagent_type="frontend-ui-developer", name="ui-verifier",
 # Conditional 6th agent — use python-performance-engineer for backend,
 # frontend-performance-engineer for frontend
 Agent(subagent_type="python-performance-engineer", name="perf-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify performance and scalability. Score 0-10.
      Assess latency, resource usage, caching, and scaling patterns.
@@ -180,6 +180,9 @@ SendMessage(type="shutdown_request", recipient="api-verifier", content="Verifica
 SendMessage(type="shutdown_request", recipient="ui-verifier", content="Verification complete")
 SendMessage(type="shutdown_request", recipient="perf-verifier", content="Verification complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Phase 2 Task spawns above.

--- a/src/skills/assess/references/agent-teams-mode.md
+++ b/src/skills/assess/references/agent-teams-mode.md
@@ -16,7 +16,7 @@ Do NOT use Glob or Grep to discover additional files.
 """
 
 Agent(subagent_type="code-quality-reviewer", name="correctness-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess CORRECTNESS (0-10) and MAINTAINABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When you find issues that affect security, message security-assessor.
@@ -25,7 +25,7 @@ Agent(subagent_type="code-quality-reviewer", name="correctness-assessor",
      significantly (>2 points), discuss the disagreement.""")
 
 Agent(subagent_type="security-auditor", name="security-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess SECURITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When correctness-assessor flags security-relevant patterns, investigate deeper.
@@ -33,7 +33,7 @@ Agent(subagent_type="security-auditor", name="security-assessor",
      Share your score and flag any cross-dimension trade-offs.""")
 
 Agent(subagent_type="python-performance-engineer", name="perf-assessor",  # or frontend-performance-engineer for frontend
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess PERFORMANCE (0-10) and SCALABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      When security-assessor flags performance trade-offs, evaluate the impact.
@@ -41,7 +41,7 @@ Agent(subagent_type="python-performance-engineer", name="perf-assessor",  # or f
      Share your scores with reasoning for the composite calculation.""")
 
 Agent(subagent_type="test-generator", name="test-assessor",
-     team_name="assess-{target-slug}", max_turns=25,
+     team_name="assess-{target-slug}", max_turns=25, model=MODEL_OVERRIDE,
      prompt=f"""Assess TESTABILITY (0-10) for: {target}
      {SCOPE_INSTRUCTIONS}
      Evaluate test coverage, test quality, and ease of testing.
@@ -56,6 +56,9 @@ SendMessage(type="shutdown_request", recipient="security-assessor", content="Ass
 SendMessage(type="shutdown_request", recipient="perf-assessor", content="Assessment complete")
 SendMessage(type="shutdown_request", recipient="test-assessor", content="Assessment complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback — Team Formation Failure:** If team formation fails, use standard Phase 2 Task spawns.

--- a/src/skills/explore/rules/agent-teams-mode.md
+++ b/src/skills/explore/rules/agent-teams-mode.md
@@ -52,6 +52,9 @@ SendMessage(type="shutdown_request", recipient="data-flow-explorer", content="Ex
 SendMessage(type="shutdown_request", recipient="backend-explorer", content="Exploration complete")
 SendMessage(type="shutdown_request", recipient="frontend-explorer", content="Exploration complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Task tool spawns. See [exploration-agents.md](exploration-agents.md).

--- a/src/skills/fix-issue/references/agent-teams-rca.md
+++ b/src/skills/fix-issue/references/agent-teams-rca.md
@@ -50,6 +50,9 @@ SendMessage(type="shutdown_request", recipient="backend-expert", content="Fix va
 SendMessage(type="shutdown_request", recipient="frontend-expert", content="Fix validated")
 SendMessage(type="shutdown_request", recipient="test-planner", content="Fix validated")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Phase 4 Task spawns.

--- a/src/skills/implement/references/agent-teams-full-stack.md
+++ b/src/skills/implement/references/agent-teams-full-stack.md
@@ -282,16 +282,9 @@ After all teammates complete (or when all tasks are done):
    SendMessage(type="shutdown_request", recipient="test-engineer")
    SendMessage(type="shutdown_request", recipient="code-reviewer")
    TeamDelete()
-   ```
 
-6. **Clean up worktrees:**
-   ```bash
-   git worktree remove ../{project}-backend
-   git worktree remove ../{project}-frontend
-   git worktree remove ../{project}-tests
-   git branch -d feat/{feature}/backend
-   git branch -d feat/{feature}/frontend
-   git branch -d feat/{feature}/tests
+   # Worktree cleanup (CC 2.1.72)
+   ExitWorktree(action="keep")  # Keep branch for PR
    ```
 
 ---

--- a/src/skills/implement/references/agent-teams-phases.md
+++ b/src/skills/implement/references/agent-teams-phases.md
@@ -11,19 +11,19 @@ TeamCreate(team_name="implement-{feature-slug}", description="Architecture for {
 
 # Spawn 4 teammates (5th role — UX — is lead-managed or optional)
 Agent(subagent_type="backend-system-architect", name="backend-architect",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Design backend architecture. Message frontend-dev when API contract ready.")
 
 Agent(subagent_type="frontend-ui-developer", name="frontend-dev",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Design frontend architecture. Wait for API contract from backend-architect.")
 
 Agent(subagent_type="test-generator", name="test-engineer",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Plan test strategy. Start fixtures immediately, tests as contracts stabilize.")
 
 Agent(subagent_type="code-quality-reviewer", name="code-reviewer",
-     team_name="implement-{feature-slug}",
+     team_name="implement-{feature-slug}", model=MODEL_OVERRIDE,
      prompt="Review architecture decisions as they're shared. Flag issues to author directly.")
 ```
 
@@ -113,11 +113,8 @@ SendMessage(type="shutdown_request", recipient="code-reviewer",
 ```python
 TeamDelete()  # Remove team and shared task list
 
-# Clean up worktrees (if used)
-Bash("git worktree remove ../{project}-backend")
-Bash("git worktree remove ../{project}-frontend")
-Bash("git worktree remove ../{project}-tests")
-Bash("git branch -d feat/{feature}/backend feat/{feature}/frontend feat/{feature}/tests")
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")  # Keep branch for PR
 ```
 
 > Phases 7-10 (Scope Creep, E2E Verification, Documentation, Reflection) are the same in both modes — the team is already disbanded.

--- a/src/skills/review-pr/rules/agent-prompts-agent-teams.md
+++ b/src/skills/review-pr/rules/agent-prompts-agent-teams.md
@@ -137,6 +137,9 @@ SendMessage(type="shutdown_request", recipient="backend-reviewer", content="Revi
 # if HAS_FRONTEND:
 SendMessage(type="shutdown_request", recipient="frontend-reviewer", content="Review complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 **Incorrect — No team teardown:**
@@ -153,6 +156,7 @@ Agent(subagent_type="security-auditor", team_name="review-pr-$PR_NUMBER")
 SendMessage(type="shutdown_request", recipient="quality-reviewer", content="Review complete")
 SendMessage(type="shutdown_request", recipient="security-reviewer", content="Review complete")
 TeamDelete()  # Clean shutdown
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Task tool spawns from [agent-prompts-task-tool.md](agent-prompts-task-tool.md).

--- a/src/skills/verify/references/verification-phases.md
+++ b/src/skills/verify/references/verification-phases.md
@@ -115,7 +115,7 @@ In Agent Teams mode, form a verification team where agents share findings and co
 TeamCreate(team_name="verify-{feature}", description="Verify {feature}")
 
 Agent(subagent_type="code-quality-reviewer", name="quality-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify code quality. Score 0-10.
      When you find patterns that affect security, message security-verifier.
@@ -124,7 +124,7 @@ Agent(subagent_type="code-quality-reviewer", name="quality-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="security-auditor", name="security-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Security verification. Score 0-10.
      When quality-verifier flags security-relevant patterns, investigate deeper.
@@ -133,7 +133,7 @@ Agent(subagent_type="security-auditor", name="security-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="test-generator", name="test-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify test coverage. Score 0-10.
      When quality-verifier or security-verifier flag untested paths, quantify the gap.
@@ -142,7 +142,7 @@ Agent(subagent_type="test-generator", name="test-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="backend-system-architect", name="api-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify API design and backend patterns. Score 0-10.
      When security-verifier flags endpoint issues, validate and score.
@@ -150,7 +150,7 @@ Agent(subagent_type="backend-system-architect", name="api-verifier",
      Feature: {feature}.""")
 
 Agent(subagent_type="frontend-ui-developer", name="ui-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify frontend implementation. Score 0-10.
      When api-verifier shares API patterns, verify frontend matches.
@@ -161,7 +161,7 @@ Agent(subagent_type="frontend-ui-developer", name="ui-verifier",
 # Conditional 6th agent — use python-performance-engineer for backend,
 # frontend-performance-engineer for frontend
 Agent(subagent_type="python-performance-engineer", name="perf-verifier",
-     team_name="verify-{feature}",
+     team_name="verify-{feature}", model=MODEL_OVERRIDE,
      prompt="""# Cache-optimized: stable content first (CC 2.1.72)
      Verify performance and scalability. Score 0-10.
      Assess latency, resource usage, caching, and scaling patterns.
@@ -180,6 +180,9 @@ SendMessage(type="shutdown_request", recipient="api-verifier", content="Verifica
 SendMessage(type="shutdown_request", recipient="ui-verifier", content="Verification complete")
 SendMessage(type="shutdown_request", recipient="perf-verifier", content="Verification complete")
 TeamDelete()
+
+# Worktree cleanup (CC 2.1.72)
+ExitWorktree(action="keep")
 ```
 
 > **Fallback:** If team formation fails, use standard Phase 2 Task spawns above.


### PR DESCRIPTION
## Summary
- **ExitWorktree cleanup** added after `TeamDelete()` in all 6 Agent Teams teardown paths (verify, assess, fix-issue, explore, review-pr, implement)
- **`model=MODEL_OVERRIDE`** added to all Agent Teams spawns for assess (4 agents), verify (6 agents), implement (4 agents)
- Replaces old `git worktree remove` pattern in implement Agent Teams refs with `ExitWorktree(action="keep")`

Follow-up to PR #1060 which only updated the Task tool flow — Agent Teams paths were missed.

## Files changed (7 source + 7 plugins + 6 docs = 20)

| Skill | ExitWorktree | Model Override |
|-------|-------------|----------------|
| verify/references/verification-phases.md | After TeamDelete | 6 agents |
| assess/references/agent-teams-mode.md | After TeamDelete | 4 agents |
| implement/references/agent-teams-phases.md | Replaces git worktree remove | 4 agents |
| implement/references/agent-teams-full-stack.md | Replaces git worktree remove | - |
| fix-issue/references/agent-teams-rca.md | After TeamDelete | - |
| explore/rules/agent-teams-mode.md | After TeamDelete | - |
| review-pr/rules/agent-prompts-agent-teams.md | After TeamDelete (x2) | - |

## Test plan
- [x] `npm run build` — 89 skills, 31 agents, 99 hooks
- [x] `npm run test:skills` — all 89 skills pass (12/12 checks)
- [ ] CI validates on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
