### PR TITLE
fix(docs): update CC version requirement from 2.1.72 to 2.1.74

### DIFF
--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -69,7 +69,7 @@ Without Tavily, web research falls back to WebFetch → agent-browser automatica
 
 ## Requirements
 
-- **Claude Code** >= 2.1.72
+- **Claude Code** >= 2.1.74
 - **Node.js** >= 18 (for hooks)
 - **Git** (for commit/PR workflows)
 

--- a/docs/site/content/docs/getting-started/release-channels.mdx
+++ b/docs/site/content/docs/getting-started/release-channels.mdx
@@ -53,7 +53,7 @@ Look for: `Plugin: ork v7.2.0 (stable)`
 **What you get:**
 - Fully tested features across macOS, Ubuntu, Windows
 - Regular bug fixes and security patches
-- Compatible with Claude Code >= 2.1.72
+- Compatible with Claude Code >= 2.1.74
 
 **Update frequency:** Weekly or as needed for bug fixes.
 
@@ -179,7 +179,7 @@ Plugin:     ork v7.2.0-alpha.42 (alpha)
 ## Compatibility
 
 All three channels require:
-- Claude Code >= 2.1.72
+- Claude Code >= 2.1.74
 - Node.js >= 18 (for hooks)
 - Git (for commit/PR workflows)
 

--- a/docs/site/content/docs/troubleshooting/faq.mdx
+++ b/docs/site/content/docs/troubleshooting/faq.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'fumadocs-ui/components/callout';
 
 ### What version of Claude Code do I need?
 
-OrchestKit requires Claude Code 2.1.72 or later. Check your version:
+OrchestKit requires Claude Code 2.1.74 or later. Check your version:
 
 ```bash
 claude --version

--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -11,7 +11,7 @@ export const SITE = {
   domain: "https://orchestkit.vercel.app",
   github: "https://github.com/yonatangross/orchestkit",
   installCommand: "claude install orchestkit/ork",
-  ccVersion: "2.1.72+",
+  ccVersion: "2.1.74+",
 } as const;
 
 export const COUNTS = {


### PR DESCRIPTION
## Summary
- Docs site showed `>= 2.1.72` but source of truth (`cc-version-matrix.ts` + `CLAUDE.md`) is `>= 2.1.74`
- Updated 4 files: `constants.ts`, `installation.mdx`, `release-channels.mdx`, `faq.mdx`

## Test plan
- [ ] CI validates on push
- [ ] Verify site banner shows `2.1.74+`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
