### PR TITLE
fix(security): resolve yauzl CVE and pinned-dependencies alert

### DIFF
--- a/orchestkit-demos/package-lock.json
+++ b/orchestkit-demos/package-lock.json
@@ -4141,15 +4141,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/fflate": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
@@ -8030,13 +8021,16 @@
       "license": "ISC"
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.1.tgz",
+      "integrity": "sha512-k1isifdbpNSFEHFJ1ZY4YDewv0IH9FR61lDetaRMD3j2ae3bIXGV+7c+LHCqtQGofSd8PIyV4X6+dHMAnSr60A==",
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {

--- a/orchestkit-demos/package.json
+++ b/orchestkit-demos/package.json
@@ -66,7 +66,8 @@
   },
   "overrides": {
     "webpack": "^5.104.1",
-    "ajv": "^8.17.1"
+    "ajv": "^8.17.1",
+    "yauzl": "^3.2.1"
   },
   "private": true
 }

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -238,7 +238,13 @@ for manifest in "$MANIFESTS_DIR"/*.json; do
     # Build MCP server if source exists
     if [[ -d "$SRC_DIR/mcp-server" ]] && [[ -f "$SRC_DIR/mcp-server/package.json" ]]; then
         pushd "$SRC_DIR/mcp-server" > /dev/null
-        [[ ! -d "node_modules" ]] && npm install --ignore-scripts 2>/dev/null
+        if [[ ! -d "node_modules" ]]; then
+            if [[ -f "package-lock.json" ]]; then
+                npm ci --ignore-scripts 2>/dev/null
+            else
+                npm install --ignore-scripts 2>/dev/null
+            fi
+        fi
         node esbuild.config.mjs
         popd > /dev/null
     fi


### PR DESCRIPTION
## Summary

- Override yauzl to ^3.2.1 in orchestkit-demos (fixes Dependabot #29 — off-by-one error in yauzl < 3.2.1)
- Use npm ci when lockfile exists in build-plugins.sh (fixes Scorecard pinned-dependencies alert #126)

## Test plan

- [x] npm run build passes (93 skills)
- [x] yauzl@3.2.1 resolved in lockfile
- [ ] Dependabot #29 auto-closes after merge
- [ ] Code scanning #126 resolves on next Scorecard run