### PR TITLE
chore: remove release-as pin after 7.11.0 release

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -14,7 +14,6 @@
   "bootstrap-sha": "c5fbeca5028a6cb309cef3bb1f2d6cc7c2f2ddfa",
   "packages": {
     ".": {
-      "release-as": "7.11.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
Remove release-as override so future releases auto-calculate from conventional commits.