### PR TITLE
feat(skills): update notebooklm for v0.5.2 + cinematic video overviews

### DIFF
--- a/plugins/ork/skills/notebooklm/SKILL.md
+++ b/plugins/ork/skills/notebooklm/SKILL.md
@@ -3,9 +3,9 @@ name: notebooklm
 license: MIT
 compatibility: "Claude Code 2.1.76+."
 author: OrchestKit
-description: "NotebookLM integration patterns for external RAG, research synthesis, studio content generation, and knowledge management. Use when creating notebooks, adding sources, generating audio/video, or querying NotebookLM via MCP."
-version: 1.1.0
-tags: [notebooklm, mcp, rag, google, podcast, research, knowledge-management]
+description: "NotebookLM integration patterns for external RAG, research synthesis, studio content generation (audio, cinematic video, slides, infographics, mind maps), and knowledge management. Use when creating notebooks, adding sources, generating audio/video, or querying NotebookLM via MCP."
+version: 1.2.0
+tags: [notebooklm, mcp, rag, google, podcast, video, cinematic, research, knowledge-management]
 user-invocable: false
 disable-model-invocation: true
 context: fork
@@ -26,9 +26,19 @@ allowed-tools:
 
 # NotebookLM
 
-NotebookLM = external RAG engine that offloads reading from your context window. Uses the `notebooklm-mcp-cli` MCP server (PyPI, v0.4.8+) to create notebooks, manage sources, generate content, and query with grounded AI responses. Supports batch operations across notebooks, pipelines, and multilingual content generation.
+NotebookLM = external RAG engine that offloads reading from your context window. Uses the `notebooklm-mcp-cli` MCP server (PyPI, v0.5.0+) to create notebooks, manage sources, generate content, and query with grounded AI responses. Supports batch operations across notebooks, pipelines, and multilingual content generation.
 
 > **Disclaimer**: Uses internal undocumented Google APIs via browser authentication. Sessions last ~20 minutes. API may change without notice.
+
+### What's New (March 2026)
+
+- **Cinematic Video Overviews** (Mar 4) — fully animated narrated videos powered by Gemini 3 + Veo 3. Google AI Ultra only, 20/day limit, English only.
+- **4 Audio Formats** — Brief, Critique, Debate, Deep Dive (was single podcast style)
+- **8x Source Capacity** — 8x more source material per conversation, 6x extended memory
+- **Per-Slide Editing** — `studio_revise` edits individual slides without regenerating the full deck
+- **3-Panel UI** — Sources / Chat / Studio layout on notebooklm.google.com
+- **Research timeout** (v0.5.0) — `research_import` now configurable via `--timeout` / `timeout` param (default 300s, was 120s)
+- **Deep research errors** (v0.5.1) — `RPCError` class with error codes, auto-retry on transient API failures
 
 ## Prerequisites
 
@@ -61,7 +71,7 @@ What are you trying to do?
 │   └── Configure chat style ────► chat_configure
 │
 ├── Generate studio content
-│   ├── 9 artifact types ────────► rules/workflow-studio-content.md
+│   ├── 10 artifact types ───────► rules/workflow-studio-content.md
 │   ├── Revise slides ───────────► studio_revise (creates new deck)
 │   └── Export to Docs/Sheets ──► export_artifact
 │
@@ -96,7 +106,7 @@ What are you trying to do?
 | **Workflows** | `workflow-second-brain.md` | HIGH | Decision docs, project hub, agent interop |
 | **Workflows** | `workflow-research-offload.md` | HIGH | Synthesis, onboarding, token savings |
 | **Workflows** | `workflow-knowledge-base.md` | HIGH | Debugging KB, security handbook, team knowledge |
-| **Workflows** | `workflow-studio-content.md` | MEDIUM | 9 artifact types (audio overview, deep dive, slides...) |
+| **Workflows** | `workflow-studio-content.md` | HIGH | 10 artifact types (audio, cinematic video, slides, infographics, mind maps...) |
 | **Research** | `workflow-research-discovery.md` | HIGH | Web/Drive research async flow |
 | **Collaboration** | `workflow-sharing-collaboration.md` | MEDIUM | Public links, collaborator invites, batch sharing |
 | **Batch** | `workflow-batch-pipelines.md` | HIGH | Cross-notebook queries, batch ops, pipelines |
@@ -122,7 +132,7 @@ What are you trying to do?
 | Tags | tags (organize and smart-select notebooks) | 1 |
 | Auth | save_auth_tokens, refresh_auth, server_info | 3 |
 
-**Total: 37 tools across 13 groups** (v0.4.8+)
+**Total: 37 tools across 13 groups** (v0.5.0+)
 
 ## Key Decisions
 
@@ -133,7 +143,10 @@ What are you trying to do?
 | Large sources | Split >50K chars into multiple sources for better retrieval |
 | Auth expired? | `nlm login --check`; sessions last ~20 min, re-auth with `nlm login` |
 | Studio content | Use studio_create, poll with studio_status (generation takes 2-5 min) |
-| Research discovery | research_start for web/Drive discovery, then research_import to add findings |
+| Cinematic video | `studio_create(artifact_type="cinematic_video")` — requires Ultra, English only, 20/day |
+| Audio format | Choose brief/critique/debate/deep_dive via `audio_format` param |
+| Research discovery | research_start for web/Drive discovery, then research_import (timeout=300s default) |
+| Deep research | `research_start(mode="deep")` for multi-source synthesis (v0.5.1+, auto-retries) |
 | Release notebooks | One notebook per minor version; upload CHANGELOG + key skill diffs as sources |
 | Query vs search | notebook_query for AI-grounded answers; source_get_content for raw text |
 | Notes vs sources | Notes for your insights/annotations; sources for external documents |
@@ -162,7 +175,11 @@ notebook_query(notebook_id="...", query="What are the key differences between OA
 studio_create(notebook_id="...", artifact_type="audio", audio_format="deep_dive", language="he", confirm=True)
 studio_status(notebook_id="...")  # Poll until complete
 
-# 5. Capture insights as notes
+# 5. Generate a cinematic video overview (Ultra only, English)
+studio_create(notebook_id="...", artifact_type="cinematic_video", confirm=True)
+studio_status(notebook_id="...")  # Poll — takes 3-8 minutes
+
+# 6. Capture insights as notes
 note(notebook_id="...", action="create", content="Key takeaway: PKCE is mandatory in 2.1")
 ```
 

--- a/plugins/ork/skills/notebooklm/rules/workflow-research-discovery.md
+++ b/plugins/ork/skills/notebooklm/rules/workflow-research-discovery.md
@@ -31,9 +31,17 @@ task = research_start(
 status = research_status(task_id=task.id)
 # status: "searching" | "analyzing" | "completed"
 
-# 3. Import discovered sources into notebook
-research_import(task_id=task.id, notebook_id="...")
+# 3. Import discovered sources into notebook (v0.5.0+: timeout configurable)
+research_import(task_id=task.id, notebook_id="...", timeout=300)
 # Adds the most relevant discovered sources automatically
+# Default timeout is 300s (was 120s pre-0.5.0). Use --timeout in CLI.
+```
+
+**Deep research mode** (v0.5.1+):
+```
+# Deep research for comprehensive multi-source synthesis
+research_start(notebook_id="...", topic="...", mode="deep")
+# Transient API errors now auto-retry with RPCError handling
 ```
 
 **Key rules:**
@@ -41,5 +49,7 @@ research_import(task_id=task.id, notebook_id="...")
 - Always poll with `research_status` -- research takes 1-3 minutes
 - Research uses Google API quota -- avoid running many parallel research tasks
 - Import results with `research_import` to add discovered sources to your notebook
+- For notebooks with many sources, increase `timeout` on `research_import` (default 300s, was 120s)
+- Use `mode="deep"` for comprehensive synthesis -- transient errors are now auto-retried (v0.5.1+)
 - Combine web and Drive sources for comprehensive coverage
 - Follow up with `notebook_query` to synthesize the newly imported sources

--- a/plugins/ork/skills/notebooklm/rules/workflow-studio-content.md
+++ b/plugins/ork/skills/notebooklm/rules/workflow-studio-content.md
@@ -2,12 +2,12 @@
 title: "Studio Content Generation"
 impact: MEDIUM
 impactDescription: "Studio artifacts take 2-5 minutes; without polling pattern, users wait blindly"
-tags: [studio, podcast, video, content-generation]
+tags: [studio, podcast, video, cinematic, content-generation]
 ---
 
 ## Studio Content Generation
 
-NotebookLM Studio generates 9 artifact types from notebook sources. All generation is async -- create, poll status, then download.
+NotebookLM Studio generates 10 artifact types from notebook sources. All generation is async -- create, poll status, then download.
 
 **Incorrect -- calling studio_create and waiting synchronously:**
 ```
@@ -29,11 +29,12 @@ status = studio_status(artifact_id=artifact.id)
 download_artifact(artifact_id=artifact.id, path="./output/podcast.mp3")
 ```
 
-**All 9 studio artifact types:**
+**All 10 studio artifact types:**
 | Type | Output | Use case |
 |------|--------|----------|
-| `audio_overview` | MP3 podcast | Summarize sources as conversational audio |
-| `video_overview` | MP4 video | Visual summary with narration |
+| `audio_overview` | MP3 podcast | Summarize sources as conversational audio (4 formats: brief, critique, debate, deep_dive) |
+| `video_overview` | MP4 video | Visual summary with narration (slides + voiceover) |
+| `cinematic_video` | MP4 video | Fully animated cinematic video (Gemini 3 + Veo 3). **Requires Google AI Ultra**, English only, max 20/day |
 | `mind_map` | SVG/PNG | Visual topic relationships |
 | `quiz` | JSON | Test comprehension of sources |
 | `flashcards` | JSON | Study aid from source material |

--- a/src/skills/notebooklm/SKILL.md
+++ b/src/skills/notebooklm/SKILL.md
@@ -3,9 +3,9 @@ name: notebooklm
 license: MIT
 compatibility: "Claude Code 2.1.76+."
 author: OrchestKit
-description: "NotebookLM integration patterns for external RAG, research synthesis, studio content generation, and knowledge management. Use when creating notebooks, adding sources, generating audio/video, or querying NotebookLM via MCP."
-version: 1.1.0
-tags: [notebooklm, mcp, rag, google, podcast, research, knowledge-management]
+description: "NotebookLM integration patterns for external RAG, research synthesis, studio content generation (audio, cinematic video, slides, infographics, mind maps), and knowledge management. Use when creating notebooks, adding sources, generating audio/video, or querying NotebookLM via MCP."
+version: 1.2.0
+tags: [notebooklm, mcp, rag, google, podcast, video, cinematic, research, knowledge-management]
 user-invocable: false
 disable-model-invocation: true
 context: fork
@@ -26,9 +26,19 @@ allowed-tools:
 
 # NotebookLM
 
-NotebookLM = external RAG engine that offloads reading from your context window. Uses the `notebooklm-mcp-cli` MCP server (PyPI, v0.4.8+) to create notebooks, manage sources, generate content, and query with grounded AI responses. Supports batch operations across notebooks, pipelines, and multilingual content generation.
+NotebookLM = external RAG engine that offloads reading from your context window. Uses the `notebooklm-mcp-cli` MCP server (PyPI, v0.5.0+) to create notebooks, manage sources, generate content, and query with grounded AI responses. Supports batch operations across notebooks, pipelines, and multilingual content generation.
 
 > **Disclaimer**: Uses internal undocumented Google APIs via browser authentication. Sessions last ~20 minutes. API may change without notice.
+
+### What's New (March 2026)
+
+- **Cinematic Video Overviews** (Mar 4) — fully animated narrated videos powered by Gemini 3 + Veo 3. Google AI Ultra only, 20/day limit, English only.
+- **4 Audio Formats** — Brief, Critique, Debate, Deep Dive (was single podcast style)
+- **8x Source Capacity** — 8x more source material per conversation, 6x extended memory
+- **Per-Slide Editing** — `studio_revise` edits individual slides without regenerating the full deck
+- **3-Panel UI** — Sources / Chat / Studio layout on notebooklm.google.com
+- **Research timeout** (v0.5.0) — `research_import` now configurable via `--timeout` / `timeout` param (default 300s, was 120s)
+- **Deep research errors** (v0.5.1) — `RPCError` class with error codes, auto-retry on transient API failures
 
 ## Prerequisites
 
@@ -61,7 +71,7 @@ What are you trying to do?
 │   └── Configure chat style ────► chat_configure
 │
 ├── Generate studio content
-│   ├── 9 artifact types ────────► rules/workflow-studio-content.md
+│   ├── 10 artifact types ───────► rules/workflow-studio-content.md
 │   ├── Revise slides ───────────► studio_revise (creates new deck)
 │   └── Export to Docs/Sheets ──► export_artifact
 │
@@ -96,7 +106,7 @@ What are you trying to do?
 | **Workflows** | `workflow-second-brain.md` | HIGH | Decision docs, project hub, agent interop |
 | **Workflows** | `workflow-research-offload.md` | HIGH | Synthesis, onboarding, token savings |
 | **Workflows** | `workflow-knowledge-base.md` | HIGH | Debugging KB, security handbook, team knowledge |
-| **Workflows** | `workflow-studio-content.md` | MEDIUM | 9 artifact types (audio overview, deep dive, slides...) |
+| **Workflows** | `workflow-studio-content.md` | HIGH | 10 artifact types (audio, cinematic video, slides, infographics, mind maps...) |
 | **Research** | `workflow-research-discovery.md` | HIGH | Web/Drive research async flow |
 | **Collaboration** | `workflow-sharing-collaboration.md` | MEDIUM | Public links, collaborator invites, batch sharing |
 | **Batch** | `workflow-batch-pipelines.md` | HIGH | Cross-notebook queries, batch ops, pipelines |
@@ -122,7 +132,7 @@ What are you trying to do?
 | Tags | tags (organize and smart-select notebooks) | 1 |
 | Auth | save_auth_tokens, refresh_auth, server_info | 3 |
 
-**Total: 37 tools across 13 groups** (v0.4.8+)
+**Total: 37 tools across 13 groups** (v0.5.0+)
 
 ## Key Decisions
 
@@ -133,7 +143,10 @@ What are you trying to do?
 | Large sources | Split >50K chars into multiple sources for better retrieval |
 | Auth expired? | `nlm login --check`; sessions last ~20 min, re-auth with `nlm login` |
 | Studio content | Use studio_create, poll with studio_status (generation takes 2-5 min) |
-| Research discovery | research_start for web/Drive discovery, then research_import to add findings |
+| Cinematic video | `studio_create(artifact_type="cinematic_video")` — requires Ultra, English only, 20/day |
+| Audio format | Choose brief/critique/debate/deep_dive via `audio_format` param |
+| Research discovery | research_start for web/Drive discovery, then research_import (timeout=300s default) |
+| Deep research | `research_start(mode="deep")` for multi-source synthesis (v0.5.1+, auto-retries) |
 | Release notebooks | One notebook per minor version; upload CHANGELOG + key skill diffs as sources |
 | Query vs search | notebook_query for AI-grounded answers; source_get_content for raw text |
 | Notes vs sources | Notes for your insights/annotations; sources for external documents |
@@ -162,7 +175,11 @@ notebook_query(notebook_id="...", query="What are the key differences between OA
 studio_create(notebook_id="...", artifact_type="audio", audio_format="deep_dive", language="he", confirm=True)
 studio_status(notebook_id="...")  # Poll until complete
 
-# 5. Capture insights as notes
+# 5. Generate a cinematic video overview (Ultra only, English)
+studio_create(notebook_id="...", artifact_type="cinematic_video", confirm=True)
+studio_status(notebook_id="...")  # Poll — takes 3-8 minutes
+
+# 6. Capture insights as notes
 note(notebook_id="...", action="create", content="Key takeaway: PKCE is mandatory in 2.1")
 ```
 

--- a/src/skills/notebooklm/rules/workflow-research-discovery.md
+++ b/src/skills/notebooklm/rules/workflow-research-discovery.md
@@ -31,9 +31,17 @@ task = research_start(
 status = research_status(task_id=task.id)
 # status: "searching" | "analyzing" | "completed"
 
-# 3. Import discovered sources into notebook
-research_import(task_id=task.id, notebook_id="...")
+# 3. Import discovered sources into notebook (v0.5.0+: timeout configurable)
+research_import(task_id=task.id, notebook_id="...", timeout=300)
 # Adds the most relevant discovered sources automatically
+# Default timeout is 300s (was 120s pre-0.5.0). Use --timeout in CLI.
+```
+
+**Deep research mode** (v0.5.1+):
+```
+# Deep research for comprehensive multi-source synthesis
+research_start(notebook_id="...", topic="...", mode="deep")
+# Transient API errors now auto-retry with RPCError handling
 ```
 
 **Key rules:**
@@ -41,5 +49,7 @@ research_import(task_id=task.id, notebook_id="...")
 - Always poll with `research_status` -- research takes 1-3 minutes
 - Research uses Google API quota -- avoid running many parallel research tasks
 - Import results with `research_import` to add discovered sources to your notebook
+- For notebooks with many sources, increase `timeout` on `research_import` (default 300s, was 120s)
+- Use `mode="deep"` for comprehensive synthesis -- transient errors are now auto-retried (v0.5.1+)
 - Combine web and Drive sources for comprehensive coverage
 - Follow up with `notebook_query` to synthesize the newly imported sources

--- a/src/skills/notebooklm/rules/workflow-studio-content.md
+++ b/src/skills/notebooklm/rules/workflow-studio-content.md
@@ -2,12 +2,12 @@
 title: "Studio Content Generation"
 impact: MEDIUM
 impactDescription: "Studio artifacts take 2-5 minutes; without polling pattern, users wait blindly"
-tags: [studio, podcast, video, content-generation]
+tags: [studio, podcast, video, cinematic, content-generation]
 ---
 
 ## Studio Content Generation
 
-NotebookLM Studio generates 9 artifact types from notebook sources. All generation is async -- create, poll status, then download.
+NotebookLM Studio generates 10 artifact types from notebook sources. All generation is async -- create, poll status, then download.
 
 **Incorrect -- calling studio_create and waiting synchronously:**
 ```
@@ -29,11 +29,12 @@ status = studio_status(artifact_id=artifact.id)
 download_artifact(artifact_id=artifact.id, path="./output/podcast.mp3")
 ```
 
-**All 9 studio artifact types:**
+**All 10 studio artifact types:**
 | Type | Output | Use case |
 |------|--------|----------|
-| `audio_overview` | MP3 podcast | Summarize sources as conversational audio |
-| `video_overview` | MP4 video | Visual summary with narration |
+| `audio_overview` | MP3 podcast | Summarize sources as conversational audio (4 formats: brief, critique, debate, deep_dive) |
+| `video_overview` | MP4 video | Visual summary with narration (slides + voiceover) |
+| `cinematic_video` | MP4 video | Fully animated cinematic video (Gemini 3 + Veo 3). **Requires Google AI Ultra**, English only, max 20/day |
 | `mind_map` | SVG/PNG | Visual topic relationships |
 | `quiz` | JSON | Test comprehension of sources |
 | `flashcards` | JSON | Study aid from source material |


### PR DESCRIPTION
## Summary
- Bump notebooklm-mcp-cli reference from v0.4.8 to v0.5.0+
- Add cinematic video overviews (Mar 4 — Gemini 3 + Veo 3, Ultra only, 20/day)
- Document research_import timeout param (v0.5.0: 120s→300s configurable)
- Add deep research mode with RPCError auto-retry (v0.5.1+)
- Update artifact types from 9 to 10, add What's New section
- Document 4 audio format types in key decisions

## Test plan
- [ ] Build passes (93 skills)
- [ ] Skill under 500 lines (204 lines)
- [ ] notebooklm rules reference cinematic_video correctly