### PR TITLE
fix(docs): regenerate docs data for v7.5.1

### DIFF
--- a/docs/site/lib/generated/plugins-data.ts
+++ b/docs/site/lib/generated/plugins-data.ts
@@ -9,7 +9,7 @@ export const PLUGINS: Plugin[] = [
     "description": "The complete AI development toolkit — 89 skills, 31 agents, 99 hooks.",
     "fullDescription": "The complete OrchestKit toolkit. Includes all workflow skills (implement, explore, verify, review-pr, commit), all memory skills (remember, memory, mem0, fabric), product/UX skills, accessibility, specialized patterns for Python (FastAPI, SQLAlchemy, Celery), React (RSC, TanStack, Zustand), LLM integration, RAG retrieval, and all specialized agents.",
     "category": "development",
-    "version": "7.4.0",
+    "version": "7.5.1",
     "skillCount": 89,
     "agentCount": 31,
     "hooks": 99,


### PR DESCRIPTION
## Summary
- Release-please bumped to 7.5.1 but `plugins-data.ts` still showed 7.4.0
- Ran `npm run generate:docs-data` to sync

## Test plan
- [ ] CI validates on push
- [ ] Verify site shows v7.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
