### PR TITLE
chore: override release-please to 7.9.1

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -14,6 +14,7 @@
   "bootstrap-sha": "c5fbeca5028a6cb309cef3bb1f2d6cc7c2f2ddfa",
   "packages": {
     ".": {
+      "release-as": "7.9.1",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary
- Override release-please version to 7.9.1 instead of 7.10.0
- The feat(docs) commit was a docs-site-only change (analytics integration), not a user-facing plugin feature
- Adds release-as: 7.9.1 to .release-please-config.json

**Note:** Remove the release-as key after the 7.9.1 release PR is merged.