### PR TITLE
fix(docs): parse release-please changelog format in data generator

### DIFF
--- a/docs/site/lib/generated/changelog-data.ts
+++ b/docs/site/lib/generated/changelog-data.ts
@@ -17,6 +17,190 @@ export interface ChangelogEntry {
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    "version": "7.16.0",
+    "date": "2026-03-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "CC 2.1.78 adoption — StopFailure, PLUGIN_DATA, effort frontmatter, worktree ([#1104](https://github.com/yonatangross/orchestkit/issues/1104)) ([de50151](https://github.com/yonatangross/orchestkit/commit/de501510ea39940312a74efe30270c634332f413))",
+          "**compat:** update OrchestKit for CC 2.1.80 features ([#1124](https://github.com/yonatangross/orchestkit/issues/1124)) ([1f0e578](https://github.com/yonatangross/orchestkit/commit/1f0e578a27f2aa953d18784ab77362950d73a8c6))",
+          "**cover:** add /ork:cover skill + bump to 7.11.0 ([#1096](https://github.com/yonatangross/orchestkit/issues/1096)) ([36f14c6](https://github.com/yonatangross/orchestkit/commit/36f14c6f3266460a5a1afe14e1927bba2fa0a948))",
+          "**docs:** docs site overhaul — CTA, categories, sidebar, dep graph, quiz ([#1114](https://github.com/yonatangross/orchestkit/issues/1114)) ([edd84e5](https://github.com/yonatangross/orchestkit/commit/edd84e545c4955c06d99ca0e19ff625e6506ac90))",
+          "**docs:** integrate @yonatan-hq/analytics for cross-project tracking ([#1090](https://github.com/yonatangross/orchestkit/issues/1090)) ([3e294dc](https://github.com/yonatangross/orchestkit/commit/3e294dce69fbf112d48b4b1521383c398e871f29))",
+          "**eval:** Sprint 1 — trigger runner + CONTRIBUTING-SKILLS eval docs ([#1065](https://github.com/yonatangross/orchestkit/issues/1065)) ([8d845c7](https://github.com/yonatangross/orchestkit/commit/8d845c7090ff8d799789ff1b24c34360261c8f49))",
+          "**notebooklm:** update skill for notebooklm-mcp-cli v0.4.8 ([#1094](https://github.com/yonatangross/orchestkit/issues/1094)) ([0b72024](https://github.com/yonatangross/orchestkit/commit/0b72024d3a866bd4fb43daa2ed2f6bc79e1e9c07))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))",
+          "**skills:** adopt CC 2.1.72 features — ExitWorktree, model override ([#1036](https://github.com/yonatangross/orchestkit/issues/1036)) ([#1060](https://github.com/yonatangross/orchestkit/issues/1060)) ([96fd3a0](https://github.com/yonatangross/orchestkit/commit/96fd3a0ece399e3f843b11d3f018a0792eea9d46))",
+          "**skills:** skills health — CC 2.1.72 alignment (all phases) ([#1040](https://github.com/yonatangross/orchestkit/issues/1040)) ([b9db695](https://github.com/yonatangross/orchestkit/commit/b9db695763654ade01009ad439a16b7cd6179121))",
+          "Sprint 2 Wave A — eval runner, 1M context GA, RFC 9457 agent errors (v7.6.0) ([#1067](https://github.com/yonatangross/orchestkit/issues/1067)) ([12968a5](https://github.com/yonatangross/orchestkit/commit/12968a54e86446bf83773f0e098cf48f3c95ae9d))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**ci:** auto-bump docs site version on release ([#1117](https://github.com/yonatangross/orchestkit/issues/1117)) ([ddf5f3b](https://github.com/yonatangross/orchestkit/commit/ddf5f3bb17e41f19669442a4c3e120efb871deb6))",
+          "**docs:** fix hooks spotlights generation in build script ([#1126](https://github.com/yonatangross/orchestkit/issues/1126)) ([c74ebf4](https://github.com/yonatangross/orchestkit/commit/c74ebf4f38d876134ebd19b0c44d2353f863f584))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))",
+          "**docs:** update CC version requirement from 2.1.72 to 2.1.74 ([#1062](https://github.com/yonatangross/orchestkit/issues/1062)) ([622ba4c](https://github.com/yonatangross/orchestkit/commit/622ba4cfa0d5d4b9b1707c2f93897a311b3a1586))",
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))",
+          "**docs:** update generated plugins-data version to 7.4.0 ([#1058](https://github.com/yonatangross/orchestkit/issues/1058)) ([e2693b1](https://github.com/yonatangross/orchestkit/commit/e2693b16b3f8cddb40348b5790611a004f37009e))",
+          "**security:** resolve CodeQL and Scorecard alerts ([#1027](https://github.com/yonatangross/orchestkit/issues/1027)) ([ab9136c](https://github.com/yonatangross/orchestkit/commit/ab9136c09593632a9c10a7d44ca4c9799df297ed))",
+          "**security:** resolve yauzl CVE and pinned-dependencies alert ([#1101](https://github.com/yonatangross/orchestkit/issues/1101)) ([d96d68d](https://github.com/yonatangross/orchestkit/commit/d96d68d1bbaf55a8f41e982b0debfcf71fc792a6))",
+          "**skills:** add ExitWorktree + model override to Agent Teams teardown paths ([#1061](https://github.com/yonatangross/orchestkit/issues/1061)) ([c326666](https://github.com/yonatangross/orchestkit/commit/c3266663634912450ed965fae5ca6df752019705))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#1025](https://github.com/yonatangross/orchestkit/issues/1025)) ([f924b27](https://github.com/yonatangross/orchestkit/commit/f924b27a7ef02dd1f53be0400390d4a1f4d4600c))",
+          "fix hono CVE + organize playgrounds by date ([#1039](https://github.com/yonatangross/orchestkit/issues/1039)) ([b43cf2d](https://github.com/yonatangross/orchestkit/commit/b43cf2dc8f9d62d54b727de72928e123c2330e51))",
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))",
+          "**main:** release 7.11.0 ([#1099](https://github.com/yonatangross/orchestkit/issues/1099)) ([d20b85d](https://github.com/yonatangross/orchestkit/commit/d20b85dc2391eeeb32f3c140900ab38ff83e901b))",
+          "**main:** release 7.11.1 ([#1102](https://github.com/yonatangross/orchestkit/issues/1102)) ([4716cfe](https://github.com/yonatangross/orchestkit/commit/4716cfe837663fc7170b8e6bcb19d585bb05e6ce))",
+          "**main:** release 7.14.0 ([#1115](https://github.com/yonatangross/orchestkit/issues/1115)) ([648cdea](https://github.com/yonatangross/orchestkit/commit/648cdea25943c7377b1fede0fe208d5e47583c9d))",
+          "**main:** release 7.14.1 ([#1118](https://github.com/yonatangross/orchestkit/issues/1118)) ([93002f3](https://github.com/yonatangross/orchestkit/commit/93002f3235042fecb6c2d4be2abecf1d200a8fc0))",
+          "**main:** release 7.2.0 ([#1010](https://github.com/yonatangross/orchestkit/issues/1010)) ([a6420bb](https://github.com/yonatangross/orchestkit/commit/a6420bbd4c50e234ccad3eeba676846e36b68a3d))",
+          "**main:** release 7.2.1 ([#1013](https://github.com/yonatangross/orchestkit/issues/1013)) ([2a83685](https://github.com/yonatangross/orchestkit/commit/2a8368559de636960593f3258e79afeb511d3311))",
+          "**main:** release 7.3.0 ([#1024](https://github.com/yonatangross/orchestkit/issues/1024)) ([490317f](https://github.com/yonatangross/orchestkit/commit/490317fdc2c397f54a9bd067edc7ecd4043b0777))",
+          "**main:** release 7.3.1 ([#1026](https://github.com/yonatangross/orchestkit/issues/1026)) ([363a44f](https://github.com/yonatangross/orchestkit/commit/363a44fcb9f69c4866a6e3fa7bde9ee4be4b2b26))",
+          "**main:** release 7.3.2 ([#1028](https://github.com/yonatangross/orchestkit/issues/1028)) ([9f67f37](https://github.com/yonatangross/orchestkit/commit/9f67f378c1aa81a9653b5c6a1a482eba7870d4de))",
+          "**main:** release 7.4.0 ([#1057](https://github.com/yonatangross/orchestkit/issues/1057)) ([f8a7bfd](https://github.com/yonatangross/orchestkit/commit/f8a7bfde3221cf196bc7ec8678d7301278777ce3))",
+          "**main:** release 7.5.0 ([#1059](https://github.com/yonatangross/orchestkit/issues/1059)) ([059f43d](https://github.com/yonatangross/orchestkit/commit/059f43d19db7fa61d4a01eafadc73077e615e248))",
+          "**main:** release 7.5.1 ([#1063](https://github.com/yonatangross/orchestkit/issues/1063)) ([6c14540](https://github.com/yonatangross/orchestkit/commit/6c145408a4f3bda6cc6f74c403b33a0622f4c024))",
+          "**main:** release 7.9.0 ([#1066](https://github.com/yonatangross/orchestkit/issues/1066)) ([8aa0b27](https://github.com/yonatangross/orchestkit/commit/8aa0b2763d9f458680fba777905414ee83a252f8))",
+          "override release-please to 7.9.1 ([#1093](https://github.com/yonatangross/orchestkit/issues/1093)) ([caa4efd](https://github.com/yonatangross/orchestkit/commit/caa4efd87a0afa640f2e63d7c2aecc508dcf3f33))",
+          "pin release-as to 7.11.0 ([#1100](https://github.com/yonatangross/orchestkit/issues/1100)) ([06acb3f](https://github.com/yonatangross/orchestkit/commit/06acb3fdf8e7bc3020bae216e8c94d5af3887ad5))",
+          "remove release-as pin after 7.11.0 release ([#1103](https://github.com/yonatangross/orchestkit/issues/1103)) ([5fd681c](https://github.com/yonatangross/orchestkit/commit/5fd681cf73bf1362c4b4fd254c4100e86185f51e))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "split testing-patterns, CC 2.1.72 upgrade, HTTP hooks fix ([#1015](https://github.com/yonatangross/orchestkit/issues/1015)) ([7bcab43](https://github.com/yonatangross/orchestkit/commit/7bcab430a21abdaaba714b8c7153351877387646))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/download-artifact from 8.0.0 to 8.0.1 ([#1097](https://github.com/yonatangross/orchestkit/issues/1097)) ([ac52e6a](https://github.com/yonatangross/orchestkit/commit/ac52e6a47089114ec454c1a3e34c779432c49810))",
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))",
+          "update anthropics/claude-code-action requirement to 26ec041249acb0a944c0a47b6c0c13f05dbc5b44 ([#1098](https://github.com/yonatangross/orchestkit/issues/1098)) ([8a7600e](https://github.com/yonatangross/orchestkit/commit/8a7600e2b9270547dcfc522d95dde26e9b8f3bc3))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.15.0",
+    "date": "2026-03-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "feat(skills): effort frontmatter on 40 skills — CC 2.1.80 overrides model effort level (18 high, 22 low)",
+          "feat(hooks): rate_limits display in statusline — shows rate limit usage alongside context percentage",
+          "feat(compat): version-compatibility matrix updated with 13 CC 2.1.80 entries",
+          "docs: simplified plugin install commands (`/plugin install` single-step flow)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.14.1",
+    "date": "2026-03-19",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** auto-bump docs site version on release ([#1117](https://github.com/yonatangross/orchestkit/issues/1117)) ([ddf5f3b](https://github.com/yonatangross/orchestkit/commit/ddf5f3bb17e41f19669442a4c3e120efb871deb6))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.14.0",
+    "date": "2026-03-19",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "CC 2.1.78 adoption — StopFailure, PLUGIN_DATA, effort frontmatter, worktree ([#1104](https://github.com/yonatangross/orchestkit/issues/1104)) ([de50151](https://github.com/yonatangross/orchestkit/commit/de501510ea39940312a74efe30270c634332f413))",
+          "**cover:** add /ork:cover skill + bump to 7.11.0 ([#1096](https://github.com/yonatangross/orchestkit/issues/1096)) ([36f14c6](https://github.com/yonatangross/orchestkit/commit/36f14c6f3266460a5a1afe14e1927bba2fa0a948))",
+          "**docs:** docs site overhaul — CTA, categories, sidebar, dep graph, quiz ([#1114](https://github.com/yonatangross/orchestkit/issues/1114)) ([edd84e5](https://github.com/yonatangross/orchestkit/commit/edd84e545c4955c06d99ca0e19ff625e6506ac90))",
+          "**docs:** integrate @yonatan-hq/analytics for cross-project tracking ([#1090](https://github.com/yonatangross/orchestkit/issues/1090)) ([3e294dc](https://github.com/yonatangross/orchestkit/commit/3e294dce69fbf112d48b4b1521383c398e871f29))",
+          "**eval:** Sprint 1 — trigger runner + CONTRIBUTING-SKILLS eval docs ([#1065](https://github.com/yonatangross/orchestkit/issues/1065)) ([8d845c7](https://github.com/yonatangross/orchestkit/commit/8d845c7090ff8d799789ff1b24c34360261c8f49))",
+          "**notebooklm:** update skill for notebooklm-mcp-cli v0.4.8 ([#1094](https://github.com/yonatangross/orchestkit/issues/1094)) ([0b72024](https://github.com/yonatangross/orchestkit/commit/0b72024d3a866bd4fb43daa2ed2f6bc79e1e9c07))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))",
+          "**skills:** adopt CC 2.1.72 features — ExitWorktree, model override ([#1036](https://github.com/yonatangross/orchestkit/issues/1036)) ([#1060](https://github.com/yonatangross/orchestkit/issues/1060)) ([96fd3a0](https://github.com/yonatangross/orchestkit/commit/96fd3a0ece399e3f843b11d3f018a0792eea9d46))",
+          "**skills:** skills health — CC 2.1.72 alignment (all phases) ([#1040](https://github.com/yonatangross/orchestkit/issues/1040)) ([b9db695](https://github.com/yonatangross/orchestkit/commit/b9db695763654ade01009ad439a16b7cd6179121))",
+          "Sprint 2 Wave A — eval runner, 1M context GA, RFC 9457 agent errors (v7.6.0) ([#1067](https://github.com/yonatangross/orchestkit/issues/1067)) ([12968a5](https://github.com/yonatangross/orchestkit/commit/12968a54e86446bf83773f0e098cf48f3c95ae9d))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))",
+          "**docs:** update CC version requirement from 2.1.72 to 2.1.74 ([#1062](https://github.com/yonatangross/orchestkit/issues/1062)) ([622ba4c](https://github.com/yonatangross/orchestkit/commit/622ba4cfa0d5d4b9b1707c2f93897a311b3a1586))",
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))",
+          "**docs:** update generated plugins-data version to 7.4.0 ([#1058](https://github.com/yonatangross/orchestkit/issues/1058)) ([e2693b1](https://github.com/yonatangross/orchestkit/commit/e2693b16b3f8cddb40348b5790611a004f37009e))",
+          "**security:** resolve CodeQL and Scorecard alerts ([#1027](https://github.com/yonatangross/orchestkit/issues/1027)) ([ab9136c](https://github.com/yonatangross/orchestkit/commit/ab9136c09593632a9c10a7d44ca4c9799df297ed))",
+          "**security:** resolve yauzl CVE and pinned-dependencies alert ([#1101](https://github.com/yonatangross/orchestkit/issues/1101)) ([d96d68d](https://github.com/yonatangross/orchestkit/commit/d96d68d1bbaf55a8f41e982b0debfcf71fc792a6))",
+          "**skills:** add ExitWorktree + model override to Agent Teams teardown paths ([#1061](https://github.com/yonatangross/orchestkit/issues/1061)) ([c326666](https://github.com/yonatangross/orchestkit/commit/c3266663634912450ed965fae5ca6df752019705))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#1025](https://github.com/yonatangross/orchestkit/issues/1025)) ([f924b27](https://github.com/yonatangross/orchestkit/commit/f924b27a7ef02dd1f53be0400390d4a1f4d4600c))",
+          "fix hono CVE + organize playgrounds by date ([#1039](https://github.com/yonatangross/orchestkit/issues/1039)) ([b43cf2d](https://github.com/yonatangross/orchestkit/commit/b43cf2dc8f9d62d54b727de72928e123c2330e51))",
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))",
+          "**main:** release 7.11.0 ([#1099](https://github.com/yonatangross/orchestkit/issues/1099)) ([d20b85d](https://github.com/yonatangross/orchestkit/commit/d20b85dc2391eeeb32f3c140900ab38ff83e901b))",
+          "**main:** release 7.11.1 ([#1102](https://github.com/yonatangross/orchestkit/issues/1102)) ([4716cfe](https://github.com/yonatangross/orchestkit/commit/4716cfe837663fc7170b8e6bcb19d585bb05e6ce))",
+          "**main:** release 7.2.0 ([#1010](https://github.com/yonatangross/orchestkit/issues/1010)) ([a6420bb](https://github.com/yonatangross/orchestkit/commit/a6420bbd4c50e234ccad3eeba676846e36b68a3d))",
+          "**main:** release 7.2.1 ([#1013](https://github.com/yonatangross/orchestkit/issues/1013)) ([2a83685](https://github.com/yonatangross/orchestkit/commit/2a8368559de636960593f3258e79afeb511d3311))",
+          "**main:** release 7.3.0 ([#1024](https://github.com/yonatangross/orchestkit/issues/1024)) ([490317f](https://github.com/yonatangross/orchestkit/commit/490317fdc2c397f54a9bd067edc7ecd4043b0777))",
+          "**main:** release 7.3.1 ([#1026](https://github.com/yonatangross/orchestkit/issues/1026)) ([363a44f](https://github.com/yonatangross/orchestkit/commit/363a44fcb9f69c4866a6e3fa7bde9ee4be4b2b26))",
+          "**main:** release 7.3.2 ([#1028](https://github.com/yonatangross/orchestkit/issues/1028)) ([9f67f37](https://github.com/yonatangross/orchestkit/commit/9f67f378c1aa81a9653b5c6a1a482eba7870d4de))",
+          "**main:** release 7.4.0 ([#1057](https://github.com/yonatangross/orchestkit/issues/1057)) ([f8a7bfd](https://github.com/yonatangross/orchestkit/commit/f8a7bfde3221cf196bc7ec8678d7301278777ce3))",
+          "**main:** release 7.5.0 ([#1059](https://github.com/yonatangross/orchestkit/issues/1059)) ([059f43d](https://github.com/yonatangross/orchestkit/commit/059f43d19db7fa61d4a01eafadc73077e615e248))",
+          "**main:** release 7.5.1 ([#1063](https://github.com/yonatangross/orchestkit/issues/1063)) ([6c14540](https://github.com/yonatangross/orchestkit/commit/6c145408a4f3bda6cc6f74c403b33a0622f4c024))",
+          "**main:** release 7.9.0 ([#1066](https://github.com/yonatangross/orchestkit/issues/1066)) ([8aa0b27](https://github.com/yonatangross/orchestkit/commit/8aa0b2763d9f458680fba777905414ee83a252f8))",
+          "override release-please to 7.9.1 ([#1093](https://github.com/yonatangross/orchestkit/issues/1093)) ([caa4efd](https://github.com/yonatangross/orchestkit/commit/caa4efd87a0afa640f2e63d7c2aecc508dcf3f33))",
+          "pin release-as to 7.11.0 ([#1100](https://github.com/yonatangross/orchestkit/issues/1100)) ([06acb3f](https://github.com/yonatangross/orchestkit/commit/06acb3fdf8e7bc3020bae216e8c94d5af3887ad5))",
+          "remove release-as pin after 7.11.0 release ([#1103](https://github.com/yonatangross/orchestkit/issues/1103)) ([5fd681c](https://github.com/yonatangross/orchestkit/commit/5fd681cf73bf1362c4b4fd254c4100e86185f51e))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "split testing-patterns, CC 2.1.72 upgrade, HTTP hooks fix ([#1015](https://github.com/yonatangross/orchestkit/issues/1015)) ([7bcab43](https://github.com/yonatangross/orchestkit/commit/7bcab430a21abdaaba714b8c7153351877387646))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/download-artifact from 8.0.0 to 8.0.1 ([#1097](https://github.com/yonatangross/orchestkit/issues/1097)) ([ac52e6a](https://github.com/yonatangross/orchestkit/commit/ac52e6a47089114ec454c1a3e34c779432c49810))",
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))",
+          "update anthropics/claude-code-action requirement to 26ec041249acb0a944c0a47b6c0c13f05dbc5b44 ([#1098](https://github.com/yonatangross/orchestkit/issues/1098)) ([8a7600e](https://github.com/yonatangross/orchestkit/commit/8a7600e2b9270547dcfc522d95dde26e9b8f3bc3))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "7.13.0",
     "date": "2026-03-18",
     "compareUrl": "",
@@ -47,6 +231,15 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     "compareUrl": "",
     "sections": [
       {
+        "type": "added",
+        "items": [
+          "**StopFailure hook** (CC 2.1.78): new `stop/stop-failure-handler.ts` flushes state and writes emergency handoff on API error/rate limit — error-loop safe by design (#1106)",
+          "**CLAUDE_PLUGIN_DATA persistence** (CC 2.1.78): `getPluginDataDir/getSessionStorageDir/getAnalyticsStorageDir` in `paths.ts`; session storage migrates to persistent directory that survives plugin updates (#1107)",
+          "**effort frontmatter defaults**: 21 agents annotated with `effort: low/medium`; remaining 12 default to `high` (#1108)",
+          "**worktree hook validation**: tests confirming `WorktreeCreate/WorktreeRemove` registration and handler correctness after CC 2.1.78 `--worktree` flag fix (#1109)"
+        ]
+      },
+      {
         "type": "changed",
         "items": [
           "Minimum Claude Code engine bumped to `>= 2.1.78`",
@@ -69,6 +262,94 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     ]
   },
   {
+    "version": "7.11.1",
+    "date": "2026-03-16",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**security:** resolve yauzl CVE and pinned-dependencies alert ([#1101](https://github.com/yonatangross/orchestkit/issues/1101)) ([d96d68d](https://github.com/yonatangross/orchestkit/commit/d96d68d1bbaf55a8f41e982b0debfcf71fc792a6))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "remove release-as pin after 7.11.0 release ([#1103](https://github.com/yonatangross/orchestkit/issues/1103)) ([5fd681c](https://github.com/yonatangross/orchestkit/commit/5fd681cf73bf1362c4b4fd254c4100e86185f51e))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.11.0",
+    "date": "2026-03-16",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "**cover:** add /ork:cover skill + bump to 7.11.0 ([#1096](https://github.com/yonatangross/orchestkit/issues/1096)) ([36f14c6](https://github.com/yonatangross/orchestkit/commit/36f14c6f3266460a5a1afe14e1927bba2fa0a948))",
+          "**docs:** integrate @yonatan-hq/analytics for cross-project tracking ([#1090](https://github.com/yonatangross/orchestkit/issues/1090)) ([3e294dc](https://github.com/yonatangross/orchestkit/commit/3e294dce69fbf112d48b4b1521383c398e871f29))",
+          "**eval:** Sprint 1 — trigger runner + CONTRIBUTING-SKILLS eval docs ([#1065](https://github.com/yonatangross/orchestkit/issues/1065)) ([8d845c7](https://github.com/yonatangross/orchestkit/commit/8d845c7090ff8d799789ff1b24c34360261c8f49))",
+          "**notebooklm:** update skill for notebooklm-mcp-cli v0.4.8 ([#1094](https://github.com/yonatangross/orchestkit/issues/1094)) ([0b72024](https://github.com/yonatangross/orchestkit/commit/0b72024d3a866bd4fb43daa2ed2f6bc79e1e9c07))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))",
+          "**skills:** adopt CC 2.1.72 features — ExitWorktree, model override ([#1036](https://github.com/yonatangross/orchestkit/issues/1036)) ([#1060](https://github.com/yonatangross/orchestkit/issues/1060)) ([96fd3a0](https://github.com/yonatangross/orchestkit/commit/96fd3a0ece399e3f843b11d3f018a0792eea9d46))",
+          "**skills:** skills health — CC 2.1.72 alignment (all phases) ([#1040](https://github.com/yonatangross/orchestkit/issues/1040)) ([b9db695](https://github.com/yonatangross/orchestkit/commit/b9db695763654ade01009ad439a16b7cd6179121))",
+          "Sprint 2 Wave A — eval runner, 1M context GA, RFC 9457 agent errors (v7.6.0) ([#1067](https://github.com/yonatangross/orchestkit/issues/1067)) ([12968a5](https://github.com/yonatangross/orchestkit/commit/12968a54e86446bf83773f0e098cf48f3c95ae9d))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))",
+          "**docs:** update CC version requirement from 2.1.72 to 2.1.74 ([#1062](https://github.com/yonatangross/orchestkit/issues/1062)) ([622ba4c](https://github.com/yonatangross/orchestkit/commit/622ba4cfa0d5d4b9b1707c2f93897a311b3a1586))",
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))",
+          "**docs:** update generated plugins-data version to 7.4.0 ([#1058](https://github.com/yonatangross/orchestkit/issues/1058)) ([e2693b1](https://github.com/yonatangross/orchestkit/commit/e2693b16b3f8cddb40348b5790611a004f37009e))",
+          "**security:** resolve CodeQL and Scorecard alerts ([#1027](https://github.com/yonatangross/orchestkit/issues/1027)) ([ab9136c](https://github.com/yonatangross/orchestkit/commit/ab9136c09593632a9c10a7d44ca4c9799df297ed))",
+          "**skills:** add ExitWorktree + model override to Agent Teams teardown paths ([#1061](https://github.com/yonatangross/orchestkit/issues/1061)) ([c326666](https://github.com/yonatangross/orchestkit/commit/c3266663634912450ed965fae5ca6df752019705))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#1025](https://github.com/yonatangross/orchestkit/issues/1025)) ([f924b27](https://github.com/yonatangross/orchestkit/commit/f924b27a7ef02dd1f53be0400390d4a1f4d4600c))",
+          "fix hono CVE + organize playgrounds by date ([#1039](https://github.com/yonatangross/orchestkit/issues/1039)) ([b43cf2d](https://github.com/yonatangross/orchestkit/commit/b43cf2dc8f9d62d54b727de72928e123c2330e51))",
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))",
+          "**main:** release 7.2.0 ([#1010](https://github.com/yonatangross/orchestkit/issues/1010)) ([a6420bb](https://github.com/yonatangross/orchestkit/commit/a6420bbd4c50e234ccad3eeba676846e36b68a3d))",
+          "**main:** release 7.2.1 ([#1013](https://github.com/yonatangross/orchestkit/issues/1013)) ([2a83685](https://github.com/yonatangross/orchestkit/commit/2a8368559de636960593f3258e79afeb511d3311))",
+          "**main:** release 7.3.0 ([#1024](https://github.com/yonatangross/orchestkit/issues/1024)) ([490317f](https://github.com/yonatangross/orchestkit/commit/490317fdc2c397f54a9bd067edc7ecd4043b0777))",
+          "**main:** release 7.3.1 ([#1026](https://github.com/yonatangross/orchestkit/issues/1026)) ([363a44f](https://github.com/yonatangross/orchestkit/commit/363a44fcb9f69c4866a6e3fa7bde9ee4be4b2b26))",
+          "**main:** release 7.3.2 ([#1028](https://github.com/yonatangross/orchestkit/issues/1028)) ([9f67f37](https://github.com/yonatangross/orchestkit/commit/9f67f378c1aa81a9653b5c6a1a482eba7870d4de))",
+          "**main:** release 7.4.0 ([#1057](https://github.com/yonatangross/orchestkit/issues/1057)) ([f8a7bfd](https://github.com/yonatangross/orchestkit/commit/f8a7bfde3221cf196bc7ec8678d7301278777ce3))",
+          "**main:** release 7.5.0 ([#1059](https://github.com/yonatangross/orchestkit/issues/1059)) ([059f43d](https://github.com/yonatangross/orchestkit/commit/059f43d19db7fa61d4a01eafadc73077e615e248))",
+          "**main:** release 7.5.1 ([#1063](https://github.com/yonatangross/orchestkit/issues/1063)) ([6c14540](https://github.com/yonatangross/orchestkit/commit/6c145408a4f3bda6cc6f74c403b33a0622f4c024))",
+          "**main:** release 7.9.0 ([#1066](https://github.com/yonatangross/orchestkit/issues/1066)) ([8aa0b27](https://github.com/yonatangross/orchestkit/commit/8aa0b2763d9f458680fba777905414ee83a252f8))",
+          "override release-please to 7.9.1 ([#1093](https://github.com/yonatangross/orchestkit/issues/1093)) ([caa4efd](https://github.com/yonatangross/orchestkit/commit/caa4efd87a0afa640f2e63d7c2aecc508dcf3f33))",
+          "pin release-as to 7.11.0 ([#1100](https://github.com/yonatangross/orchestkit/issues/1100)) ([06acb3f](https://github.com/yonatangross/orchestkit/commit/06acb3fdf8e7bc3020bae216e8c94d5af3887ad5))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "split testing-patterns, CC 2.1.72 upgrade, HTTP hooks fix ([#1015](https://github.com/yonatangross/orchestkit/issues/1015)) ([7bcab43](https://github.com/yonatangross/orchestkit/commit/7bcab430a21abdaaba714b8c7153351877387646))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/download-artifact from 8.0.0 to 8.0.1 ([#1097](https://github.com/yonatangross/orchestkit/issues/1097)) ([ac52e6a](https://github.com/yonatangross/orchestkit/commit/ac52e6a47089114ec454c1a3e34c779432c49810))",
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))",
+          "update anthropics/claude-code-action requirement to 26ec041249acb0a944c0a47b6c0c13f05dbc5b44 ([#1098](https://github.com/yonatangross/orchestkit/issues/1098)) ([8a7600e](https://github.com/yonatangross/orchestkit/commit/8a7600e2b9270547dcfc522d95dde26e9b8f3bc3))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "7.9.1",
     "date": "2026-03-15",
     "compareUrl": "",
@@ -78,6 +359,67 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
         "items": [
           "Integrate `@yonatan-hq/analytics` for cross-project page view tracking in docs site",
           "Add Edge route handler for HMAC-signed analytics event forwarding to HQ API"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.9.0",
+    "date": "2026-03-15",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "**eval:** Sprint 1 — trigger runner + CONTRIBUTING-SKILLS eval docs ([#1065](https://github.com/yonatangross/orchestkit/issues/1065)) ([8d845c7](https://github.com/yonatangross/orchestkit/commit/8d845c7090ff8d799789ff1b24c34360261c8f49))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))",
+          "**skills:** adopt CC 2.1.72 features — ExitWorktree, model override ([#1036](https://github.com/yonatangross/orchestkit/issues/1036)) ([#1060](https://github.com/yonatangross/orchestkit/issues/1060)) ([96fd3a0](https://github.com/yonatangross/orchestkit/commit/96fd3a0ece399e3f843b11d3f018a0792eea9d46))",
+          "**skills:** skills health — CC 2.1.72 alignment (all phases) ([#1040](https://github.com/yonatangross/orchestkit/issues/1040)) ([b9db695](https://github.com/yonatangross/orchestkit/commit/b9db695763654ade01009ad439a16b7cd6179121))",
+          "Sprint 2 Wave A — eval runner, 1M context GA, RFC 9457 agent errors (v7.6.0) ([#1067](https://github.com/yonatangross/orchestkit/issues/1067)) ([12968a5](https://github.com/yonatangross/orchestkit/commit/12968a54e86446bf83773f0e098cf48f3c95ae9d))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))",
+          "**docs:** update CC version requirement from 2.1.72 to 2.1.74 ([#1062](https://github.com/yonatangross/orchestkit/issues/1062)) ([622ba4c](https://github.com/yonatangross/orchestkit/commit/622ba4cfa0d5d4b9b1707c2f93897a311b3a1586))",
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))",
+          "**docs:** update generated plugins-data version to 7.4.0 ([#1058](https://github.com/yonatangross/orchestkit/issues/1058)) ([e2693b1](https://github.com/yonatangross/orchestkit/commit/e2693b16b3f8cddb40348b5790611a004f37009e))",
+          "**security:** resolve CodeQL and Scorecard alerts ([#1027](https://github.com/yonatangross/orchestkit/issues/1027)) ([ab9136c](https://github.com/yonatangross/orchestkit/commit/ab9136c09593632a9c10a7d44ca4c9799df297ed))",
+          "**skills:** add ExitWorktree + model override to Agent Teams teardown paths ([#1061](https://github.com/yonatangross/orchestkit/issues/1061)) ([c326666](https://github.com/yonatangross/orchestkit/commit/c3266663634912450ed965fae5ca6df752019705))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#1025](https://github.com/yonatangross/orchestkit/issues/1025)) ([f924b27](https://github.com/yonatangross/orchestkit/commit/f924b27a7ef02dd1f53be0400390d4a1f4d4600c))",
+          "fix hono CVE + organize playgrounds by date ([#1039](https://github.com/yonatangross/orchestkit/issues/1039)) ([b43cf2d](https://github.com/yonatangross/orchestkit/commit/b43cf2dc8f9d62d54b727de72928e123c2330e51))",
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))",
+          "**main:** release 7.2.0 ([#1010](https://github.com/yonatangross/orchestkit/issues/1010)) ([a6420bb](https://github.com/yonatangross/orchestkit/commit/a6420bbd4c50e234ccad3eeba676846e36b68a3d))",
+          "**main:** release 7.2.1 ([#1013](https://github.com/yonatangross/orchestkit/issues/1013)) ([2a83685](https://github.com/yonatangross/orchestkit/commit/2a8368559de636960593f3258e79afeb511d3311))",
+          "**main:** release 7.3.0 ([#1024](https://github.com/yonatangross/orchestkit/issues/1024)) ([490317f](https://github.com/yonatangross/orchestkit/commit/490317fdc2c397f54a9bd067edc7ecd4043b0777))",
+          "**main:** release 7.3.1 ([#1026](https://github.com/yonatangross/orchestkit/issues/1026)) ([363a44f](https://github.com/yonatangross/orchestkit/commit/363a44fcb9f69c4866a6e3fa7bde9ee4be4b2b26))",
+          "**main:** release 7.3.2 ([#1028](https://github.com/yonatangross/orchestkit/issues/1028)) ([9f67f37](https://github.com/yonatangross/orchestkit/commit/9f67f378c1aa81a9653b5c6a1a482eba7870d4de))",
+          "**main:** release 7.4.0 ([#1057](https://github.com/yonatangross/orchestkit/issues/1057)) ([f8a7bfd](https://github.com/yonatangross/orchestkit/commit/f8a7bfde3221cf196bc7ec8678d7301278777ce3))",
+          "**main:** release 7.5.0 ([#1059](https://github.com/yonatangross/orchestkit/issues/1059)) ([059f43d](https://github.com/yonatangross/orchestkit/commit/059f43d19db7fa61d4a01eafadc73077e615e248))",
+          "**main:** release 7.5.1 ([#1063](https://github.com/yonatangross/orchestkit/issues/1063)) ([6c14540](https://github.com/yonatangross/orchestkit/commit/6c145408a4f3bda6cc6f74c403b33a0622f4c024))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "split testing-patterns, CC 2.1.72 upgrade, HTTP hooks fix ([#1015](https://github.com/yonatangross/orchestkit/issues/1015)) ([7bcab43](https://github.com/yonatangross/orchestkit/commit/7bcab430a21abdaaba714b8c7153351877387646))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))"
         ]
       }
     ]
@@ -249,6 +591,91 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     ]
   },
   {
+    "version": "7.5.1",
+    "date": "2026-03-12",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**docs:** update CC version requirement from 2.1.72 to 2.1.74 ([#1062](https://github.com/yonatangross/orchestkit/issues/1062)) ([622ba4c](https://github.com/yonatangross/orchestkit/commit/622ba4cfa0d5d4b9b1707c2f93897a311b3a1586))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.5.0",
+    "date": "2026-03-12",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "**skills:** adopt CC 2.1.72 features — ExitWorktree, model override ([#1036](https://github.com/yonatangross/orchestkit/issues/1036)) ([#1060](https://github.com/yonatangross/orchestkit/issues/1060)) ([96fd3a0](https://github.com/yonatangross/orchestkit/commit/96fd3a0ece399e3f843b11d3f018a0792eea9d46))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**docs:** update generated plugins-data version to 7.4.0 ([#1058](https://github.com/yonatangross/orchestkit/issues/1058)) ([e2693b1](https://github.com/yonatangross/orchestkit/commit/e2693b16b3f8cddb40348b5790611a004f37009e))",
+          "**skills:** add ExitWorktree + model override to Agent Teams teardown paths ([#1061](https://github.com/yonatangross/orchestkit/issues/1061)) ([c326666](https://github.com/yonatangross/orchestkit/commit/c3266663634912450ed965fae5ca6df752019705))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.4.0",
+    "date": "2026-03-12",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))",
+          "**skills:** skills health — CC 2.1.72 alignment (all phases) ([#1040](https://github.com/yonatangross/orchestkit/issues/1040)) ([b9db695](https://github.com/yonatangross/orchestkit/commit/b9db695763654ade01009ad439a16b7cd6179121))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))",
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))",
+          "**security:** resolve CodeQL and Scorecard alerts ([#1027](https://github.com/yonatangross/orchestkit/issues/1027)) ([ab9136c](https://github.com/yonatangross/orchestkit/commit/ab9136c09593632a9c10a7d44ca4c9799df297ed))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#1025](https://github.com/yonatangross/orchestkit/issues/1025)) ([f924b27](https://github.com/yonatangross/orchestkit/commit/f924b27a7ef02dd1f53be0400390d4a1f4d4600c))",
+          "fix hono CVE + organize playgrounds by date ([#1039](https://github.com/yonatangross/orchestkit/issues/1039)) ([b43cf2d](https://github.com/yonatangross/orchestkit/commit/b43cf2dc8f9d62d54b727de72928e123c2330e51))",
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))",
+          "**main:** release 7.2.0 ([#1010](https://github.com/yonatangross/orchestkit/issues/1010)) ([a6420bb](https://github.com/yonatangross/orchestkit/commit/a6420bbd4c50e234ccad3eeba676846e36b68a3d))",
+          "**main:** release 7.2.1 ([#1013](https://github.com/yonatangross/orchestkit/issues/1013)) ([2a83685](https://github.com/yonatangross/orchestkit/commit/2a8368559de636960593f3258e79afeb511d3311))",
+          "**main:** release 7.3.0 ([#1024](https://github.com/yonatangross/orchestkit/issues/1024)) ([490317f](https://github.com/yonatangross/orchestkit/commit/490317fdc2c397f54a9bd067edc7ecd4043b0777))",
+          "**main:** release 7.3.1 ([#1026](https://github.com/yonatangross/orchestkit/issues/1026)) ([363a44f](https://github.com/yonatangross/orchestkit/commit/363a44fcb9f69c4866a6e3fa7bde9ee4be4b2b26))",
+          "**main:** release 7.3.2 ([#1028](https://github.com/yonatangross/orchestkit/issues/1028)) ([9f67f37](https://github.com/yonatangross/orchestkit/commit/9f67f378c1aa81a9653b5c6a1a482eba7870d4de))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "split testing-patterns, CC 2.1.72 upgrade, HTTP hooks fix ([#1015](https://github.com/yonatangross/orchestkit/issues/1015)) ([7bcab43](https://github.com/yonatangross/orchestkit/commit/7bcab430a21abdaaba714b8c7153351877387646))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "7.5.0",
     "date": "2026-03-12",
     "compareUrl": "",
@@ -319,10 +746,87 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     "compareUrl": "",
     "sections": [
       {
+        "type": "fixed",
+        "items": [
+          "**security:** resolve CodeQL and Scorecard alerts ([#1027](https://github.com/yonatangross/orchestkit/issues/1027)) ([ab9136c](https://github.com/yonatangross/orchestkit/commit/ab9136c09593632a9c10a7d44ca4c9799df297ed))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "fix hono CVE + organize playgrounds by date ([#1039](https://github.com/yonatangross/orchestkit/issues/1039)) ([b43cf2d](https://github.com/yonatangross/orchestkit/commit/b43cf2dc8f9d62d54b727de72928e123c2330e51))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.3.2",
+    "date": "2026-03-11",
+    "compareUrl": "",
+    "sections": [
+      {
         "type": "security",
         "items": [
           "**hooks:** fix second-order command injection in `gitExec()` (CodeQL #124, High) — add `assertSafeGitArgs()` blocklist for `--upload-pack`, `--receive-pack`, `--exec`, `-c` options that can execute arbitrary commands via git",
           "**ci:** fix unpinned npm dependency in `claude-health.yml` (Scorecard #125, Medium) — add `--ignore-scripts` to `npm install` and bump to `@2.1.72`"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.3.1",
+    "date": "2026-03-11",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump the npm_and_yarn group across 2 directories with 1 update ([#1025](https://github.com/yonatangross/orchestkit/issues/1025)) ([f924b27](https://github.com/yonatangross/orchestkit/commit/f924b27a7ef02dd1f53be0400390d4a1f4d4600c))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.3.0",
+    "date": "2026-03-10",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))",
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))",
+          "**main:** release 7.2.0 ([#1010](https://github.com/yonatangross/orchestkit/issues/1010)) ([a6420bb](https://github.com/yonatangross/orchestkit/commit/a6420bbd4c50e234ccad3eeba676846e36b68a3d))",
+          "**main:** release 7.2.1 ([#1013](https://github.com/yonatangross/orchestkit/issues/1013)) ([2a83685](https://github.com/yonatangross/orchestkit/commit/2a8368559de636960593f3258e79afeb511d3311))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "split testing-patterns, CC 2.1.72 upgrade, HTTP hooks fix ([#1015](https://github.com/yonatangross/orchestkit/issues/1015)) ([7bcab43](https://github.com/yonatangross/orchestkit/commit/7bcab430a21abdaaba714b8c7153351877387646))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))"
         ]
       }
     ]
@@ -397,6 +901,55 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
         "items": [
           "**evals:** update help.eval.json from \"5 GIT skills\" to \"4 GIT skills\"",
           "**tests:** update split-bundles expected hook count to 176"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.2.1",
+    "date": "2026-03-09",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**docs:** update generated plugins-data version to 7.2.0 ([#1012](https://github.com/yonatangross/orchestkit/issues/1012)) ([dca7243](https://github.com/yonatangross/orchestkit/commit/dca72432fd9982b3457d3423aad1124155a94584))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/setup-node from 6.2.0 to 6.3.0 ([#1008](https://github.com/yonatangross/orchestkit/issues/1008)) ([61f73f5](https://github.com/yonatangross/orchestkit/commit/61f73f5f49327e0a773110aefb387d4b2bb2113b))",
+          "bump github/codeql-action from 4.32.4 to 4.32.6 ([#1009](https://github.com/yonatangross/orchestkit/issues/1009)) ([13a0975](https://github.com/yonatangross/orchestkit/commit/13a097584115d899681c321d15e2b8c05bda68ac))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.2.0",
+    "date": "2026-03-09",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "add ci-automation skill + GitHub Actions workflows ([#1006](https://github.com/yonatangross/orchestkit/issues/1006)) ([8b328a7](https://github.com/yonatangross/orchestkit/commit/8b328a7dc3e06428c17b2349dae1d8b92eb57350))",
+          "**skills:** add 13 cognitive-science UX rules across 5 existing skills ([#1011](https://github.com/yonatangross/orchestkit/issues/1011)) ([91b62ac](https://github.com/yonatangross/orchestkit/commit/91b62ac1ab43a1d3296b84e05b402d0102600531))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 7.1.10 ([#1000](https://github.com/yonatangross/orchestkit/issues/1000)) ([d0c48a1](https://github.com/yonatangross/orchestkit/commit/d0c48a1f8f135fa741bb16a39166c1f0e5ebc965))",
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))"
         ]
       }
     ]
@@ -484,6 +1037,27 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     ]
   },
   {
+    "version": "7.1.10",
+    "date": "2026-03-06",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))",
+          "**ci:** add plugins[0].version to release-please extra-files ([#1001](https://github.com/yonatangross/orchestkit/issues/1001)) ([8a4faad](https://github.com/yonatangross/orchestkit/commit/8a4faadf651d822d3c4e748360a27ca23cc9af14))",
+          "**docs:** replace broken ASCII diagrams with fumadocs Steps ([#999](https://github.com/yonatangross/orchestkit/issues/999)) ([2c1b6fe](https://github.com/yonatangross/orchestkit/commit/2c1b6fee670c4e1c8be2855bb23596792f354874))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 7.1.7 ([#998](https://github.com/yonatangross/orchestkit/issues/998)) ([c4607ad](https://github.com/yonatangross/orchestkit/commit/c4607ad811ec43b9cd6dc5ac323af953eca4096a))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "7.1.9",
     "date": "2026-03-06",
     "compareUrl": "",
@@ -508,6 +1082,19 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
           "Add missing `/ork:prd` command to command-skills page",
           "Fix stale skill counts and clarify \"listed vs invocable\" text in skills overview",
           "Fix skill.mjs bundle hook count from \"1+\" to \"19\" in hooks overview"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.1.7",
+    "date": "2026-03-06",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** add bootstrap-sha to release-please config ([#997](https://github.com/yonatangross/orchestkit/issues/997)) ([0d46843](https://github.com/yonatangross/orchestkit/commit/0d468437e75ffc7d3842f46972bd19836c565435))"
         ]
       }
     ]
@@ -764,12 +1351,73 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     "compareUrl": "",
     "sections": [
       {
+        "type": "added",
+        "items": [
+          "**eval:** Overhaul eval skills, agents, and LangGraph/Langfuse compatibility",
+          "**skills:** Extract `create-pr` into 7 rules + 4 references (274→156 lines)",
+          "**skills:** Compress 8 bloated skills (demo-producer, plan-viz, doctor, fix-issue, skill-evolution, verify, memory, assess) with content preserved in rules/references",
+          "**testing:** Add 3 new test suites: agent skill refs, build drift, cross-skill refs"
+        ]
+      },
+      {
         "type": "fixed",
         "items": [
           "Fix 20 broken cross-skill references across 12 skills",
           "Fix 5 weak skill descriptions (configure, feedback, help, release-checklist, skill-evolution)",
           "Bump minimum Claude Code version to 2.1.56",
           "Resolve all verification findings (Langfuse v2 remnants, credential warnings, sync guards)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.7.0",
+    "date": "2026-02-23",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "dead code cleanup & PostToolUse consolidation ([#684](https://github.com/yonatangross/orchestkit/issues/684)) ([#790](https://github.com/yonatangross/orchestkit/issues/790)) ([da245ac](https://github.com/yonatangross/orchestkit/commit/da245ac82c587763b95269c62bf2b9f3c44115d3))",
+          "**docs:** add Vercel Analytics, Speed Insights, and dynamic social proof ([#809](https://github.com/yonatangross/orchestkit/issues/809), [#810](https://github.com/yonatangross/orchestkit/issues/810)) ([#812](https://github.com/yonatangross/orchestkit/issues/812)) ([714af85](https://github.com/yonatangross/orchestkit/commit/714af856d4983c2d87d7b5c936c9284e549b003f))",
+          "integrate Claude Code 2.1.50 features ([#805](https://github.com/yonatangross/orchestkit/issues/805)) ([60a16d2](https://github.com/yonatangross/orchestkit/commit/60a16d210227a343364266c7e3b0ee544f80af0e))",
+          "security hardening & hook consolidation (Milestone [#72](https://github.com/yonatangross/orchestkit/issues/72)) ([#788](https://github.com/yonatangross/orchestkit/issues/788)) ([5f014b4](https://github.com/yonatangross/orchestkit/commit/5f014b477d7e4aad04fbaeb13d8b72db08edc19a))",
+          "**skills:** add presentation-builder skill ([#817](https://github.com/yonatangross/orchestkit/issues/817)) ([93cacda](https://github.com/yonatangross/orchestkit/commit/93cacda9e19322126cbd8e01af69b2d98bb16146))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "add plugins/ plugin.json to release-please extra-files ([#822](https://github.com/yonatangross/orchestkit/issues/822)) ([8eb27cb](https://github.com/yonatangross/orchestkit/commit/8eb27cbb258bb1b8d6d0f175691b2c240c3c060b))",
+          "eliminate 32 code scanning alerts (19 CodeQL + 13 Scorecard) ([#792](https://github.com/yonatangross/orchestkit/issues/792)) ([12e796b](https://github.com/yonatangross/orchestkit/commit/12e796b5a715b930f43eaa8e08d9fa38603e867d))",
+          "eliminate 91 CodeQL alerts + fix 30 pre-existing test failures ([#782](https://github.com/yonatangross/orchestkit/issues/782)) ([ca47641](https://github.com/yonatangross/orchestkit/commit/ca476416b81c217998af5e9b5305b44a4b6ffa8a))",
+          "**release:** scope release-please from v6.1.0 to prevent 7.0.0 ([#786](https://github.com/yonatangross/orchestkit/issues/786)) ([83a248b](https://github.com/yonatangross/orchestkit/commit/83a248b522313c453fa9fbdeb5e020998542350f))",
+          "remove 35 broken symlinks from .claude/ ([#813](https://github.com/yonatangross/orchestkit/issues/813)) ([3bd179c](https://github.com/yonatangross/orchestkit/commit/3bd179c919b8367fbe100f0080fe3e263b002472))",
+          "resolve 21 code scanning alerts (17 CodeQL + 4 Scorecard) ([#825](https://github.com/yonatangross/orchestkit/issues/825)) ([00e9ed8](https://github.com/yonatangross/orchestkit/commit/00e9ed883dad67e74e7b3b9fbc0e2361c9dac80f))",
+          "sanitize shell arg in security-scan-aggregator bandit command ([#828](https://github.com/yonatangross/orchestkit/issues/828)) ([18c0415](https://github.com/yonatangross/orchestkit/commit/18c0415ad99d949b082115a978d6f560a69f378f))",
+          "sync manifests and pyproject.toml to v6.3.0 ([#806](https://github.com/yonatangross/orchestkit/issues/806)) ([d06661d](https://github.com/yonatangross/orchestkit/commit/d06661d18a3386367c8a1c3ae06b071a657c885c))",
+          "use jq for plugin.json generation to match release-please format ([#824](https://github.com/yonatangross/orchestkit/issues/824)) ([0a37a07](https://github.com/yonatangross/orchestkit/commit/0a37a07a411c17e2503d135ffbca2423ea0e9624))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 6.1.3 ([#787](https://github.com/yonatangross/orchestkit/issues/787)) ([612ad89](https://github.com/yonatangross/orchestkit/commit/612ad8939f4a456ea5714212f96dab9cf6eca75a))",
+          "**main:** release 6.2.0 ([#789](https://github.com/yonatangross/orchestkit/issues/789)) ([54042ff](https://github.com/yonatangross/orchestkit/commit/54042ff5f4a4e654e9bb05708a752cd71ce10a97))",
+          "**main:** release 6.2.0 ([#791](https://github.com/yonatangross/orchestkit/issues/791)) ([a37b5d4](https://github.com/yonatangross/orchestkit/commit/a37b5d40ec2c5d3af330af6e3263d16a2b961685))",
+          "**main:** release 6.3.0 ([#793](https://github.com/yonatangross/orchestkit/issues/793)) ([737982c](https://github.com/yonatangross/orchestkit/commit/737982c15349dcd24a92cd04993b46c09b2a37a0))",
+          "**main:** release 6.4.0 ([#808](https://github.com/yonatangross/orchestkit/issues/808)) ([bfbdbf3](https://github.com/yonatangross/orchestkit/commit/bfbdbf3c6d4d8c6945ddc0430cb52d28ba5e132b))",
+          "**main:** release 6.5.0 ([#814](https://github.com/yonatangross/orchestkit/issues/814)) ([05cf210](https://github.com/yonatangross/orchestkit/commit/05cf2100e0a1365551ee7406ca681de18f983a6c))",
+          "**main:** release 6.6.0 ([#823](https://github.com/yonatangross/orchestkit/issues/823)) ([70282ea](https://github.com/yonatangross/orchestkit/commit/70282ea9f0b6cd218aa620e224d8141b091c63db))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/attest-build-provenance from 2.4.0 to 3.2.0 ([#816](https://github.com/yonatangross/orchestkit/issues/816)) ([04a2cee](https://github.com/yonatangross/orchestkit/commit/04a2cee77500cb544e35bd02dc85a397f8f3c810))",
+          "bump github/codeql-action from 4.32.3 to 4.32.4 ([#815](https://github.com/yonatangross/orchestkit/issues/815)) ([e31096e](https://github.com/yonatangross/orchestkit/commit/e31096e7624424e1c37c2e7baaabccf8c6b782d6))",
+          "pin package manager dependencies for Scorecard compliance ([#827](https://github.com/yonatangross/orchestkit/issues/827)) ([45dec20](https://github.com/yonatangross/orchestkit/commit/45dec207b7be47814e7598e718244844ff950ac8))",
+          "restrict workflow-level permissions to read-all in release-please ([#820](https://github.com/yonatangross/orchestkit/issues/820)) ([8e03fe5](https://github.com/yonatangross/orchestkit/commit/8e03fe5eca022aa71a65820e47cd5dac652380f9))"
         ]
       }
     ]
@@ -815,6 +1463,54 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     ]
   },
   {
+    "version": "6.6.0",
+    "date": "2026-02-23",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "dead code cleanup & PostToolUse consolidation ([#684](https://github.com/yonatangross/orchestkit/issues/684)) ([#790](https://github.com/yonatangross/orchestkit/issues/790)) ([da245ac](https://github.com/yonatangross/orchestkit/commit/da245ac82c587763b95269c62bf2b9f3c44115d3))",
+          "**docs:** add Vercel Analytics, Speed Insights, and dynamic social proof ([#809](https://github.com/yonatangross/orchestkit/issues/809), [#810](https://github.com/yonatangross/orchestkit/issues/810)) ([#812](https://github.com/yonatangross/orchestkit/issues/812)) ([714af85](https://github.com/yonatangross/orchestkit/commit/714af856d4983c2d87d7b5c936c9284e549b003f))",
+          "integrate Claude Code 2.1.50 features ([#805](https://github.com/yonatangross/orchestkit/issues/805)) ([60a16d2](https://github.com/yonatangross/orchestkit/commit/60a16d210227a343364266c7e3b0ee544f80af0e))",
+          "security hardening & hook consolidation (Milestone [#72](https://github.com/yonatangross/orchestkit/issues/72)) ([#788](https://github.com/yonatangross/orchestkit/issues/788)) ([5f014b4](https://github.com/yonatangross/orchestkit/commit/5f014b477d7e4aad04fbaeb13d8b72db08edc19a))",
+          "**skills:** add presentation-builder skill ([#817](https://github.com/yonatangross/orchestkit/issues/817)) ([93cacda](https://github.com/yonatangross/orchestkit/commit/93cacda9e19322126cbd8e01af69b2d98bb16146))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "add plugins/ plugin.json to release-please extra-files ([#822](https://github.com/yonatangross/orchestkit/issues/822)) ([8eb27cb](https://github.com/yonatangross/orchestkit/commit/8eb27cbb258bb1b8d6d0f175691b2c240c3c060b))",
+          "eliminate 32 code scanning alerts (19 CodeQL + 13 Scorecard) ([#792](https://github.com/yonatangross/orchestkit/issues/792)) ([12e796b](https://github.com/yonatangross/orchestkit/commit/12e796b5a715b930f43eaa8e08d9fa38603e867d))",
+          "eliminate 91 CodeQL alerts + fix 30 pre-existing test failures ([#782](https://github.com/yonatangross/orchestkit/issues/782)) ([ca47641](https://github.com/yonatangross/orchestkit/commit/ca476416b81c217998af5e9b5305b44a4b6ffa8a))",
+          "**release:** scope release-please from v6.1.0 to prevent 7.0.0 ([#786](https://github.com/yonatangross/orchestkit/issues/786)) ([83a248b](https://github.com/yonatangross/orchestkit/commit/83a248b522313c453fa9fbdeb5e020998542350f))",
+          "remove 35 broken symlinks from .claude/ ([#813](https://github.com/yonatangross/orchestkit/issues/813)) ([3bd179c](https://github.com/yonatangross/orchestkit/commit/3bd179c919b8367fbe100f0080fe3e263b002472))",
+          "sync manifests and pyproject.toml to v6.3.0 ([#806](https://github.com/yonatangross/orchestkit/issues/806)) ([d06661d](https://github.com/yonatangross/orchestkit/commit/d06661d18a3386367c8a1c3ae06b071a657c885c))",
+          "use jq for plugin.json generation to match release-please format ([#824](https://github.com/yonatangross/orchestkit/issues/824)) ([0a37a07](https://github.com/yonatangross/orchestkit/commit/0a37a07a411c17e2503d135ffbca2423ea0e9624))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 6.1.3 ([#787](https://github.com/yonatangross/orchestkit/issues/787)) ([612ad89](https://github.com/yonatangross/orchestkit/commit/612ad8939f4a456ea5714212f96dab9cf6eca75a))",
+          "**main:** release 6.2.0 ([#789](https://github.com/yonatangross/orchestkit/issues/789)) ([54042ff](https://github.com/yonatangross/orchestkit/commit/54042ff5f4a4e654e9bb05708a752cd71ce10a97))",
+          "**main:** release 6.2.0 ([#791](https://github.com/yonatangross/orchestkit/issues/791)) ([a37b5d4](https://github.com/yonatangross/orchestkit/commit/a37b5d40ec2c5d3af330af6e3263d16a2b961685))",
+          "**main:** release 6.3.0 ([#793](https://github.com/yonatangross/orchestkit/issues/793)) ([737982c](https://github.com/yonatangross/orchestkit/commit/737982c15349dcd24a92cd04993b46c09b2a37a0))",
+          "**main:** release 6.4.0 ([#808](https://github.com/yonatangross/orchestkit/issues/808)) ([bfbdbf3](https://github.com/yonatangross/orchestkit/commit/bfbdbf3c6d4d8c6945ddc0430cb52d28ba5e132b))",
+          "**main:** release 6.5.0 ([#814](https://github.com/yonatangross/orchestkit/issues/814)) ([05cf210](https://github.com/yonatangross/orchestkit/commit/05cf2100e0a1365551ee7406ca681de18f983a6c))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/attest-build-provenance from 2.4.0 to 3.2.0 ([#816](https://github.com/yonatangross/orchestkit/issues/816)) ([04a2cee](https://github.com/yonatangross/orchestkit/commit/04a2cee77500cb544e35bd02dc85a397f8f3c810))",
+          "bump github/codeql-action from 4.32.3 to 4.32.4 ([#815](https://github.com/yonatangross/orchestkit/issues/815)) ([e31096e](https://github.com/yonatangross/orchestkit/commit/e31096e7624424e1c37c2e7baaabccf8c6b782d6))",
+          "restrict workflow-level permissions to read-all in release-please ([#820](https://github.com/yonatangross/orchestkit/issues/820)) ([8e03fe5](https://github.com/yonatangross/orchestkit/commit/8e03fe5eca022aa71a65820e47cd5dac652380f9))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "6.5.3",
     "date": "2026-02-23",
     "compareUrl": "",
@@ -844,7 +1540,51 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     "version": "6.5.1",
     "date": "2026-02-23",
     "compareUrl": "",
-    "sections": []
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "Add `presentation-builder` skill — zero-dependency HTML slide presentations with viewport fitting, 12 style presets, PPT conversion, and keyboard/touch navigation (adopted from zarazhangrui/frontend-slides, restructured into OrchestKit format)",
+          "Skill count: 67 → 68 skills, 28 → 29 user-invocable"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.5.0",
+    "date": "2026-02-22",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "dead code cleanup & PostToolUse consolidation ([#684](https://github.com/yonatangross/orchestkit/issues/684)) ([#790](https://github.com/yonatangross/orchestkit/issues/790)) ([da245ac](https://github.com/yonatangross/orchestkit/commit/da245ac82c587763b95269c62bf2b9f3c44115d3))",
+          "**docs:** add Vercel Analytics, Speed Insights, and dynamic social proof ([#809](https://github.com/yonatangross/orchestkit/issues/809), [#810](https://github.com/yonatangross/orchestkit/issues/810)) ([#812](https://github.com/yonatangross/orchestkit/issues/812)) ([714af85](https://github.com/yonatangross/orchestkit/commit/714af856d4983c2d87d7b5c936c9284e549b003f))",
+          "integrate Claude Code 2.1.50 features ([#805](https://github.com/yonatangross/orchestkit/issues/805)) ([60a16d2](https://github.com/yonatangross/orchestkit/commit/60a16d210227a343364266c7e3b0ee544f80af0e))",
+          "security hardening & hook consolidation (Milestone [#72](https://github.com/yonatangross/orchestkit/issues/72)) ([#788](https://github.com/yonatangross/orchestkit/issues/788)) ([5f014b4](https://github.com/yonatangross/orchestkit/commit/5f014b477d7e4aad04fbaeb13d8b72db08edc19a))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "eliminate 32 code scanning alerts (19 CodeQL + 13 Scorecard) ([#792](https://github.com/yonatangross/orchestkit/issues/792)) ([12e796b](https://github.com/yonatangross/orchestkit/commit/12e796b5a715b930f43eaa8e08d9fa38603e867d))",
+          "eliminate 91 CodeQL alerts + fix 30 pre-existing test failures ([#782](https://github.com/yonatangross/orchestkit/issues/782)) ([ca47641](https://github.com/yonatangross/orchestkit/commit/ca476416b81c217998af5e9b5305b44a4b6ffa8a))",
+          "**release:** scope release-please from v6.1.0 to prevent 7.0.0 ([#786](https://github.com/yonatangross/orchestkit/issues/786)) ([83a248b](https://github.com/yonatangross/orchestkit/commit/83a248b522313c453fa9fbdeb5e020998542350f))",
+          "remove 35 broken symlinks from .claude/ ([#813](https://github.com/yonatangross/orchestkit/issues/813)) ([3bd179c](https://github.com/yonatangross/orchestkit/commit/3bd179c919b8367fbe100f0080fe3e263b002472))",
+          "sync manifests and pyproject.toml to v6.3.0 ([#806](https://github.com/yonatangross/orchestkit/issues/806)) ([d06661d](https://github.com/yonatangross/orchestkit/commit/d06661d18a3386367c8a1c3ae06b071a657c885c))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 6.1.3 ([#787](https://github.com/yonatangross/orchestkit/issues/787)) ([612ad89](https://github.com/yonatangross/orchestkit/commit/612ad8939f4a456ea5714212f96dab9cf6eca75a))",
+          "**main:** release 6.2.0 ([#789](https://github.com/yonatangross/orchestkit/issues/789)) ([54042ff](https://github.com/yonatangross/orchestkit/commit/54042ff5f4a4e654e9bb05708a752cd71ce10a97))",
+          "**main:** release 6.2.0 ([#791](https://github.com/yonatangross/orchestkit/issues/791)) ([a37b5d4](https://github.com/yonatangross/orchestkit/commit/a37b5d40ec2c5d3af330af6e3263d16a2b961685))",
+          "**main:** release 6.3.0 ([#793](https://github.com/yonatangross/orchestkit/issues/793)) ([737982c](https://github.com/yonatangross/orchestkit/commit/737982c15349dcd24a92cd04993b46c09b2a37a0))",
+          "**main:** release 6.4.0 ([#808](https://github.com/yonatangross/orchestkit/issues/808)) ([bfbdbf3](https://github.com/yonatangross/orchestkit/commit/bfbdbf3c6d4d8c6945ddc0430cb52d28ba5e132b))"
+        ]
+      }
+    ]
   },
   {
     "version": "6.4.1",
@@ -855,6 +1595,62 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
         "type": "fixed",
         "items": [
           "TODO: Describe your changes here"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.4.0",
+    "date": "2026-02-22",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "**docs:** add Vercel Analytics, Speed Insights, and dynamic social proof ([#809](https://github.com/yonatangross/orchestkit/issues/809), [#810](https://github.com/yonatangross/orchestkit/issues/810)) ([#812](https://github.com/yonatangross/orchestkit/issues/812)) ([714af85](https://github.com/yonatangross/orchestkit/commit/714af856d4983c2d87d7b5c936c9284e549b003f))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "sync manifests and pyproject.toml to v6.3.0 ([#806](https://github.com/yonatangross/orchestkit/issues/806)) ([d06661d](https://github.com/yonatangross/orchestkit/commit/d06661d18a3386367c8a1c3ae06b071a657c885c))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.3.0",
+    "date": "2026-02-21",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "sync manifests and pyproject.toml to v6.3.0 (release-please gap)"
+        ]
+      },
+      {
+        "type": "added",
+        "items": [
+          "dead code cleanup & PostToolUse consolidation ([#684](https://github.com/yonatangross/orchestkit/issues/684)) ([#790](https://github.com/yonatangross/orchestkit/issues/790)) ([da245ac](https://github.com/yonatangross/orchestkit/commit/da245ac82c587763b95269c62bf2b9f3c44115d3))",
+          "integrate Claude Code 2.1.50 features ([#805](https://github.com/yonatangross/orchestkit/issues/805)) ([60a16d2](https://github.com/yonatangross/orchestkit/commit/60a16d210227a343364266c7e3b0ee544f80af0e))",
+          "security hardening & hook consolidation (Milestone [#72](https://github.com/yonatangross/orchestkit/issues/72)) ([#788](https://github.com/yonatangross/orchestkit/issues/788)) ([5f014b4](https://github.com/yonatangross/orchestkit/commit/5f014b477d7e4aad04fbaeb13d8b72db08edc19a))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "eliminate 32 code scanning alerts (19 CodeQL + 13 Scorecard) ([#792](https://github.com/yonatangross/orchestkit/issues/792)) ([12e796b](https://github.com/yonatangross/orchestkit/commit/12e796b5a715b930f43eaa8e08d9fa38603e867d))",
+          "eliminate 91 CodeQL alerts + fix 30 pre-existing test failures ([#782](https://github.com/yonatangross/orchestkit/issues/782)) ([ca47641](https://github.com/yonatangross/orchestkit/commit/ca476416b81c217998af5e9b5305b44a4b6ffa8a))",
+          "**release:** scope release-please from v6.1.0 to prevent 7.0.0 ([#786](https://github.com/yonatangross/orchestkit/issues/786)) ([83a248b](https://github.com/yonatangross/orchestkit/commit/83a248b522313c453fa9fbdeb5e020998542350f))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 6.1.3 ([#787](https://github.com/yonatangross/orchestkit/issues/787)) ([612ad89](https://github.com/yonatangross/orchestkit/commit/612ad8939f4a456ea5714212f96dab9cf6eca75a))",
+          "**main:** release 6.2.0 ([#789](https://github.com/yonatangross/orchestkit/issues/789)) ([54042ff](https://github.com/yonatangross/orchestkit/commit/54042ff5f4a4e654e9bb05708a752cd71ce10a97))",
+          "**main:** release 6.2.0 ([#791](https://github.com/yonatangross/orchestkit/issues/791)) ([a37b5d4](https://github.com/yonatangross/orchestkit/commit/a37b5d40ec2c5d3af330af6e3263d16a2b961685))"
         ]
       }
     ]
@@ -919,6 +1715,34 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     ]
   },
   {
+    "version": "6.2.0",
+    "date": "2026-02-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "dead code cleanup & PostToolUse consolidation ([#684](https://github.com/yonatangross/orchestkit/issues/684)) ([#790](https://github.com/yonatangross/orchestkit/issues/790)) ([da245ac](https://github.com/yonatangross/orchestkit/commit/da245ac82c587763b95269c62bf2b9f3c44115d3))",
+          "security hardening & hook consolidation (Milestone [#72](https://github.com/yonatangross/orchestkit/issues/72)) ([#788](https://github.com/yonatangross/orchestkit/issues/788)) ([5f014b4](https://github.com/yonatangross/orchestkit/commit/5f014b477d7e4aad04fbaeb13d8b72db08edc19a))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "eliminate 91 CodeQL alerts + fix 30 pre-existing test failures ([#782](https://github.com/yonatangross/orchestkit/issues/782)) ([ca47641](https://github.com/yonatangross/orchestkit/commit/ca476416b81c217998af5e9b5305b44a4b6ffa8a))",
+          "**release:** scope release-please from v6.1.0 to prevent 7.0.0 ([#786](https://github.com/yonatangross/orchestkit/issues/786)) ([83a248b](https://github.com/yonatangross/orchestkit/commit/83a248b522313c453fa9fbdeb5e020998542350f))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**main:** release 6.1.3 ([#787](https://github.com/yonatangross/orchestkit/issues/787)) ([612ad89](https://github.com/yonatangross/orchestkit/commit/612ad8939f4a456ea5714212f96dab9cf6eca75a))",
+          "**main:** release 6.2.0 ([#789](https://github.com/yonatangross/orchestkit/issues/789)) ([54042ff](https://github.com/yonatangross/orchestkit/commit/54042ff5f4a4e654e9bb05708a752cd71ce10a97))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "6.1.4",
     "date": "2026-02-20",
     "compareUrl": "",
@@ -943,6 +1767,33 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
         "type": "fixed",
         "items": [
           "skill-edit-tracker path bug (missing `context/` segment in session state path)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.2.0",
+    "date": "2026-02-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "security hardening & hook consolidation (Milestone [#72](https://github.com/yonatangross/orchestkit/issues/72)) ([#788](https://github.com/yonatangross/orchestkit/issues/788)) ([5f014b4](https://github.com/yonatangross/orchestkit/commit/5f014b477d7e4aad04fbaeb13d8b72db08edc19a))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.1.3",
+    "date": "2026-02-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "eliminate 91 CodeQL alerts + fix 30 pre-existing test failures ([#782](https://github.com/yonatangross/orchestkit/issues/782)) ([ca47641](https://github.com/yonatangross/orchestkit/commit/ca476416b81c217998af5e9b5305b44a4b6ffa8a))",
+          "**release:** scope release-please from v6.1.0 to prevent 7.0.0 ([#786](https://github.com/yonatangross/orchestkit/issues/786)) ([83a248b](https://github.com/yonatangross/orchestkit/commit/83a248b522313c453fa9fbdeb5e020998542350f))"
         ]
       }
     ]
@@ -975,6 +1826,19 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
     ]
   },
   {
+    "version": "6.1.0",
+    "date": "2026-02-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "CC 2.1.49 full adoption — hooks, agents, MCP overhaul ([#780](https://github.com/yonatangross/orchestkit/issues/780)) ([1234c46](https://github.com/yonatangross/orchestkit/commit/1234c462436aafcfa9027b08d93324db407219e2))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "6.0.27",
     "date": "2026-02-20",
     "compareUrl": "",
@@ -985,6 +1849,48 @@ export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
           "Eliminate 30 CodeQL ReDoS vulnerabilities (js/polynomial-redos) across 12 hook files",
           "Replace polynomial-time regex patterns with O(n) string operations",
           "Dismiss 1 Dependabot alert (ajv ReDoS in demo project — tolerable risk)"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.0.26",
+    "date": "2026-02-20",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "changed",
+        "items": [
+          "**deps-dev:** bump hono ([#761](https://github.com/yonatangross/orchestkit/issues/761)) ([fdc6f69](https://github.com/yonatangross/orchestkit/commit/fdc6f6916abebe40ef923a531b85d31c8b72b8dd))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "2026 best practices — permissions, CodeQL, SLSA, merge queue ([57ca595](https://github.com/yonatangross/orchestkit/commit/57ca595f27295787c33ed47bbb35e7472d7db88d))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "6.0.25",
+    "date": "2026-02-19",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**ci:** skip version check for Dependabot PRs ([#758](https://github.com/yonatangross/orchestkit/issues/758)) ([45c850f](https://github.com/yonatangross/orchestkit/commit/45c850fe890ad0a9900361baba8a6ad18c44fadf))",
+          "**ci:** use PAT for release-please to trigger CI on release PRs ([#760](https://github.com/yonatangross/orchestkit/issues/760)) ([5e8c700](https://github.com/yonatangross/orchestkit/commit/5e8c700d3a0d666a13c8f9aba9eb58e9371d7103))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump actions/download-artifact from 5.0.0 to 7.0.0 ([#755](https://github.com/yonatangross/orchestkit/issues/755)) ([c28f49b](https://github.com/yonatangross/orchestkit/commit/c28f49b0b8a7c7dc7ee80a3cfeb969f79d8fb387))",
+          "bump actions/upload-artifact from 5.0.0 to 6.0.0 ([#753](https://github.com/yonatangross/orchestkit/issues/753)) ([4a4f9e0](https://github.com/yonatangross/orchestkit/commit/4a4f9e0d8eb1a56f3c6551798695cc8422ad61ce))",
+          "bump gitleaks/gitleaks-action ([#756](https://github.com/yonatangross/orchestkit/issues/756)) ([b929e1b](https://github.com/yonatangross/orchestkit/commit/b929e1b872268f02b64a42a5e75bf9b5b60e4f86))",
+          "bump googleapis/release-please-action ([#754](https://github.com/yonatangross/orchestkit/issues/754)) ([8028579](https://github.com/yonatangross/orchestkit/commit/8028579b5178e18d08c9278fcce575e32e332d9d))"
         ]
       }
     ]

--- a/scripts/generate-changelog-data.js
+++ b/scripts/generate-changelog-data.js
@@ -30,14 +30,27 @@ const SECTION_TYPES = new Set([
   "security",
 ]);
 
+// Map release-please section names to Keep a Changelog types
+const SECTION_ALIASES = {
+  features: "added",
+  "bug fixes": "fixed",
+  miscellaneous: "changed",
+  documentation: "changed",
+  "code refactoring": "changed",
+  performance: "changed",
+  "ci/cd": "changed",
+};
+
 const entries = [];
 let current = null;
 let currentSection = null;
 
 for (const line of lines) {
-  // Version header: ## [6.0.16] - 2026-02-16
+  // Version header — two formats:
+  //   Keep a Changelog: ## [6.0.16] - 2026-02-16
+  //   Release-please:   ## [7.16.0](https://...) (2026-03-20)
   const versionMatch = line.match(
-    /^## \[([^\]]+)\]\s*-\s*(\d{4}-\d{2}-\d{2})/
+    /^## \[([^\]]+)\](?:\([^)]*\))?\s*[-–—]?\s*\(?(\d{4}-\d{2}-\d{2})\)?/
   );
   if (versionMatch) {
     if (current) entries.push(current);
@@ -52,10 +65,11 @@ for (const line of lines) {
     continue;
   }
 
-  // Section header: ### Added, ### Fixed, etc.
-  const sectionMatch = line.match(/^### (\w+)/);
+  // Section header: ### Added, ### Fixed, ### Features, ### Bug Fixes, etc.
+  const sectionMatch = line.match(/^### (.+)$/);
   if (sectionMatch && current) {
-    const type = sectionMatch[1].toLowerCase();
+    const rawType = sectionMatch[1].toLowerCase().trim();
+    const type = SECTION_ALIASES[rawType] || rawType;
     if (SECTION_TYPES.has(type)) {
       currentSection = { type, items: [] };
       current.sections.push(currentSection);
@@ -65,10 +79,11 @@ for (const line of lines) {
     continue;
   }
 
-  // Bullet item
-  if (line.match(/^- /) && currentSection) {
-    currentSection.items.push(line.slice(2));
-  } else if (line.match(/^\s+- /) && currentSection && currentSection.items.length > 0) {
+  // Bullet item (- or * prefix)
+  const bulletMatch = line.match(/^[-*] (.+)/);
+  if (bulletMatch && currentSection) {
+    currentSection.items.push(bulletMatch[1]);
+  } else if (line.match(/^\s+[-*] /) && currentSection && currentSection.items.length > 0) {
     // Sub-bullet — append to last item
     currentSection.items[currentSection.items.length - 1] += "\n" + line;
   }


### PR DESCRIPTION
## Summary
- Changelog parser only handled Keep a Changelog format, missing all release-please entries
- Added version regex for `## [x.y.z](url) (date)` format
- Added section aliases: Features→added, Bug Fixes→fixed, Miscellaneous→changed
- Added `*` bullet support (release-please uses `*`, not `-`)

## Result
79 → 106 versions parsed. v7.14.0, v7.14.1, v7.16.0 and 24 other release-please versions recovered.

## Test plan
- [ ] Changelog page shows all versions through v7.16.0
- [ ] Both manual entries and release-please entries render correctly