### PR TITLE
fix(docs): fix hooks spotlights generation in build script

### DIFF
--- a/docs/site/content/docs/reference/hooks/spotlights/block-writes.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/block-writes.mdx
@@ -1,0 +1,55 @@
+---
+title: "Block Writes"
+description: "Enforces read-only boundaries for investigation and review agents"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-red">Blocks</span> <span className="badge badge-purple">Agent-scoped</span>
+
+> Prevents Write, Edit, MultiEdit, and NotebookEdit operations for agents that should only investigate and report --- never modify code.
+
+## When It Fires
+
+**Event:** PreToolUse · **Matcher:** `Write`, `Edit`, `MultiEdit`, `NotebookEdit` · **Scope:** Agent-specific
+
+This hook is registered in hooks.json with agent-specific matchers, so it only fires for designated read-only agents.
+
+## What It Does
+
+When a read-only agent attempts any write operation, the hook returns a hard denial. Claude sees a message identifying the agent and explaining that it is read-only:
+
+```
+BLOCKED: Agent 'debug-investigator' is read-only.
+Write/Edit operations are not permitted.
+This agent investigates and reports - it does not modify code.
+```
+
+The agent name is read from the `CLAUDE_AGENT_ID` environment variable. All non-write tools (Bash, Read, Grep, Glob, WebFetch, etc.) are allowed through.
+
+## Agents Using This Hook
+
+| Agent | Purpose |
+|-------|---------|
+| `debug-investigator` | Investigates bugs without modifying code |
+| `code-quality-reviewer` | Reviews code quality, reports findings only |
+| `web-research-analyst` | Gathers web research data, no code changes |
+| `market-intelligence` | Gathers market/competitive intelligence |
+| `system-design-reviewer` | Reviews architecture decisions |
+
+## Blocked Tools
+
+The following tool names are intercepted and denied:
+
+- **Write** --- creating new files
+- **Edit** --- modifying existing files
+- **MultiEdit** --- batch file modifications
+- **NotebookEdit** --- Jupyter notebook cell edits
+
+## Configuration
+
+This hook has no user-configurable options. To change which agents are read-only, modify the agent-scoped hook entries in `hooks.json`.
+
+## Related Hooks
+
+- [file-guard](/docs/hooks/spotlights/file-guard) --- global file protection (complements block-writes for all agents)

--- a/docs/site/content/docs/reference/hooks/spotlights/dangerous-command-blocker.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/dangerous-command-blocker.mdx
@@ -1,0 +1,68 @@
+---
+title: "Dangerous Command Blocker"
+description: "Blocks catastrophic shell commands before they execute"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-red">Blocks</span> <span className="badge badge-gray">Global</span>
+
+> Prevents execution of commands that could cause catastrophic system damage, including filesystem destruction, device wiping, and history-rewriting git operations.
+
+## When It Fires
+
+**Event:** PreToolUse · **Matcher:** `Bash` · **Bundle:** `pretool.mjs`
+
+This hook runs as a **standalone entry** in hooks.json, separate from the unified advisory dispatcher. Because it is security-critical, it must evaluate and block before any advisory hooks run.
+
+## What It Does
+
+The dangerous command blocker normalizes incoming shell commands (collapsing whitespace, lowercasing, removing line continuations) and checks them against three categories of dangerous patterns. If any pattern matches, the command is **denied** immediately --- Claude sees a block message explaining why, and the command never executes.
+
+Unlike advisory hooks that inject guidance, this hook returns `continue: false` to hard-block the tool call. There is no override mechanism; the patterns are compiled into the hook source.
+
+## Blocked Patterns
+
+### Filesystem Destruction
+- `rm -rf /`, `rm -rf ~`, `rm -fr /`, `rm -fr ~`
+- `mv /* /dev/null`
+
+### Device Wiping
+- `> /dev/sda`, `mkfs.`, `dd if=/dev/zero of=/dev/`, `dd if=/dev/random of=/dev/`
+
+### Permission Abuse
+- `chmod -R 777 /`
+
+### Fork Bomb
+- `:()\{:|:&\};:`
+
+### Destructive Git Operations
+- `git reset --hard`, `git clean -fd`
+- `git push --force` / `git push -f` (regex match, catches flags anywhere in the command)
+
+### Database Destruction
+- `drop database`, `drop schema`, `truncate table`
+
+### Pipe-to-Shell
+- Any command piping output to `sh`, `bash`, `zsh`, or `dash` (e.g., `curl url | bash`)
+
+## What the User Sees
+
+When a command is blocked, Claude receives a denial message like:
+
+```
+Command matches dangerous pattern: rm -rf /
+
+This command could cause severe system damage and has been blocked.
+```
+
+For pipe-to-shell and force-push blocks, the message explains the specific risk (untrusted code execution or remote history rewriting).
+
+## Configuration
+
+This hook has no user-configurable options. The blocked patterns are hardcoded for maximum safety. To allow a blocked command, the user must run it manually outside Claude Code.
+
+## Related Hooks
+
+- [compound-command-validator](/docs/hooks/reference/pretool-bash#compound-command-validator) --- another security-critical blocker that runs standalone
+- [unified-advisory-dispatcher](/docs/hooks/spotlights/unified-advisory-dispatcher) --- the advisory dispatcher that runs *after* these security hooks

--- a/docs/site/content/docs/reference/hooks/spotlights/file-guard.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/file-guard.mdx
@@ -1,0 +1,71 @@
+---
+title: "File Guard"
+description: "Protects sensitive files and enforces file size limits on writes"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-red">Blocks</span> <span className="badge badge-gray">Global</span>
+
+> Prevents modification of sensitive files (secrets, keys, credentials) and blocks oversized source files to enforce modular code structure.
+
+## When It Fires
+
+**Event:** PreToolUse · **Matcher:** `Write`, `Edit` · **Bundle:** `pretool.mjs`
+
+## What It Does
+
+File guard serves two purposes: **security enforcement** and **code quality gating**.
+
+For every Write or Edit operation, the hook resolves the target file path --- including following symlinks to prevent bypass attacks (ME-001 security fix) --- and checks it against a blocklist of protected file patterns. If the file matches, the operation is denied outright.
+
+For Write operations on code files, the hook also enforces maximum line counts and detects structural bloat patterns. Files that exceed the line limit are blocked with a message suggesting how to split them. Files under the limit but showing multiple bloat signals get a warning logged (non-blocking).
+
+## Protected Paths
+
+These file patterns are **always blocked** --- Claude cannot write to them:
+
+| Pattern | What It Protects |
+|---------|-----------------|
+| `.env`, `.env.local`, `.env.production` | Environment variables and secrets |
+| `credentials.json`, `secrets.json` | Application credentials |
+| `.pem`, `private.key` | TLS/SSL certificates |
+| `id_rsa`, `id_ed25519` | SSH private keys |
+
+## File Size Limits
+
+| File Type | Default Limit | Environment Variable |
+|-----------|--------------|---------------------|
+| Source files (`.py`, `.ts`, `.tsx`, `.js`, `.jsx`, `.go`, `.rs`, `.java`) | 300 lines | `ORCHESTKIT_MAX_FILE_LINES` |
+| Test files (`*.test.*`, `*.spec.*`, `test_*`, `*_test.*`) | 500 lines | `ORCHESTKIT_MAX_TEST_FILE_LINES` |
+
+## Bloat Detection
+
+When writing code files, the hook scans for structural problems:
+
+- **God file** --- more than 15 exports in a single file
+- **Mixed concerns** --- types and logic in the same file (over 150 lines)
+- **High coupling** --- more than 20 imports
+- **Multi-class** --- multiple class declarations in one file
+- **Multi-component** --- more than 3 component declarations in one file
+
+Files over the line limit with bloat signals get a detailed denial message listing each detected pattern.
+
+## Configuration
+
+Override file size limits with environment variables:
+
+```bash
+# Allow larger source files (default: 300)
+ORCHESTKIT_MAX_FILE_LINES=500
+
+# Allow larger test files (default: 500)
+ORCHESTKIT_MAX_TEST_FILE_LINES=800
+```
+
+Config files (`package.json`, `pyproject.toml`, `tsconfig.json`) trigger a logged warning but are **not** blocked.
+
+## Related Hooks
+
+- [unified-quality-dispatcher](/docs/hooks/reference/pretool-write-edit#unified-quality-dispatcher) --- runs additional quality checks on write operations
+- [block-writes](/docs/hooks/spotlights/block-writes) --- agent-scoped write blocking for read-only agents

--- a/docs/site/content/docs/reference/hooks/spotlights/memory-validator.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/memory-validator.mdx
@@ -1,0 +1,64 @@
+---
+title: "Memory Validator"
+description: "Validates MCP memory operations to prevent accidental data loss"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-blue">Injects</span> <span className="badge badge-gray">Global</span>
+
+> Monitors MCP knowledge graph operations and warns before bulk deletions or malformed entity/relation creation.
+
+## When It Fires
+
+**Event:** PreToolUse · **Matcher:** `mcp__memory__*` · **Bundle:** `pretool.mjs`
+
+The hook checks the tool name prefix `mcp__memory__` and only activates for memory MCP tool calls. All other tools pass through silently.
+
+## What It Does
+
+The memory validator acts as a safety net for the MCP knowledge graph. It inspects each memory operation and either allows it silently, or emits a warning for operations that could cause data loss or produce invalid data.
+
+The hook **warns but does not block** --- the user still sees a confirmation prompt for flagged operations, giving them a chance to review before proceeding.
+
+## Validated Operations
+
+### Bulk Entity Deletion (`mcp__memory__delete_entities`)
+
+If more than **5 entities** are being deleted in a single call, the hook emits a warning:
+
+```
+Deleting 12 entities from knowledge graph
+```
+
+Deletions of 5 or fewer entities pass through without warning.
+
+### Bulk Relation Deletion (`mcp__memory__delete_relations`)
+
+If more than **10 relations** are being deleted in a single call, the hook emits a warning. Smaller deletions pass silently.
+
+### Entity Creation Validation (`mcp__memory__create_entities`)
+
+Every entity in the batch is checked for required fields. If any entity is missing `name` or `entityType`, the hook warns:
+
+```
+3 entities missing required fields (name, entityType)
+```
+
+Valid entity batches are logged and allowed.
+
+### Relation Creation Validation (`mcp__memory__create_relations`)
+
+Every relation is checked for `from`, `to`, and `relationType` fields. Missing fields trigger a warning with the count of invalid relations.
+
+### Read Operations
+
+All read operations (`read_graph`, `search_nodes`, `open_nodes`, `add_observations`, `delete_observations`) are always allowed without inspection.
+
+## Configuration
+
+This hook has no user-configurable options. The bulk deletion thresholds (5 entities, 10 relations) are defined in source code.
+
+## Related Hooks
+
+- [file-guard](/docs/hooks/spotlights/file-guard) --- similar protective pattern for filesystem operations

--- a/docs/site/content/docs/reference/hooks/spotlights/meta.json
+++ b/docs/site/content/docs/reference/hooks/spotlights/meta.json
@@ -1,4 +1,13 @@
 {
   "title": "Spotlights",
-  "pages": []
+  "pages": [
+    "dangerous-command-blocker",
+    "file-guard",
+    "unified-advisory-dispatcher",
+    "stop-pipeline",
+    "memory-validator",
+    "block-writes",
+    "pattern-consistency-enforcer",
+    "unified-dispatchers"
+  ]
 }

--- a/docs/site/content/docs/reference/hooks/spotlights/pattern-consistency-enforcer.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/pattern-consistency-enforcer.mdx
@@ -1,0 +1,69 @@
+---
+title: "Pattern Consistency Enforcer"
+description: "The only skill-scoped hook --- enforces established code patterns during review"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-red">Blocks</span> <span className="badge badge-green">Skill-scoped</span>
+
+> Checks written code against a project's established patterns file and blocks commits that violate architectural conventions.
+
+## When It Fires
+
+**Event:** PreToolUse · **Matcher:** `Write`, `Edit` · **Scope:** Skill (`code-review`)
+
+This is OrchestKit's **only skill-scoped hook**. It activates exclusively when the `code-review` skill is loaded, adding pattern enforcement on top of the standard file guard checks.
+
+## What It Does
+
+When code is written or edited during a code review session, the hook reads the project's established patterns file at `.claude/context/knowledge/patterns/established.json`. If the file does not exist, the hook exits silently --- pattern enforcement is opt-in.
+
+The hook then inspects the file content against category-specific rules based on file path and extension. Violations are classified as **errors** (blocking) or **warnings** (non-blocking, logged to stderr).
+
+## Enforced Patterns
+
+### Backend (Python)
+
+| Pattern | What It Catches |
+|---------|----------------|
+| **Clean Architecture layers** | Router importing directly from repositories (should go through services) |
+| **Circular dependencies** | Service importing from routers |
+| **Async SQLAlchemy** | Using sync `Session`/`sessionmaker` instead of `AsyncSession` |
+| **Pydantic v2** | Using `@validator` (v1) instead of `@field_validator` (v2) |
+| **Pydantic v2** | Using `@root_validator` (v1) instead of `@model_validator` (v2) |
+
+### Frontend (TypeScript/JavaScript)
+
+| Pattern | What It Catches |
+|---------|----------------|
+| **React 19 components** | Using `React.FC<>` instead of explicit props type |
+| **Zod validation** | API calls (`fetch`, `axios`) without Zod response validation |
+| **React 19 forms** | Form elements without `useFormStatus`/`useActionState`/`useOptimistic` (warning only) |
+| **Date formatting** | Direct `toLocaleDateString` instead of centralized `@/lib/dates` helpers |
+
+### Testing
+
+| Pattern | What It Catches |
+|---------|----------------|
+| **AAA comments** | Missing Arrange-Act-Assert comments in tests (warning only) |
+| **MSW for mocking** | Using `jest.mock` for fetch instead of MSW |
+| **Pytest fixtures** | Using unittest `setUp` instead of pytest fixtures |
+
+### AI Integration
+
+| Pattern | What It Catches |
+|---------|----------------|
+| **IDs in prompts** | Database IDs passed directly into LLM prompts |
+| **Timeout protection** | LLM calls without `asyncio.timeout` or `Promise.race` wrapping |
+
+## Configuration
+
+Pattern enforcement requires an `established.json` file at `.claude/context/knowledge/patterns/established.json`. Without this file, the hook is inactive.
+
+The patterns checked are defined in source code. To customize which patterns apply to your project, maintain the `established.json` file with your project's conventions.
+
+## Related Hooks
+
+- [file-guard](/docs/hooks/spotlights/file-guard) --- global file protection that runs alongside this hook
+- [unified-quality-dispatcher](/docs/hooks/reference/pretool-write-edit#unified-quality-dispatcher) --- additional write quality checks

--- a/docs/site/content/docs/reference/hooks/spotlights/stop-pipeline.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/stop-pipeline.mdx
@@ -1,0 +1,71 @@
+---
+title: "Stop Pipeline"
+description: "Runs 7 cleanup hooks in a detached background process after session exit"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-orange">Fire-and-forget</span> <span className="badge badge-gray">Global</span>
+
+> Ensures session cleanup hooks run without blocking Claude Code exit, by spawning a detached background worker that processes all 7 Stop hooks in parallel.
+
+## When It Fires
+
+**Event:** Stop · **Trigger:** Claude Code session ends
+
+## What It Does
+
+When a Claude Code session ends, the Stop event fires. Rather than running 7 hooks synchronously (which would delay exit by several seconds), OrchestKit uses a **fire-and-forget** pattern: the hook entry point writes the input to a temp file, spawns a detached background worker, and immediately returns --- allowing Claude Code to exit in milliseconds.
+
+The pipeline has two components:
+
+### 1. Entry Point (`stop-fire-and-forget.mjs`)
+
+- Reads the hook input from stdin
+- Writes it to `.claude/hooks/pending/stop-<uuid>.json`
+- Spawns `background-worker.mjs` as a **detached process** (`stdio: 'ignore'`, `child.unref()`)
+- Returns `{ continue: true, suppressOutput: true }` immediately
+
+### 2. Background Worker (`background-worker.mjs`)
+
+- Reads the work file, then deletes it immediately
+- Routes to the appropriate dispatcher (the `stop` dispatcher in this case)
+- Runs all 7 hooks via `Promise.allSettled` in parallel
+- Logs results to `.claude/logs/hooks/background-worker.log`
+- Self-terminates after 5 minutes if stuck
+- Cleans up orphaned temp files older than 10 minutes
+
+## Hooks in the Stop Dispatcher
+
+The unified stop dispatcher runs these hooks in parallel:
+
+**Core session hooks:**
+- `auto-save-context`, `session-patterns`, `issue-work-summary`
+- `calibration-persist`, `session-profile-aggregator`, `session-end-tracking`
+
+**Memory and instance management:**
+- `workflow-preference-learner`, `task-completion-check`
+
+**Analysis hooks:**
+- `context-compressor`, `auto-remember-continuity`, `security-scan-aggregator`
+
+**Skill validation hooks:**
+- `coverage-check`, `evidence-collector`, `coverage-threshold-gate`
+- `cross-instance-test-validator`, `di-pattern-enforcer`, `duplicate-code-detector`
+- `eval-metrics-collector`, `migration-validator`, `review-summary-generator`
+- `security-summary`, `test-pattern-validator`, `test-runner`
+
+**Heavy analysis (runs last):**
+- `full-test-suite`
+
+<Callout type="warn">
+The stop dispatcher includes **re-entry prevention**: if `input.stop_hook_active` is true, it skips all hooks to avoid infinite recursion.
+</Callout>
+
+## Configuration
+
+This hook has no user-configurable options. The background worker timeout is hardcoded at 5 minutes.
+
+## Related Hooks
+
+- [unified-dispatchers](/docs/hooks/spotlights/unified-dispatchers) --- the background worker also serves other fire-and-forget events (posttool, lifecycle, notification, etc.)

--- a/docs/site/content/docs/reference/hooks/spotlights/unified-advisory-dispatcher.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/unified-advisory-dispatcher.mdx
@@ -1,0 +1,58 @@
+---
+title: "Unified Advisory Dispatcher"
+description: "Consolidates 8 advisory hooks into a single process with budget-capped context injection"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-blue">Injects</span> <span className="badge badge-gray">Global</span>
+
+> Runs 8 advisory hooks in a single process spawn, merging their output into one context injection capped at 800 tokens.
+
+## When It Fires
+
+**Event:** PreToolUse · **Matcher:** `Bash` · **Bundle:** `pretool.mjs`
+
+## What It Does
+
+Every time Claude is about to run a Bash command, the unified advisory dispatcher executes up to 8 internal hooks in sequence and merges their output into a single `additionalContext` string. This replaces what would otherwise be 8 separate process spawns, significantly reducing latency.
+
+The dispatcher operates in three phases:
+
+1. **Input modification** --- `default-timeout-setter` runs first and may modify the command's timeout value. If it produces an `updatedInput`, that modification is passed through to Claude Code.
+
+2. **Blocking check** --- `agent-browser-safety` runs second and can **deny** the command (e.g., blocking browser automation for agents that should not use it). If it blocks, the dispatcher returns the denial immediately and skips all advisory hooks.
+
+3. **Advisory context** --- The remaining 6 hooks run in order, each producing optional context. The dispatcher accumulates context until the 800-token budget is reached, then skips remaining hooks.
+
+## Consolidated Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `default-timeout-setter` | Adds default timeout to long-running commands |
+| `agent-browser-safety` | Blocks browser tools for non-browser agents |
+| `error-pattern-warner` | Warns about common error patterns in commands |
+| `issue-docs-requirement` | Reminds about documentation when working on issues |
+| `multi-instance-quality-gate` | Enforces quality when multiple Claude instances are active |
+| `gh-issue-creation-guide` | Provides guidance for GitHub issue/PR commands |
+| `license-compliance` | Warns about license implications of package installs |
+| `affected-tests-finder` | Suggests relevant tests to run based on changed files |
+
+<Callout type="info">
+Security-critical hooks (`dangerous-command-blocker`, `compound-command-validator`) are **not** part of this dispatcher. They run as standalone entries to ensure they can block before any advisory logic executes.
+</Callout>
+
+## Token Budget
+
+The dispatcher enforces an **800-token cap** on consolidated output. Each hook's context is measured with a token estimator before being appended. If adding a hook's output would exceed the budget, that hook is skipped and a log message is emitted.
+
+Context sections from multiple hooks are joined with `---` separators.
+
+## Configuration
+
+This hook has no user-configurable options. The token budget (800) and hook execution order are defined in source code.
+
+## Related Hooks
+
+- [dangerous-command-blocker](/docs/hooks/spotlights/dangerous-command-blocker) --- security blocker that runs before this dispatcher
+- [unified-dispatchers](/docs/hooks/spotlights/unified-dispatchers) --- overview of the dispatcher pattern used across all events

--- a/docs/site/content/docs/reference/hooks/spotlights/unified-dispatchers.mdx
+++ b/docs/site/content/docs/reference/hooks/spotlights/unified-dispatchers.mdx
@@ -1,0 +1,82 @@
+---
+title: "Unified Dispatchers"
+description: "How one hooks.json entry fans out to many internal hooks across 7 events"
+---
+
+import { Callout } from "fumadocs-ui/components/callout";
+
+<span className="badge badge-blue">Injects</span> <span className="badge badge-gray">Global</span>
+
+> OrchestKit consolidates 104 hooks into a small number of hooks.json entries using unified dispatchers --- single entry points that route to many internal hooks.
+
+## The Pattern
+
+Without dispatchers, every hook would need its own entry in `hooks.json`, meaning Claude Code would spawn a separate Node.js process for each one. With 104 hooks, that would add significant latency to every tool call.
+
+The unified dispatcher pattern solves this:
+
+1. **One hooks.json entry** registers a single command per event type
+2. **One process spawn** executes the dispatcher
+3. **The dispatcher** imports and runs multiple hook functions in-process
+4. **Results are merged** into a single response (context injection, input modification, or denial)
+
+## Dispatcher Registry
+
+| Event | Dispatcher | Internal Hooks | Behavior |
+|-------|-----------|----------------|----------|
+| PreToolUse (Bash) | `unified-advisory-dispatcher` | 8 hooks | Budget-capped context injection (800 tokens) |
+| PreToolUse (Write/Edit) | `unified-quality-dispatcher` | 5 hooks | Context + blocking |
+| PreToolUse (Task) | `unified-agent-safety-dispatcher` | 4 hooks | Context + blocking |
+| PostToolUse | `unified-dispatcher` | Post-execution analysis hooks | Silent (fire-and-forget) |
+| PostToolUse (Write) | `unified-write-quality-dispatcher` | Post-write quality analysis | Context injection |
+| Stop | `unified-stop-dispatcher` | 7 hooks | Fire-and-forget via background worker |
+| UserPromptSubmit | `unified-dispatcher` | Prompt analysis and context injection | Context injection |
+| Lifecycle (SessionStart) | `unified-dispatcher` | Session initialization hooks | Silent (fire-and-forget) |
+| SubagentStop | `unified-dispatcher` | Subagent cleanup hooks | Silent (fire-and-forget) |
+| Notification | `unified-dispatcher` | Notification processing hooks | Silent (fire-and-forget) |
+| Setup | `unified-dispatcher` | One-time setup hooks | Silent (fire-and-forget) |
+
+## Execution Modes
+
+Dispatchers use two execution strategies depending on the event type:
+
+### Synchronous (PreToolUse, UserPromptSubmit)
+
+These dispatchers run hooks sequentially and return a merged result. They can:
+- **Block** the tool call (return `continue: false`)
+- **Inject context** (return `additionalContext`)
+- **Modify input** (return `updatedInput`)
+
+The dispatcher stops early if any hook blocks.
+
+### Fire-and-Forget (Stop, PostToolUse, Lifecycle, SubagentStop, Notification, Setup)
+
+These dispatchers are launched via `background-worker.mjs` as detached processes. The hooks.json entry returns immediately while the background worker:
+- Reads work from a temp file in `.claude/hooks/pending/`
+- Routes to the correct dispatcher via a registry
+- Runs all hooks via `Promise.allSettled`
+- Self-terminates after 5 minutes
+- Cleans up orphaned temp files older than 10 minutes
+
+<Callout type="info">
+Security-critical hooks (`dangerous-command-blocker`, `compound-command-validator`, `file-guard`) are **never** part of a dispatcher. They run as standalone entries to guarantee they can block before any other logic.
+</Callout>
+
+## Why Not One Giant Dispatcher?
+
+Separating dispatchers by event type provides:
+
+- **Isolation** --- a crash in post-tool hooks cannot affect pre-tool blocking
+- **Clarity** --- each dispatcher file lists exactly which hooks it manages
+- **Testability** --- each dispatcher has its own test file with focused assertions
+- **Budget control** --- different events have different token budgets and merging strategies
+
+## Configuration
+
+Dispatchers have no user-configurable options. The hook registry for each dispatcher is defined in its source file.
+
+## Related Hooks
+
+- [dangerous-command-blocker](/docs/hooks/spotlights/dangerous-command-blocker) --- standalone security hook (not in any dispatcher)
+- [stop-pipeline](/docs/hooks/spotlights/stop-pipeline) --- deep dive into the fire-and-forget stop dispatcher
+- [unified-advisory-dispatcher](/docs/hooks/spotlights/unified-advisory-dispatcher) --- deep dive into the PreToolUse Bash dispatcher

--- a/scripts/_build-docs-generate.py
+++ b/scripts/_build-docs-generate.py
@@ -12,6 +12,7 @@ Generates skills, agents, and hooks reference pages.
 import json
 import os
 import re
+import shutil
 
 from pathlib import Path
 
@@ -850,13 +851,19 @@ def generate_hooks(hooks_json: str, hooks_out: str) -> int:
         )
     (out_dir / "index.mdx").write_text("\n".join(index_lines) + "\n", encoding="utf-8")
 
-    # Generate spotlights directory structure
+    # Copy spotlights from docs/hooks/spotlights/ source directory
     spotlights_dir = out_dir / "spotlights"
     spotlights_dir.mkdir(parents=True, exist_ok=True)
-    spotlights_meta = {"title": "Spotlights", "pages": []}
-    (spotlights_dir / "meta.json").write_text(
-        json.dumps(spotlights_meta, indent=2) + "\n", encoding="utf-8"
-    )
+    spotlights_src = Path(project_root) / "docs" / "site" / "content" / "docs" / "hooks" / "spotlights"
+    if spotlights_src.exists():
+        for src_file in spotlights_src.iterdir():
+            shutil.copy2(src_file, spotlights_dir / src_file.name)
+    else:
+        # Fallback: empty spotlights if source doesn't exist
+        spotlights_meta = {"title": "Spotlights", "pages": []}
+        (spotlights_dir / "meta.json").write_text(
+            json.dumps(spotlights_meta, indent=2) + "\n", encoding="utf-8"
+        )
 
     # meta.json — include spotlights section
     pages = ["index"] + [s for s, _, _ in cat_slugs] + ["spotlights"]


### PR DESCRIPTION
## Summary
- Build script was hardcoding empty `pages: []` for reference/hooks/spotlights
- Now copies spotlight MDX files from `docs/hooks/spotlights/` source directory
- Spotlights survive rebuilds instead of being wiped every `npm run build`

## Root cause
`_build-docs-generate.py` line 856 created an empty spotlights meta.json, overwriting any manually added files on every build.

## Test plan
- [ ] `npm run build` generates 8 spotlight MDX files in reference/hooks/spotlights/
- [ ] Vercel deploy shows hooks spotlights with content