### PR TITLE
feat(docs): redesign landing page from Claude Design handoff (Closes #1247)

### DIFF
--- a/docs/feat--docs-landing-claude-design-1247/playground.html
+++ b/docs/feat--docs-landing-claude-design-1247/playground.html
@@ -1,0 +1,947 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>OrchestKit — Landing</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  /* ----- Tokens ----- */
+  :root {
+    --bg: #fafbfc;
+    --surface-sunken: #f5f7f9;
+    --surface-raised: #ffffff;
+    --fg: #0f172a;
+    --muted: #f1f5f9;
+    --muted-fg: #64748b;
+    --card: #f3f6f8;
+    --border: #e2e8f0;
+    --border-strong: #cbd5e1;
+    --primary-h: 163;
+    --primary-c: 0.145;
+    --primary-l: 0.596;
+    --primary: oklch(var(--primary-l) var(--primary-c) var(--primary-h));
+    --primary-hover: oklch(0.54 0.15 var(--primary-h));
+    --primary-10: color-mix(in oklch, var(--primary) 10%, transparent);
+    --primary-20: color-mix(in oklch, var(--primary) 20%, transparent);
+    --primary-25: color-mix(in oklch, var(--primary) 25%, transparent);
+    --ring: color-mix(in oklch, var(--primary) 25%, transparent);
+
+    --dot-opacity: 0.04;
+    --hero-gradient: 0.6;
+    --card-pad-y: 20px;
+    --card-pad-x: 22px;
+    --grid-gap: 14px;
+
+    --ff-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --ff-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, monospace;
+  }
+
+  :root[data-theme="dark"] {
+    --bg: #0c0f14;
+    --surface-sunken: #090c11;
+    --surface-raised: #141a24;
+    --fg: #e2e8f0;
+    --muted: #1c2436;
+    --muted-fg: #94a3b8;
+    --card: #111621;
+    --border: #1e293b;
+    --border-strong: #27364d;
+    --primary-l: 0.69;
+    --primary: oklch(var(--primary-l) 0.155 var(--primary-h));
+  }
+
+  :root[data-density="compact"] {
+    --card-pad-y: 14px;
+    --card-pad-x: 16px;
+    --grid-gap: 10px;
+  }
+  :root[data-density="roomy"] {
+    --card-pad-y: 28px;
+    --card-pad-x: 30px;
+    --grid-gap: 20px;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: var(--ff-sans);
+    background: var(--bg);
+    color: var(--fg);
+    font-size: 15px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    /* Dot grid motif */
+    background-image: radial-gradient(circle at 1px 1px, color-mix(in oklch, var(--fg) calc(var(--dot-opacity) * 100%), transparent) 1px, transparent 0);
+    background-size: 8px 8px;
+    background-position: 0 0;
+  }
+  a { color: inherit; text-decoration: none; }
+  p { margin: 0; }
+  h1, h2, h3, h4 { margin: 0; font-weight: 600; letter-spacing: -0.01em; }
+
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 28px;
+  }
+
+  /* ----- Nav ----- */
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    backdrop-filter: saturate(140%) blur(10px);
+    -webkit-backdrop-filter: saturate(140%) blur(10px);
+    background: color-mix(in oklch, var(--bg) 78%, transparent);
+    border-bottom: 1px solid color-mix(in oklch, var(--border) 70%, transparent);
+  }
+  .nav-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 56px;
+  }
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .brand-mark {
+    width: 22px; height: 22px;
+    border-radius: 5px;
+    background: var(--fg);
+    color: var(--bg);
+    display: grid; place-items: center;
+    font-family: var(--ff-mono);
+    font-weight: 600;
+    font-size: 12px;
+    position: relative;
+  }
+  .brand-mark::after {
+    content: '';
+    position: absolute; inset: 3px;
+    border-radius: 3px;
+    background: var(--primary);
+    mask: radial-gradient(circle at center, #000 38%, transparent 40%);
+    -webkit-mask: radial-gradient(circle at center, #000 38%, transparent 40%);
+  }
+  .nav-links {
+    display: flex;
+    gap: 28px;
+    font-size: 13.5px;
+    color: var(--muted-fg);
+  }
+  .nav-links a:hover { color: var(--fg); }
+  .nav-right {
+    display: flex; align-items: center; gap: 14px;
+  }
+  .nav-right .ghost {
+    font-size: 13.5px; color: var(--muted-fg);
+  }
+  .nav-right .ghost:hover { color: var(--fg); }
+  @media (max-width: 720px) { .nav-links { display: none; } }
+
+  /* ----- Hero ----- */
+  .hero {
+    position: relative;
+    padding: 96px 0 72px;
+    overflow: hidden;
+  }
+  .hero-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(ellipse 80% 60% at 50% 0%,
+        color-mix(in oklch, var(--primary) calc(var(--hero-gradient) * 14%), transparent) 0%,
+        transparent 60%),
+      radial-gradient(ellipse 40% 30% at 50% 10%,
+        color-mix(in oklch, var(--primary) calc(var(--hero-gradient) * 8%), transparent) 0%,
+        transparent 70%);
+  }
+  .hero-inner {
+    position: relative;
+    text-align: center;
+    max-width: 820px;
+    margin: 0 auto;
+  }
+  .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 5px 11px 5px 8px;
+    border-radius: 999px;
+    background: color-mix(in oklch, var(--primary) 10%, transparent);
+    color: var(--primary);
+    font-family: var(--ff-mono);
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0;
+    border: 1px solid color-mix(in oklch, var(--primary) 20%, transparent);
+  }
+  .eyebrow .dot {
+    width: 6px; height: 6px; border-radius: 50%;
+    background: var(--primary);
+    box-shadow: 0 0 0 3px color-mix(in oklch, var(--primary) 20%, transparent);
+  }
+  .hero h1 {
+    font-size: clamp(2rem, 2.5vw + 1.5rem, 4.5rem);
+    line-height: 1.02;
+    letter-spacing: -0.025em;
+    font-weight: 600;
+    margin: 22px 0 20px;
+    color: var(--fg);
+  }
+  .hero h1 .accent {
+    background: linear-gradient(180deg, var(--fg) 0%, color-mix(in oklch, var(--fg) 70%, var(--muted-fg)) 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+  .hero-sub {
+    color: var(--muted-fg);
+    font-size: clamp(0.95rem, 0.3vw + 0.9rem, 1.125rem);
+    max-width: 620px;
+    margin: 0 auto;
+    line-height: 1.55;
+  }
+  .hero-sub .mono {
+    font-family: var(--ff-mono);
+    font-size: 0.92em;
+    color: var(--fg);
+    font-weight: 500;
+  }
+  .hero-sub .divider { opacity: 0.4; margin: 0 6px; }
+  .cta-row {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    margin-top: 32px;
+    flex-wrap: wrap;
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    padding: 0 18px;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    font-family: var(--ff-sans);
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: all 120ms ease;
+    letter-spacing: -0.005em;
+  }
+  .btn-primary {
+    background: var(--primary);
+    color: white;
+    box-shadow: 0 1px 0 0 rgba(255,255,255,0.1) inset, 0 1px 2px 0 color-mix(in oklch, var(--primary) 30%, transparent);
+  }
+  .btn-primary:hover {
+    background: var(--primary-hover);
+    transform: translateY(-0.5px);
+    box-shadow: 0 0 0 4px var(--ring), 0 1px 0 0 rgba(255,255,255,0.1) inset;
+  }
+  .btn-ghost {
+    background: transparent;
+    color: var(--fg);
+    border-color: var(--border);
+  }
+  .btn-ghost:hover {
+    background: var(--muted);
+    border-color: var(--border-strong);
+  }
+  .btn .arrow { transition: transform 150ms ease; }
+  .btn:hover .arrow { transform: translateX(2px); }
+
+  .proof {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0;
+    margin-top: 28px;
+    font-family: var(--ff-mono);
+    font-size: 12px;
+    color: var(--muted-fg);
+    flex-wrap: wrap;
+  }
+  .proof-item {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 0 14px;
+  }
+  .proof-item + .proof-item { border-left: 1px solid var(--border); }
+  .proof-item svg { opacity: 0.7; }
+  .proof-star {
+    color: var(--fg);
+    font-weight: 500;
+  }
+
+  /* ----- Section header ----- */
+  .section-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 18px;
+    gap: 16px;
+  }
+  .section-label {
+    font-family: var(--ff-mono);
+    font-size: 11.5px;
+    font-weight: 500;
+    color: var(--muted-fg);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .section-label::before {
+    content: '';
+    width: 10px; height: 1px;
+    background: var(--muted-fg);
+    opacity: 0.5;
+  }
+  .section-title {
+    font-size: 1.5rem;
+    letter-spacing: -0.015em;
+  }
+  .section-aside {
+    font-size: 13px;
+    color: var(--muted-fg);
+    font-family: var(--ff-mono);
+  }
+
+  /* ----- Value-prop strip ----- */
+  .vprop {
+    padding: 44px 0;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    background: var(--surface-sunken);
+  }
+  .vprop-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: var(--surface-raised);
+    overflow: hidden;
+  }
+  .vprop-card {
+    padding: 26px 28px;
+    position: relative;
+    transition: background 150ms ease;
+    border-left: 3px solid transparent;
+    cursor: pointer;
+  }
+  .vprop-card + .vprop-card {
+    border-left: 1px solid var(--border);
+  }
+  .vprop-card:hover {
+    background: color-mix(in oklch, var(--primary) 3%, var(--surface-raised));
+    border-left: 3px solid var(--primary);
+  }
+  .vprop-card:hover + .vprop-card { border-left: 1px solid var(--border); }
+  .vprop-eyebrow {
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    color: var(--muted-fg);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    margin-bottom: 10px;
+  }
+  .vprop-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-bottom: 6px;
+    letter-spacing: -0.01em;
+  }
+  .vprop-body {
+    font-size: 13.5px;
+    color: var(--muted-fg);
+    line-height: 1.5;
+    margin-bottom: 14px;
+    min-height: 40px;
+  }
+  .vprop-link {
+    font-family: var(--ff-mono);
+    font-size: 12.5px;
+    color: var(--primary);
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .vprop-link .arrow { transition: transform 150ms ease; }
+  .vprop-card:hover .vprop-link .arrow { transform: translateX(3px); }
+
+  @media (max-width: 820px) {
+    .vprop-grid { grid-template-columns: 1fr; }
+    .vprop-card + .vprop-card { border-left: none; border-top: 1px solid var(--border); }
+  }
+
+  /* ----- Cookbook ----- */
+  .cookbook {
+    padding: 72px 0 96px;
+  }
+
+  /* Primitives */
+  .primitives {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--grid-gap);
+    margin-bottom: 44px;
+  }
+  .prim-card {
+    position: relative;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: var(--card-pad-y) var(--card-pad-x);
+    transition: all 150ms ease;
+    overflow: hidden;
+  }
+  .prim-card::before {
+    content: '';
+    position: absolute;
+    top: 0; left: 0; right: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, color-mix(in oklch, var(--primary) 40%, transparent) 50%, transparent 100%);
+    opacity: 0;
+    transition: opacity 150ms ease;
+  }
+  .prim-card:hover {
+    border-color: color-mix(in oklch, var(--primary) 40%, var(--border));
+    box-shadow: 0 0 0 4px var(--ring);
+    transform: translateY(-1px);
+  }
+  .prim-card:hover::before { opacity: 1; }
+  .prim-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    margin-bottom: 20px;
+  }
+  .glyph {
+    width: 38px; height: 38px;
+    border-radius: 8px;
+    background: color-mix(in oklch, var(--primary) 10%, transparent);
+    color: var(--primary);
+    border: 1px solid color-mix(in oklch, var(--primary) 20%, transparent);
+    font-family: var(--ff-mono);
+    font-weight: 600;
+    font-size: 17px;
+    display: grid;
+    place-items: center;
+    letter-spacing: 0;
+  }
+  .prim-tag {
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    color: var(--muted-fg);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding-top: 10px;
+  }
+  .prim-count {
+    font-family: var(--ff-mono);
+    font-size: clamp(2rem, 2vw + 1.2rem, 2.75rem);
+    font-weight: 500;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--fg);
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+  }
+  .prim-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin-top: 10px;
+    margin-bottom: 8px;
+  }
+  .prim-desc {
+    font-size: 13px;
+    color: var(--muted-fg);
+    line-height: 1.55;
+  }
+  .prim-desc .mono {
+    font-family: var(--ff-mono);
+    color: var(--fg);
+    font-size: 0.95em;
+  }
+
+  /* Recipes */
+  .recipes {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: var(--grid-gap);
+  }
+  @media (max-width: 1280px) { .recipes { grid-template-columns: repeat(3, 1fr); } }
+  @media (max-width: 960px) {
+    .primitives { grid-template-columns: 1fr; }
+    .recipes { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 600px) { .recipes { grid-template-columns: 1fr; } }
+
+  .recipe {
+    position: relative;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: var(--card-pad-y) var(--card-pad-x);
+    transition: all 150ms ease;
+    min-height: 148px;
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+  }
+  .recipe:hover {
+    border-color: color-mix(in oklch, var(--primary) 40%, var(--border));
+    box-shadow: 0 0 0 4px var(--ring);
+    transform: translateY(-1px);
+  }
+  .recipe-num {
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    color: var(--muted-fg);
+    letter-spacing: 0.05em;
+    margin-bottom: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .recipe-num .badge {
+    font-family: var(--ff-mono);
+    font-size: 10px;
+    color: var(--primary);
+    background: color-mix(in oklch, var(--primary) 10%, transparent);
+    border: 1px solid color-mix(in oklch, var(--primary) 20%, transparent);
+    padding: 2px 6px;
+    border-radius: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+  .recipe-title {
+    font-size: 15px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+  }
+  .recipe-tag {
+    font-size: 13px;
+    color: var(--muted-fg);
+    line-height: 1.5;
+    flex: 1;
+  }
+  .recipe-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--border);
+    font-family: var(--ff-mono);
+    font-size: 11.5px;
+    color: var(--muted-fg);
+  }
+  .recipe-cmd { color: var(--fg); }
+  .recipe-arrow {
+    color: var(--primary);
+    transition: transform 150ms ease;
+  }
+  .recipe:hover .recipe-arrow { transform: translateX(3px); }
+
+  /* ----- Tweaks panel ----- */
+  .tweaks-panel {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 100;
+    width: 280px;
+    background: var(--surface-raised);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 10px 40px -10px rgba(0,0,0,0.15), 0 0 0 1px color-mix(in oklch, var(--border) 50%, transparent);
+    font-size: 12.5px;
+    display: none;
+    backdrop-filter: blur(10px);
+  }
+  .tweaks-panel[data-open="true"] { display: block; }
+  .tweaks-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 14px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+  }
+  .tweaks-title {
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg);
+  }
+  .tweaks-row {
+    margin-bottom: 12px;
+  }
+  .tweaks-row:last-child { margin-bottom: 0; }
+  .tweaks-row label {
+    display: flex;
+    justify-content: space-between;
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    color: var(--muted-fg);
+    margin-bottom: 6px;
+    letter-spacing: 0.02em;
+  }
+  .tweaks-row label .val { color: var(--fg); }
+  .tweaks-row input[type=range] {
+    width: 100%;
+    accent-color: var(--primary);
+    height: 4px;
+  }
+  .seg {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+    background: var(--muted);
+    border-radius: 6px;
+    padding: 3px;
+  }
+  .seg button {
+    background: transparent;
+    border: none;
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    padding: 5px 4px;
+    border-radius: 4px;
+    color: var(--muted-fg);
+    cursor: pointer;
+    transition: all 120ms ease;
+  }
+  .seg button[data-active="true"] {
+    background: var(--surface-raised);
+    color: var(--fg);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+  }
+  .theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6px 0 0;
+  }
+  .theme-toggle button {
+    background: var(--muted);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 10px;
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    color: var(--fg);
+    cursor: pointer;
+  }
+  .theme-toggle button:hover { background: var(--border); }
+
+</style>
+</head>
+<body data-screen-label="Landing Page">
+
+<!-- ============ NAV ============ -->
+<nav class="nav">
+  <div class="container nav-inner">
+    <a href="#" class="brand">
+      <span class="brand-mark">O</span>
+      <span>OrchestKit</span>
+    </a>
+    <div class="nav-links">
+      <a href="#cookbook">Cookbook</a>
+      <a href="#">Skills</a>
+      <a href="#">Agents</a>
+      <a href="#">Hooks</a>
+      <a href="#">Docs</a>
+    </div>
+    <div class="nav-right">
+      <a href="#" class="ghost">GitHub ↗</a>
+      <a href="#" class="btn btn-ghost" style="height:32px;padding:0 12px;font-size:12.5px;">Install</a>
+    </div>
+  </div>
+</nav>
+
+<!-- ============ HERO ============ -->
+<section class="hero" data-screen-label="Hero">
+  <div class="hero-bg"></div>
+  <div class="container hero-inner">
+    <div class="eyebrow">
+      <span class="dot"></span>
+      <span>The complete AI development toolkit for Claude Code</span>
+    </div>
+    <h1>
+      <span class="accent">Stop explaining your stack.</span><br/>
+      Start shipping.
+    </h1>
+    <p class="hero-sub">
+      <span class="mono">105 skills</span>
+      <span class="divider">·</span>
+      <span class="mono">37 agents</span>
+      <span class="divider">·</span>
+      <span class="mono">180 hooks</span>
+      — loaded on demand, zero runtime cost.
+    </p>
+    <div class="cta-row">
+      <button class="btn btn-primary">Get started <span class="arrow">→</span></button>
+      <button class="btn btn-ghost">See the cookbook</button>
+    </div>
+    <div class="proof">
+      <span class="proof-item">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/></svg>
+        <span class="proof-star">2.4k</span> stars
+      </span>
+      <span class="proof-item">MIT license</span>
+      <span class="proof-item">Claude Code ≥ 2.1.113</span>
+    </div>
+  </div>
+</section>
+
+<!-- ============ VALUE PROP STRIP ============ -->
+<section class="vprop" data-screen-label="Value Prop Strip">
+  <div class="container">
+    <div class="section-head" style="margin-bottom:24px;">
+      <span class="section-label">Paths / 03</span>
+      <span class="section-aside">Pick your entry point</span>
+    </div>
+    <div class="vprop-grid">
+      <a class="vprop-card" href="#">
+        <div class="vprop-eyebrow">01 / New here</div>
+        <div class="vprop-title">New to OrchestKit?</div>
+        <p class="vprop-body">Install and ship your first feature in under 5 minutes.</p>
+        <span class="vprop-link">Get started <span class="arrow">→</span></span>
+      </a>
+      <a class="vprop-card" href="#">
+        <div class="vprop-eyebrow">02 / Evaluating</div>
+        <div class="vprop-title">Evaluating for your team?</div>
+        <p class="vprop-body">180 hooks enforce security and quality automatically. Zero config.</p>
+        <span class="vprop-link">See the guardrails <span class="arrow">→</span></span>
+      </a>
+      <a class="vprop-card" href="#">
+        <div class="vprop-eyebrow">03 / Existing user</div>
+        <div class="vprop-title">Already using Claude Code?</div>
+        <p class="vprop-body">37 parallel specialist agents, 3-tier memory, keyword activation.</p>
+        <span class="vprop-link">What OrchestKit adds <span class="arrow">→</span></span>
+      </a>
+    </div>
+  </div>
+</section>
+
+<!-- ============ COOKBOOK ============ -->
+<section class="cookbook" id="cookbook" data-screen-label="Cookbook">
+  <div class="container">
+
+    <!-- Primitives -->
+    <div class="section-head">
+      <div>
+        <span class="section-label">Primitives / 03</span>
+        <h2 class="section-title" style="margin-top:8px;">The building blocks</h2>
+      </div>
+      <span class="section-aside">322 total</span>
+    </div>
+    <div class="primitives">
+      <article class="prim-card">
+        <div class="prim-head">
+          <div class="glyph">S</div>
+          <div class="prim-tag">/ork</div>
+        </div>
+        <div class="prim-count">105<span style="font-size:0.5em;color:var(--muted-fg);font-weight:400;letter-spacing:0;">modules</span></div>
+        <h3 class="prim-title">Skills</h3>
+        <p class="prim-desc">Reusable knowledge modules — auth patterns, migrations, API design. <span class="mono">25 commands</span> + <span class="mono">80 auto-injected</span> references.</p>
+      </article>
+      <article class="prim-card">
+        <div class="prim-head">
+          <div class="glyph">A</div>
+          <div class="prim-tag">@agent</div>
+        </div>
+        <div class="prim-count">37<span style="font-size:0.5em;color:var(--muted-fg);font-weight:400;letter-spacing:0;">personas</span></div>
+        <h3 class="prim-title">Agents</h3>
+        <p class="prim-desc">Specialized AI personas — security auditors, frontend devs, DB engineers. Curated tools and skills per agent.</p>
+      </article>
+      <article class="prim-card">
+        <div class="prim-head">
+          <div class="glyph">H</div>
+          <div class="prim-tag">lifecycle</div>
+        </div>
+        <div class="prim-count">180<span style="font-size:0.5em;color:var(--muted-fg);font-weight:400;letter-spacing:0;">hooks</span></div>
+        <h3 class="prim-title">Hooks</h3>
+        <p class="prim-desc">TypeScript lifecycle automation — block dangerous commands, inject context, enforce security. Non-blocking.</p>
+      </article>
+    </div>
+
+    <!-- Recipes -->
+    <div class="section-head">
+      <div>
+        <span class="section-label">Recipes / 08</span>
+        <h2 class="section-title" style="margin-top:8px;">Cookbook</h2>
+      </div>
+      <a href="#" class="section-aside" style="color:var(--primary);">View all recipes →</a>
+    </div>
+    <div class="recipes" id="recipes"></div>
+
+  </div>
+</section>
+
+<!-- ============ TWEAKS PANEL ============ -->
+<aside class="tweaks-panel" id="tweaks">
+  <div class="tweaks-head">
+    <span class="tweaks-title">Tweaks</span>
+    <button id="tweaks-close" style="background:none;border:none;font-family:var(--ff-mono);font-size:14px;color:var(--muted-fg);cursor:pointer;">×</button>
+  </div>
+
+  <div class="tweaks-row">
+    <label>Dot grid opacity <span class="val" id="val-dot">0.04</span></label>
+    <input type="range" id="tw-dot" min="0" max="0.12" step="0.005" value="0.04">
+  </div>
+
+  <div class="tweaks-row">
+    <label>Hero gradient <span class="val" id="val-hero">0.60</span></label>
+    <input type="range" id="tw-hero" min="0" max="1.5" step="0.05" value="0.6">
+  </div>
+
+  <div class="tweaks-row">
+    <label>Accent hue <span class="val" id="val-hue">163°</span></label>
+    <input type="range" id="tw-hue" min="133" max="193" step="1" value="163">
+  </div>
+
+  <div class="tweaks-row">
+    <label>Card density</label>
+    <div class="seg" id="seg-density">
+      <button data-v="compact">Compact</button>
+      <button data-v="comfortable" data-active="true">Default</button>
+      <button data-v="roomy">Roomy</button>
+    </div>
+  </div>
+
+  <div class="tweaks-row theme-toggle">
+    <span style="font-family:var(--ff-mono);font-size:11px;color:var(--muted-fg);">Theme</span>
+    <button id="tw-theme">Switch to dark</button>
+  </div>
+</aside>
+
+<script>
+  // ============ Recipes (render from data) ============
+  const RECIPES = [
+    { title: "Implement a feature", tag: "From idea to merged PR with parallel AI agents.", cmd: "/ork:implement", badge: null },
+    { title: "Claude Design → PR", tag: "Handoff URL in, reviewable PR out.", cmd: "/ork:design-ship", badge: "NEW" },
+    { title: "Review a PR", tag: "Parallel specialized reviewers, synthesized comment.", cmd: "/ork:review", badge: null },
+    { title: "Fix a GitHub issue", tag: "Root-cause analysis, regression detection, linked PR.", cmd: "/ork:fix-issue", badge: null },
+    { title: "Task management", tag: "Multi-agent TaskCreate / TaskList / dependency chains.", cmd: "/ork:task", badge: null },
+    { title: "Set up memory", tag: "3-tier knowledge graph that persists across sessions.", cmd: "/ork:memory", badge: null },
+    { title: "Create a demo video", tag: "VHS + Remotion pipeline, auto-generated voiceover.", cmd: "/ork:demo", badge: null },
+    { title: "Security audit", tag: "Parallel scan across auth, secrets, OWASP, dependencies.", cmd: "/ork:audit", badge: null },
+  ];
+  const recipesEl = document.getElementById('recipes');
+  recipesEl.innerHTML = RECIPES.map((r, i) => `
+    <a class="recipe" href="#">
+      <div class="recipe-num">
+        <span>${String(i+1).padStart(2,'0')} / 08</span>
+        ${r.badge ? `<span class="badge">${r.badge}</span>` : ''}
+      </div>
+      <div class="recipe-title">${r.title}</div>
+      <div class="recipe-tag">${r.tag}</div>
+      <div class="recipe-foot">
+        <span class="recipe-cmd">${r.cmd}</span>
+        <span class="recipe-arrow">→</span>
+      </div>
+    </a>
+  `).join('');
+
+  // ============ Tweaks ============
+  const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+    "dotOpacity": 0.055,
+    "heroGradient": 0.55,
+    "accentHue": 163,
+    "density": "comfortable",
+    "theme": "dark"
+  }/*EDITMODE-END*/;
+
+  let state = { ...TWEAK_DEFAULTS };
+
+  function applyState() {
+    const root = document.documentElement;
+    root.style.setProperty('--dot-opacity', state.dotOpacity);
+    root.style.setProperty('--hero-gradient', state.heroGradient);
+    root.style.setProperty('--primary-h', state.accentHue);
+    root.setAttribute('data-density', state.density);
+    root.setAttribute('data-theme', state.theme);
+
+    // UI sync
+    document.getElementById('val-dot').textContent = Number(state.dotOpacity).toFixed(3);
+    document.getElementById('val-hero').textContent = Number(state.heroGradient).toFixed(2);
+    document.getElementById('val-hue').textContent = state.accentHue + '°';
+    document.getElementById('tw-dot').value = state.dotOpacity;
+    document.getElementById('tw-hero').value = state.heroGradient;
+    document.getElementById('tw-hue').value = state.accentHue;
+    document.querySelectorAll('#seg-density button').forEach(b => {
+      b.setAttribute('data-active', b.dataset.v === state.density ? 'true' : 'false');
+    });
+    const themeBtn = document.getElementById('tw-theme');
+    if (themeBtn) themeBtn.textContent = state.theme === 'dark' ? 'Switch to light' : 'Switch to dark';
+  }
+
+  function persist() {
+    try {
+      window.parent.postMessage({type:'__edit_mode_set_keys', edits: state}, '*');
+    } catch(e){}
+  }
+
+  // Listen for edit mode toggle
+  window.addEventListener('message', (e) => {
+    const d = e.data;
+    if (!d || !d.type) return;
+    if (d.type === '__activate_edit_mode') {
+      document.getElementById('tweaks').setAttribute('data-open', 'true');
+    }
+    if (d.type === '__deactivate_edit_mode') {
+      document.getElementById('tweaks').setAttribute('data-open', 'false');
+    }
+  });
+  try { window.parent.postMessage({type:'__edit_mode_available'}, '*'); } catch(e){}
+
+  // Hook up controls
+  document.getElementById('tw-dot').addEventListener('input', e => {
+    state.dotOpacity = parseFloat(e.target.value); applyState(); persist();
+  });
+  document.getElementById('tw-hero').addEventListener('input', e => {
+    state.heroGradient = parseFloat(e.target.value); applyState(); persist();
+  });
+  document.getElementById('tw-hue').addEventListener('input', e => {
+    state.accentHue = parseInt(e.target.value, 10); applyState(); persist();
+  });
+  document.querySelectorAll('#seg-density button').forEach(btn => {
+    btn.addEventListener('click', () => {
+      state.density = btn.dataset.v; applyState(); persist();
+    });
+  });
+  document.getElementById('tw-theme').addEventListener('click', () => {
+    state.theme = state.theme === 'dark' ? 'light' : 'dark';
+    applyState(); persist();
+  });
+  document.getElementById('tweaks-close').addEventListener('click', () => {
+    document.getElementById('tweaks').setAttribute('data-open', 'false');
+  });
+
+  applyState();
+</script>
+
+</body>
+</html>

--- a/docs/site/app/(home)/page.tsx
+++ b/docs/site/app/(home)/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChevronRight, ArrowRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { CopyInstallButton } from "./copy-button";
 import { SITE, COUNTS } from "@/lib/constants";
 import { COMPOSITIONS } from "@/lib/generated/compositions-data";
@@ -339,7 +339,7 @@ export default async function HomePage() {
           </div>
 
           <div className="grid grid-cols-1 gap-[14px] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {RECIPES.map((r, i) => (
+            {RECIPES.map((r, idx) => (
               <Link
                 key={r.href}
                 href={r.href}
@@ -347,7 +347,7 @@ export default async function HomePage() {
               >
                 <div className="mb-3 flex items-center justify-between font-mono text-[11px] tracking-[0.05em] text-fd-muted-foreground">
                   <span className="tabular-nums">
-                    {String(i + 1).padStart(2, "0")} / {String(RECIPES.length).padStart(2, "0")}
+                    {String(idx + 1).padStart(2, "0")} / {String(RECIPES.length).padStart(2, "0")}
                   </span>
                   {r.badge ? (
                     <span className="rounded border border-[var(--color-fd-primary-20)] bg-[var(--color-fd-primary-10)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.06em] text-fd-primary">

--- a/docs/site/app/(home)/page.tsx
+++ b/docs/site/app/(home)/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, ArrowRight } from "lucide-react";
 import { CopyInstallButton } from "./copy-button";
 import { SITE, COUNTS } from "@/lib/constants";
 import { COMPOSITIONS } from "@/lib/generated/compositions-data";
@@ -23,22 +23,35 @@ async function getStarCount(): Promise<number | null> {
 const PRIMITIVES = [
   {
     letter: "S",
+    tag: "/ork",
     title: "Skills",
     count: COUNTS.skills,
-    desc: `Reusable knowledge modules — auth patterns, migrations, API design. ${COUNTS.commands} commands + ${COUNTS.skills - COUNTS.commands} auto-injected references.`,
+    unit: "modules",
+    desc: (
+      <>
+        Reusable knowledge modules — auth patterns, migrations, API design.{" "}
+        <span className="font-mono text-fd-foreground">{COUNTS.commands} commands</span> +{" "}
+        <span className="font-mono text-fd-foreground">{COUNTS.skills - COUNTS.commands} auto-injected</span>{" "}
+        references.
+      </>
+    ),
     href: "/docs/reference/skills",
   },
   {
     letter: "A",
+    tag: "@agent",
     title: "Agents",
     count: COUNTS.agents,
+    unit: "personas",
     desc: "Specialized AI personas — security auditors, frontend devs, DB engineers. Curated tools and skills per agent.",
     href: "/docs/reference/agents",
   },
   {
     letter: "H",
+    tag: "lifecycle",
     title: "Hooks",
     count: COUNTS.hooks,
+    unit: "hooks",
     desc: "TypeScript lifecycle automation — block dangerous commands, inject context, enforce security. Non-blocking.",
     href: "/docs/reference/hooks",
   },
@@ -46,18 +59,21 @@ const PRIMITIVES = [
 
 const PERSONAS = [
   {
+    eyebrow: "01 / New here",
     title: "New to OrchestKit?",
     desc: "Install and ship your first feature in under 5 minutes.",
     cta: "Get started",
     href: "/docs/getting-started/installation",
   },
   {
+    eyebrow: "02 / Evaluating",
     title: "Evaluating for your team?",
     desc: `${COUNTS.hooks} hooks enforce security and quality automatically. Zero config.`,
     cta: "See the guardrails",
     href: "/docs/reference/hooks",
   },
   {
+    eyebrow: "03 / Existing user",
     title: "Already using Claude Code?",
     desc: `${COUNTS.agents} parallel specialist agents, 3-tier memory, keyword activation.`,
     cta: "What OrchestKit adds",
@@ -65,303 +81,384 @@ const PERSONAS = [
   },
 ] as const;
 
-const QUICK_PATHS = [
-  { title: "First 10 Minutes", desc: "Install to first AI-assisted commit", href: "/docs/getting-started/first-10-minutes" },
-  { title: "Find Your Path", desc: "Backend, Frontend, AI, or DevOps", href: "/docs/getting-started/navigating" },
-  { title: "Cookbook", desc: "Real workflow walkthroughs", href: "/docs/cookbook/implement-feature" },
-  { title: "How It Works", desc: "Skills, Agents, and Hooks in depth", href: "/docs/foundations/skills-agents-hooks" },
-] as const;
+type Recipe = {
+  title: string;
+  tag: string;
+  cmd: string;
+  href: string;
+  badge?: string;
+};
+
+const RECIPES: Recipe[] = [
+  { title: "Implement a feature", tag: "From idea to merged PR with parallel AI agents.", cmd: "/ork:implement", href: "/docs/cookbook/implement-feature" },
+  { title: "Claude Design → PR", tag: "Handoff URL in, reviewable PR out.", cmd: "/ork:design-ship", href: "/docs/cookbook/claude-design-handoff", badge: "NEW" },
+  { title: "Review a PR", tag: "Parallel specialized reviewers, synthesized comment.", cmd: "/ork:review-pr", href: "/docs/cookbook/review-pr" },
+  { title: "Fix a GitHub issue", tag: "Root-cause analysis, regression detection, linked PR.", cmd: "/ork:fix-issue", href: "/docs/cookbook/fix-github-issue" },
+  { title: "Task management", tag: "Multi-agent TaskCreate / TaskList / dependency chains.", cmd: "TaskCreate", href: "/docs/cookbook/task-management" },
+  { title: "Set up memory", tag: "3-tier knowledge graph that persists across sessions.", cmd: "/ork:memory", href: "/docs/cookbook/setup-memory" },
+  { title: "Create a demo video", tag: "VHS + Remotion pipeline, auto-generated voiceover.", cmd: "/ork:demo-producer", href: "/docs/cookbook/create-demo-video" },
+  { title: "Security audit", tag: "Parallel scan across auth, secrets, OWASP, dependencies.", cmd: "/ork:audit-full", href: "/docs/cookbook/security-audit" },
+];
+
+const formatStars = (n: number): string =>
+  n >= 1000 ? `${(n / 1000).toFixed(n >= 10_000 ? 0 : 1)}k` : `${n}`;
 
 export default async function HomePage() {
   const stars = await getStarCount();
+  const primitiveTotal = COUNTS.skills + COUNTS.agents + COUNTS.hooks;
+
   return (
     <main>
-      {/* Hero — left-aligned, dot-grid background */}
-      <section aria-labelledby="hero-heading" className="relative min-h-[70vh] flex items-center overflow-hidden">
-        <div className="absolute inset-0 bg-dot-grid" aria-hidden="true" />
+      {/* ============ HERO ============ */}
+      <section
+        aria-labelledby="hero-heading"
+        className="relative overflow-hidden border-b border-fd-border"
+      >
+        {/* Radial emerald gradient top-center */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse 80% 60% at 50% 0%, var(--color-fd-primary-10) 0%, transparent 60%), radial-gradient(ellipse 40% 30% at 50% 10%, var(--color-fd-primary-5) 0%, transparent 70%)",
+          }}
+        />
+        {/* Dot grid motif */}
+        <div aria-hidden="true" className="absolute inset-0 bg-dot-grid opacity-60" />
 
-        <div className="relative z-10 mx-auto w-full max-w-[1024px] px-6 py-20">
+        <div className="relative mx-auto max-w-[1200px] px-7 py-24 sm:py-28 text-center">
           <AnimateOnView>
-            <span className="overline">OrchestKit v{SITE.version}</span>
+            <span className="inline-flex items-center gap-2 rounded-full border border-[var(--color-fd-primary-20)] bg-[var(--color-fd-primary-10)] px-2.5 py-1.5 font-mono text-[12px] font-medium text-fd-primary">
+              <span
+                aria-hidden="true"
+                className="h-1.5 w-1.5 rounded-full bg-fd-primary"
+                style={{ boxShadow: "0 0 0 3px var(--color-fd-primary-20)" }}
+              />
+              The complete AI development toolkit for Claude Code
+            </span>
           </AnimateOnView>
 
-          <AnimateOnView delay={100} className="mt-4">
-            <h1 id="hero-heading" className="max-w-3xl text-fluid-h1 font-bold tracking-tight text-fd-foreground">
-              Stop explaining your stack.
+          <AnimateOnView delay={100} className="mt-5">
+            <h1
+              id="hero-heading"
+              className="text-fluid-h1 font-semibold leading-[1.02] tracking-[-0.025em] text-fd-foreground"
+            >
+              <span
+                className="bg-clip-text text-transparent"
+                style={{
+                  backgroundImage:
+                    "linear-gradient(180deg, var(--color-fd-foreground) 0%, color-mix(in oklch, var(--color-fd-foreground) 70%, var(--color-fd-muted-foreground)) 100%)",
+                }}
+              >
+                Stop explaining your stack.
+              </span>
               <br />
-              <span className="text-fd-primary">Start shipping.</span>
+              Start shipping.
             </h1>
           </AnimateOnView>
 
-          <AnimateOnView delay={200} className="mt-6">
-            <p className="max-w-lg text-[15px] text-fd-muted-foreground leading-relaxed">
-              {COUNTS.skills} skills, {COUNTS.agents} agents, and {COUNTS.hooks} hooks that turn Claude Code into
-              a full development team.
+          <AnimateOnView delay={200} className="mt-5">
+            <p className="mx-auto max-w-[620px] text-[clamp(0.95rem,0.3vw+0.9rem,1.125rem)] leading-[1.55] text-fd-muted-foreground">
+              <span className="font-mono text-[0.92em] font-medium text-fd-foreground">
+                {COUNTS.skills} skills
+              </span>
+              <span className="mx-1.5 opacity-40">·</span>
+              <span className="font-mono text-[0.92em] font-medium text-fd-foreground">
+                {COUNTS.agents} agents
+              </span>
+              <span className="mx-1.5 opacity-40">·</span>
+              <span className="font-mono text-[0.92em] font-medium text-fd-foreground">
+                {COUNTS.hooks} hooks
+              </span>
+              {" "}— loaded on demand, zero runtime cost.
             </p>
           </AnimateOnView>
 
-          <AnimateOnView delay={300} className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <AnimateOnView delay={300} className="mt-8 flex flex-wrap items-center justify-center gap-2.5">
             <Link
               href="/docs/getting-started/first-10-minutes"
-              className="hover-glow inline-flex h-10 items-center rounded-lg bg-fd-primary px-6 text-sm font-semibold text-fd-primary-foreground transition-colors hover:bg-[var(--color-fd-primary-50)]"
+              className="inline-flex h-10 items-center gap-2 rounded-lg bg-fd-primary px-[18px] text-sm font-medium text-fd-primary-foreground transition-all duration-150 hover:-translate-y-px hover:bg-[oklch(0.54_0.15_163)] hover:shadow-[0_0_0_4px_var(--color-fd-glow)]"
             >
-              Get Started
+              Get started{" "}
+              <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" aria-hidden="true" />
             </Link>
             <CopyInstallButton />
+            <Link
+              href="#cookbook"
+              className="inline-flex h-10 items-center rounded-lg border border-fd-border bg-transparent px-[18px] text-sm font-medium text-fd-foreground transition-colors hover:border-[var(--color-fd-primary-30)] hover:bg-fd-muted"
+            >
+              See the cookbook
+            </Link>
+          </AnimateOnView>
+
+          <AnimateOnView delay={400} className="mt-7 flex flex-wrap items-center justify-center font-mono text-[12px] text-fd-muted-foreground">
             <a
-              href={SITE.github}
+              href={`${SITE.github}/stargazers`}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex h-10 items-center gap-2 rounded-lg border border-fd-border bg-fd-card px-4 text-sm font-medium text-fd-foreground transition-all hover:bg-[var(--color-fd-primary-5)] hover:border-[var(--color-fd-primary-30)]"
-              aria-label="Star OrchestKit on GitHub"
+              className="inline-flex items-center gap-1.5 px-3.5 transition-colors hover:text-fd-foreground"
             >
-              <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+              <svg className="h-3 w-3 opacity-70" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
               </svg>
-              Star on GitHub
+              {stars !== null ? (
+                <>
+                  <span className="font-medium text-fd-foreground tabular-nums">{formatStars(stars)}</span>
+                  <span>stars</span>
+                </>
+              ) : (
+                <span>Star on GitHub</span>
+              )}
             </a>
+            <span aria-hidden="true" className="h-3 w-px bg-fd-border" />
+            <span className="inline-flex items-center gap-1.5 px-3.5">MIT license</span>
+            <span aria-hidden="true" className="h-3 w-px bg-fd-border" />
+            <span className="inline-flex items-center gap-1.5 px-3.5">Claude Code ≥ {SITE.ccVersion}</span>
           </AnimateOnView>
-
-          {/* Circuit-trace stat bar — animated counters */}
-          <AnimateOnView delay={400} className="mt-16 hidden items-center justify-between border-t border-fd-border pt-8 max-w-2xl sm:flex" distance={16}>
-            <AnimateOnView delay={500} className="text-center" distance={20}>
-              <dd className="font-mono text-[40px] font-bold tabular-nums text-fd-foreground leading-none">{COUNTS.skills}</dd>
-              <dt className="mt-1 overline-muted">Skills</dt>
-            </AnimateOnView>
-
-            <div className="flex-1 mx-6 relative">
-              <div className="circuit-line" />
-              <div className="circuit-dot absolute top-1/2 left-0 -translate-y-1/2 -translate-x-1/2" />
-              <div className="circuit-dot absolute top-1/2 right-0 -translate-y-1/2 translate-x-1/2" />
-            </div>
-
-            <AnimateOnView delay={600} className="text-center" distance={20}>
-              <dd className="font-mono text-[40px] font-bold tabular-nums text-fd-foreground leading-none">{COUNTS.agents}</dd>
-              <dt className="mt-1 overline-muted">Agents</dt>
-            </AnimateOnView>
-
-            <div className="flex-1 mx-6 relative">
-              <div className="circuit-line" />
-              <div className="circuit-dot absolute top-1/2 left-0 -translate-y-1/2 -translate-x-1/2" />
-              <div className="circuit-dot absolute top-1/2 right-0 -translate-y-1/2 translate-x-1/2" />
-            </div>
-
-            <AnimateOnView delay={700} className="text-center" distance={20}>
-              <dd className="font-mono text-[40px] font-bold tabular-nums text-fd-foreground leading-none">{COUNTS.hooks}</dd>
-              <dt className="mt-1 overline-muted">Hooks</dt>
-            </AnimateOnView>
-          </AnimateOnView>
-
-          {/* Mobile stats — stacked, no connectors */}
-          <dl className="mt-10 grid grid-cols-3 gap-4 border-t border-fd-border pt-6 sm:hidden" aria-label="Quick statistics">
-            {([
-              [COUNTS.skills, "Skills"],
-              [COUNTS.agents, "Agents"],
-              [COUNTS.hooks, "Hooks"],
-            ] as const).map(([n, label]) => (
-              <div key={label} className="text-center">
-                <dd className="font-mono text-2xl font-bold tabular-nums text-fd-foreground">{n}</dd>
-                <dt className="mt-0.5 overline-muted">{label}</dt>
-              </div>
-            ))}
-          </dl>
         </div>
       </section>
 
-      {/* Social proof */}
-      <section aria-label="Community traction" className="border-t border-fd-border bg-[var(--color-fd-surface-sunken)]">
-        <div className="mx-auto flex max-w-[1024px] items-center justify-center gap-6 px-6 py-4 text-[13px] text-fd-muted-foreground sm:gap-8">
-          <a
-            href={`${SITE.github}/stargazers`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1.5 transition-colors hover:text-fd-foreground"
-          >
-            <svg className="h-3.5 w-3.5 text-fd-primary" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
-            </svg>
-            {stars !== null && <span className="font-mono font-medium tabular-nums">{stars}</span>}{" "}stars on GitHub
-          </a>
-          <span className="h-3 w-px bg-fd-border" aria-hidden="true" />
-          <span className="flex items-center gap-1.5">
-            Open source · MIT-style license
-          </span>
-          <span className="hidden h-3 w-px bg-fd-border sm:block" aria-hidden="true" />
-          <a
-            href={`${SITE.github}/network/members`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="hidden items-center gap-1.5 transition-colors hover:text-fd-foreground sm:flex"
-          >
-            Community-driven
-          </a>
-        </div>
-      </section>
-
-      {/* Coverage areas */}
-      <section aria-label="Coverage areas" className="border-t border-fd-border bg-[var(--color-fd-surface-sunken)]">
-        <div className="mx-auto max-w-[1024px] px-6 py-5">
-          <div className="flex flex-wrap justify-center gap-3">
-            {["Backend", "Frontend", "AI / LLM", "Security", "DevOps", "Testing", "Product", "Data"].map((label) => (
-              <div key={label} className="flex items-center gap-1.5 text-xs text-fd-muted-foreground">
-                <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-fd-primary-30)]" />
-                <span>{label}</span>
-              </div>
-            ))}
+      {/* ============ VALUE-PROP STRIP ============ */}
+      <section
+        aria-labelledby="personas-heading"
+        className="border-b border-fd-border bg-[var(--color-fd-surface-sunken)] py-11"
+      >
+        <div className="mx-auto max-w-[1200px] px-7">
+          <div className="mb-6 flex items-baseline justify-between gap-4">
+            <span className="inline-flex items-center gap-2.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground">
+              <span aria-hidden="true" className="h-px w-2.5 bg-fd-muted-foreground opacity-50" />
+              Paths / 03
+            </span>
+            <span id="personas-heading" className="font-mono text-[13px] text-fd-muted-foreground">
+              Pick your entry point
+            </span>
           </div>
-        </div>
-      </section>
-
-      {/* Primitives — accent-border cards */}
-      <section aria-labelledby="primitives-heading" className="border-t border-fd-border">
-        <div className="mx-auto max-w-[1024px] px-6 py-12 sm:py-16">
-          <span className="overline">Building Blocks</span>
-          <h2 id="primitives-heading" className="mt-2 text-fluid-h2 font-semibold tracking-tight text-fd-foreground">
-            Three primitives, infinite workflows
-          </h2>
-          <p className="mt-2 max-w-lg text-[15px] text-fd-muted-foreground">
-            Everything in OrchestKit composes from these building blocks.
-          </p>
-
-          <div className="mt-8 grid gap-px sm:grid-cols-3">
-            {PRIMITIVES.map((item) => (
+          <div className="grid grid-cols-1 overflow-hidden rounded-xl border border-fd-border bg-[var(--color-fd-surface-raised)] md:grid-cols-3">
+            {PERSONAS.map((p, i) => (
               <Link
-                key={item.letter}
-                href={item.href}
-                className="group border border-fd-border border-l-2 border-l-fd-primary bg-fd-card p-5 transition-all duration-200 hover:bg-[var(--color-fd-primary-5)] hover:border-l-fd-primary sm:rounded-r-lg hover:shadow-[0_0_12px_var(--color-fd-glow)]"
+                key={p.href}
+                href={p.href}
+                className="group relative border-fd-border p-[26px_28px] transition-colors hover:bg-[color-mix(in_oklch,var(--color-fd-primary)_3%,var(--color-fd-surface-raised))] md:border-l md:first:border-l-0 border-t md:border-t-0 first:border-t-0 border-l-[3px] border-l-transparent hover:border-l-fd-primary"
               >
-                <div className="mb-2 inline-flex h-7 w-7 items-center justify-center rounded border border-fd-border font-mono text-xs font-bold text-fd-primary" aria-hidden="true">
-                  {item.letter}
+                <div className="mb-2.5 font-mono text-[11px] uppercase tracking-[0.04em] text-fd-muted-foreground">
+                  {p.eyebrow}
                 </div>
-                <h3 className="font-semibold text-fd-foreground">
-                  {item.count} {item.title}
-                </h3>
-                <p className="mt-1.5 text-[13px] leading-relaxed text-fd-muted-foreground">
-                  {item.desc}
-                </p>
-                <span className="mt-3 inline-flex items-center gap-1 font-mono text-[11px] font-medium text-fd-primary opacity-0 transition-all duration-200 group-hover:opacity-100" aria-hidden="true">
-                  Browse all
-                  <ChevronRight className="h-3 w-3" />
-                </span>
-              </Link>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Choose Your Path — persona-based entry points */}
-      <section aria-labelledby="personas-heading" className="border-t border-fd-border bg-[var(--color-fd-surface-sunken)]">
-        <div className="mx-auto max-w-[1024px] px-6 py-12 sm:py-16">
-          <span className="overline">Choose Your Path</span>
-          <h2 id="personas-heading" className="mt-2 text-fluid-h2 font-semibold tracking-tight text-fd-foreground">
-            Where do you want to start?
-          </h2>
-          <div className="mt-8 grid gap-4 sm:grid-cols-3">
-            {PERSONAS.map((persona) => (
-              <Link
-                key={persona.href}
-                href={persona.href}
-                className="group flex flex-col justify-between border border-fd-border bg-fd-card p-5 rounded-lg transition-all duration-200 hover:bg-[var(--color-fd-primary-5)] hover:border-[var(--color-fd-primary-30)] hover:shadow-[0_0_12px_var(--color-fd-glow)]"
-              >
-                <div>
-                  <h3 className="font-semibold text-fd-foreground">{persona.title}</h3>
-                  <p className="mt-2 text-[13px] leading-relaxed text-fd-muted-foreground">{persona.desc}</p>
+                <div className="mb-1.5 text-base font-semibold tracking-[-0.01em] text-fd-foreground">
+                  {p.title}
                 </div>
-                <span className="mt-4 inline-flex items-center gap-1 font-mono text-[12px] font-medium text-fd-primary transition-all group-hover:gap-2">
-                  {persona.cta}
-                  <ChevronRight className="h-3 w-3" />
-                </span>
-              </Link>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      {/* Demo Showcase */}
-      <section aria-labelledby="demos-heading" className="border-t border-fd-border">
-        <div className="mx-auto max-w-[1024px] px-6 py-12 sm:py-16">
-          <span className="overline">Demos</span>
-          <h2 id="demos-heading" className="mt-2 text-fluid-h2 font-semibold tracking-tight text-fd-foreground">
-            See it in action
-          </h2>
-          <p className="mt-2 max-w-md text-[15px] text-fd-muted-foreground">
-            Every command skill comes with a demo composition.
-          </p>
-          <div className="mt-6 flex gap-3 overflow-x-auto pb-4">
-            {COMPOSITIONS.filter(c => c.format === "landscape" && c.videoCdn).slice(0, 6).map((comp) => (
-              <Link
-                key={comp.id}
-                href="/docs/reference"
-                className="group flex-none w-[260px] border border-fd-border bg-fd-card overflow-hidden rounded-lg transition-all duration-200 hover:bg-[var(--color-fd-primary-5)] hover:border-[var(--color-fd-primary-30)]"
-              >
-                <div className="aspect-video bg-fd-background relative">
-                  <OptimizedThumbnail
-                    src={comp.thumbnailCdn ?? `/thumbnails/${comp.id}.png`}
-                    alt={`${comp.id.replace(/([A-Z])/g, ' $1').trim()} — ${comp.durationSeconds}s demo`}
+                <p className="mb-3.5 min-h-10 text-[13.5px] leading-[1.5] text-fd-muted-foreground">{p.desc}</p>
+                <span className="inline-flex items-center gap-1.5 font-mono text-[12.5px] font-medium text-fd-primary">
+                  {p.cta}
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="h-3 w-3 transition-transform duration-150 group-hover:translate-x-[3px]"
                   />
-                  <span className="absolute bottom-1.5 left-1.5 rounded bg-black/70 px-1.5 py-0.5 font-mono text-[10px] font-medium text-white">
-                    {comp.durationSeconds}s
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ============ COOKBOOK (primitives + recipes) ============ */}
+      <section aria-labelledby="cookbook-heading" className="border-b border-fd-border" id="cookbook">
+        <div className="mx-auto max-w-[1200px] px-7 py-[72px]">
+          {/* Primitives */}
+          <div className="mb-[18px] flex items-baseline justify-between gap-4">
+            <div>
+              <span className="inline-flex items-center gap-2.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground">
+                <span aria-hidden="true" className="h-px w-2.5 bg-fd-muted-foreground opacity-50" />
+                Primitives / 03
+              </span>
+              <h2
+                id="cookbook-heading"
+                className="mt-2 text-2xl font-semibold tracking-[-0.015em] text-fd-foreground"
+              >
+                The building blocks
+              </h2>
+            </div>
+            <span className="font-mono text-[13px] text-fd-muted-foreground">
+              <span className="tabular-nums">{primitiveTotal}</span> total
+            </span>
+          </div>
+
+          <div className="mb-11 grid grid-cols-1 gap-[14px] md:grid-cols-3">
+            {PRIMITIVES.map((p) => (
+              <Link
+                key={p.letter}
+                href={p.href}
+                className="group relative overflow-hidden rounded-[10px] border border-fd-border bg-[var(--color-fd-surface-raised)] p-5 transition-all duration-150 hover:-translate-y-px hover:border-[color-mix(in_oklch,var(--color-fd-primary)_40%,var(--color-fd-border))] hover:shadow-[0_0_0_4px_var(--color-fd-glow)]"
+              >
+                {/* Top-accent shimmer on hover */}
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-x-0 top-0 h-px opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                  style={{
+                    background:
+                      "linear-gradient(90deg, transparent 0%, color-mix(in oklch, var(--color-fd-primary) 40%, transparent) 50%, transparent 100%)",
+                  }}
+                />
+                <div className="mb-5 flex items-start justify-between">
+                  <div
+                    aria-hidden="true"
+                    className="grid h-[38px] w-[38px] place-items-center rounded-lg border border-[var(--color-fd-primary-20)] bg-[var(--color-fd-primary-10)] font-mono text-[17px] font-semibold text-fd-primary"
+                  >
+                    {p.letter}
+                  </div>
+                  <div className="pt-2.5 font-mono text-[11px] uppercase tracking-[0.06em] text-fd-muted-foreground">
+                    {p.tag}
+                  </div>
+                </div>
+                <div className="flex items-baseline gap-1.5 font-mono text-[clamp(2rem,2vw+1.2rem,2.75rem)] font-medium leading-none tracking-[-0.03em] text-fd-foreground">
+                  <span className="tabular-nums">{p.count}</span>
+                  <span className="text-[0.5em] font-normal tracking-normal text-fd-muted-foreground">
+                    {p.unit}
                   </span>
                 </div>
-                <div className="p-3">
-                  <h3 className="text-sm font-medium text-fd-foreground">{comp.id.replace(/([A-Z])/g, ' $1').trim()}</h3>
-                  <p className="mt-0.5 font-mono text-[11px] text-fd-muted-foreground">{comp.command}</p>
-                </div>
+                <h3 className="mt-2.5 mb-2 text-base font-semibold text-fd-foreground">{p.title}</h3>
+                <p className="text-[13px] leading-[1.55] text-fd-muted-foreground">{p.desc}</p>
               </Link>
             ))}
           </div>
-          <div className="mt-3">
+
+          {/* Recipes */}
+          <div className="mb-[18px] flex items-baseline justify-between gap-4">
+            <div>
+              <span className="inline-flex items-center gap-2.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground">
+                <span aria-hidden="true" className="h-px w-2.5 bg-fd-muted-foreground opacity-50" />
+                Recipes / {String(RECIPES.length).padStart(2, "0")}
+              </span>
+              <h2 className="mt-2 text-2xl font-semibold tracking-[-0.015em] text-fd-foreground">Cookbook</h2>
+            </div>
             <Link
-              href="/docs/reference"
-              className="font-mono text-[13px] text-fd-primary hover:text-[var(--color-fd-primary-50)] transition-colors"
+              href="/docs/cookbook/implement-feature"
+              className="font-mono text-[13px] text-fd-primary transition-colors hover:text-[var(--color-fd-primary-50)]"
             >
-              View all compositions &rarr;
+              View all recipes →
             </Link>
           </div>
-        </div>
-      </section>
 
-      {/* Quick paths */}
-      <section aria-labelledby="quickpaths-heading" className="border-t border-fd-border">
-        <div className="mx-auto max-w-[1024px] px-6 py-12 sm:py-16">
-          <span className="overline">Quick Start</span>
-          <h2 id="quickpaths-heading" className="mt-2 mb-6 text-2xl font-semibold tracking-tight text-fd-foreground">
-            Jump right in
-          </h2>
-          <div className="grid gap-px sm:grid-cols-2">
-            {QUICK_PATHS.map((item) => (
+          <div className="grid grid-cols-1 gap-[14px] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {RECIPES.map((r, i) => (
               <Link
-                key={item.href}
-                href={item.href}
-                className="group flex items-center justify-between border border-fd-border bg-fd-card px-4 py-3.5 transition-all duration-200 hover:bg-[var(--color-fd-primary-5)]"
+                key={r.href}
+                href={r.href}
+                className="group relative flex min-h-[148px] flex-col rounded-[10px] border border-fd-border bg-[var(--color-fd-surface-raised)] p-5 transition-all duration-150 hover:-translate-y-px hover:border-[color-mix(in_oklch,var(--color-fd-primary)_40%,var(--color-fd-border))] hover:shadow-[0_0_0_4px_var(--color-fd-glow)]"
               >
-                <div>
-                  <h3 className="text-sm font-medium text-fd-foreground">{item.title}</h3>
-                  <div className="text-[13px] text-fd-muted-foreground">{item.desc}</div>
+                <div className="mb-3 flex items-center justify-between font-mono text-[11px] tracking-[0.05em] text-fd-muted-foreground">
+                  <span className="tabular-nums">
+                    {String(i + 1).padStart(2, "0")} / {String(RECIPES.length).padStart(2, "0")}
+                  </span>
+                  {r.badge ? (
+                    <span className="rounded border border-[var(--color-fd-primary-20)] bg-[var(--color-fd-primary-10)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.06em] text-fd-primary">
+                      {r.badge}
+                    </span>
+                  ) : null}
                 </div>
-                <ChevronRight
-                  className="h-4 w-4 shrink-0 text-fd-muted-foreground transition-all group-hover:translate-x-0.5 group-hover:text-fd-primary"
-                  aria-hidden="true"
-                />
+                <div className="mb-2 text-[15px] font-semibold leading-[1.3] tracking-[-0.01em] text-fd-foreground">
+                  {r.title}
+                </div>
+                <div className="flex-1 text-[13px] leading-[1.5] text-fd-muted-foreground">{r.tag}</div>
+                <div className="mt-3.5 flex items-center justify-between border-t border-dashed border-fd-border pt-3 font-mono text-[11.5px] text-fd-muted-foreground">
+                  <span className="text-fd-foreground">{r.cmd}</span>
+                  <ArrowRight
+                    aria-hidden="true"
+                    className="h-3 w-3 text-fd-primary transition-transform duration-150 group-hover:translate-x-[3px]"
+                  />
+                </div>
               </Link>
             ))}
           </div>
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="border-t border-fd-border">
-        <div className="mx-auto flex max-w-[1024px] items-center justify-between px-6 py-5 text-[13px] text-fd-muted-foreground">
+      {/* ============ DEMO SHOWCASE (kept from prior landing) ============ */}
+      <section aria-labelledby="demos-heading" className="border-b border-fd-border">
+        <div className="mx-auto max-w-[1200px] px-7 py-16">
+          <div className="mb-[18px] flex items-baseline justify-between gap-4">
+            <div>
+              <span className="inline-flex items-center gap-2.5 font-mono text-[11.5px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground">
+                <span aria-hidden="true" className="h-px w-2.5 bg-fd-muted-foreground opacity-50" />
+                Demos
+              </span>
+              <h2
+                id="demos-heading"
+                className="mt-2 text-2xl font-semibold tracking-[-0.015em] text-fd-foreground"
+              >
+                See it in action
+              </h2>
+            </div>
+            <Link
+              href="/docs/reference"
+              className="font-mono text-[13px] text-fd-primary transition-colors hover:text-[var(--color-fd-primary-50)]"
+            >
+              View all →
+            </Link>
+          </div>
+          <div className="flex gap-[14px] overflow-x-auto pb-4">
+            {COMPOSITIONS.filter((c) => c.format === "landscape" && c.videoCdn)
+              .slice(0, 6)
+              .map((comp) => (
+                <Link
+                  key={comp.id}
+                  href="/docs/reference"
+                  className="group w-[260px] flex-none overflow-hidden rounded-[10px] border border-fd-border bg-[var(--color-fd-surface-raised)] transition-all duration-150 hover:-translate-y-px hover:border-[color-mix(in_oklch,var(--color-fd-primary)_40%,var(--color-fd-border))] hover:shadow-[0_0_0_4px_var(--color-fd-glow)]"
+                >
+                  <div className="relative aspect-video bg-fd-background">
+                    <OptimizedThumbnail
+                      src={comp.thumbnailCdn ?? `/thumbnails/${comp.id}.png`}
+                      alt={`${comp.id.replace(/([A-Z])/g, " $1").trim()} — ${comp.durationSeconds}s demo`}
+                    />
+                    <span className="absolute bottom-1.5 left-1.5 rounded bg-black/70 px-1.5 py-0.5 font-mono text-[10px] font-medium text-white">
+                      {comp.durationSeconds}s
+                    </span>
+                  </div>
+                  <div className="p-3">
+                    <h3 className="text-sm font-medium text-fd-foreground">
+                      {comp.id.replace(/([A-Z])/g, " $1").trim()}
+                    </h3>
+                    <p className="mt-0.5 font-mono text-[11px] text-fd-muted-foreground">{comp.command}</p>
+                  </div>
+                </Link>
+              ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ============ FOOTER ============ */}
+      <footer>
+        <div className="mx-auto flex max-w-[1200px] items-center justify-between px-7 py-5 text-[13px] text-fd-muted-foreground">
           <span>
             Built with{" "}
-            <a href="https://fumadocs.dev" target="_blank" rel="noopener noreferrer" className="text-fd-muted-foreground underline decoration-fd-border underline-offset-4 hover:text-fd-primary">
+            <a
+              href="https://fumadocs.dev"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline decoration-fd-border underline-offset-4 hover:text-fd-primary"
+            >
               Fumadocs
+            </a>
+            {" · "}
+            Designed with{" "}
+            <a
+              href="https://claude.ai/design"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline decoration-fd-border underline-offset-4 hover:text-fd-primary"
+            >
+              Claude Design
             </a>
           </span>
           <nav aria-label="Footer" className="flex gap-5">
-            <a href={SITE.github} target="_blank" rel="noopener noreferrer" className="hover:text-fd-muted-foreground">GitHub</a>
-            <Link href="/docs/getting-started/installation" className="hover:text-fd-muted-foreground">Docs</Link>
-            <Link href="/docs/cookbook/implement-feature" className="hover:text-fd-muted-foreground">Cookbook</Link>
+            <a href={SITE.github} target="_blank" rel="noopener noreferrer" className="hover:text-fd-foreground">
+              GitHub
+            </a>
+            <Link href="/docs/getting-started/installation" className="hover:text-fd-foreground">
+              Docs
+            </Link>
+            <Link href="#cookbook" className="hover:text-fd-foreground">
+              Cookbook
+            </Link>
           </nav>
         </div>
       </footer>

--- a/docs/site/content/docs/reference/skills/design-import.mdx
+++ b/docs/site/content/docs/reference/skills/design-import.mdx
@@ -154,7 +154,7 @@ The agent already ran component-search per component. Read decisions from the no
 
 For each component with decision `scaffold` or `adapt`, invoke design-to-code:
 
-```python
+````python
 for component in payload["components"]:
     if component["decision"] in ("scaffold", "adapt"):
         # Compose, don't reimplement — design-to-code owns the EXTRACT/MATCH/ADAPT/RENDER pipeline
@@ -177,7 +177,7 @@ for component in payload["components"]:
           Write the component, mirror existing project file structure, use project tokens.
           """
         )
-```
+````
 
 ## Phase 5 — Provenance
 

--- a/plugins/ork/commands/design-import.md
+++ b/plugins/ork/commands/design-import.md
@@ -149,7 +149,7 @@ The agent already ran component-search per component. Read decisions from the no
 
 For each component with decision `scaffold` or `adapt`, invoke design-to-code:
 
-```python
+````python
 for component in payload["components"]:
     if component["decision"] in ("scaffold", "adapt"):
         # Compose, don't reimplement — design-to-code owns the EXTRACT/MATCH/ADAPT/RENDER pipeline
@@ -172,7 +172,7 @@ for component in payload["components"]:
           Write the component, mirror existing project file structure, use project tokens.
           """
         )
-```
+````
 
 ## Phase 5 — Provenance
 

--- a/plugins/ork/skills/design-import/SKILL.md
+++ b/plugins/ork/skills/design-import/SKILL.md
@@ -192,7 +192,7 @@ The agent already ran component-search per component. Read decisions from the no
 
 For each component with decision `scaffold` or `adapt`, invoke design-to-code:
 
-```python
+````python
 for component in payload["components"]:
     if component["decision"] in ("scaffold", "adapt"):
         # Compose, don't reimplement — design-to-code owns the EXTRACT/MATCH/ADAPT/RENDER pipeline
@@ -215,7 +215,7 @@ for component in payload["components"]:
           Write the component, mirror existing project file structure, use project tokens.
           """
         )
-```
+````
 
 ## Phase 5 — Provenance
 

--- a/src/skills/design-import/SKILL.md
+++ b/src/skills/design-import/SKILL.md
@@ -192,7 +192,7 @@ The agent already ran component-search per component. Read decisions from the no
 
 For each component with decision `scaffold` or `adapt`, invoke design-to-code:
 
-```python
+````python
 for component in payload["components"]:
     if component["decision"] in ("scaffold", "adapt"):
         # Compose, don't reimplement — design-to-code owns the EXTRACT/MATCH/ADAPT/RENDER pipeline
@@ -215,7 +215,7 @@ for component in payload["components"]:
           Write the component, mirror existing project file structure, use project tokens.
           """
         )
-```
+````
 
 ## Phase 5 — Provenance
 


### PR DESCRIPTION
## Summary

**First real dogfood of `/ork:design-ship` (Bet A, milestone #113, shipped in #1390).** A Claude Design handoff bundle goes in, this PR comes out — closing existing issue #1247 (shadcn/ui Luma-style docs landing) and proving the closed-loop pipeline works end-to-end on a production target.

Bundle source: `https://api.anthropic.com/v1/design/h/62GsSRNuR5Qe_XdTa2QnZg`

## What changed

### `docs/site/app/(home)/page.tsx`

The 947-line `Landing Page.html` from the Claude Design bundle was a faithful HTML prototype with three stacked sections: hero, value-prop strip, cookbook (primitives + recipes). Ported to React + fumadocs with these decisions:

- **Tokens**: bundle's hex/oklch palette mapped onto existing fumadocs `--color-fd-*` variables (they already aligned). Dark mode works out of the box without adding a separate theme system.
- **Hero**: top-center radial emerald gradient, dot-grid backdrop, eyebrow pill with pulsing dot, gradient-text H1 split, mono-inflected count subhead, primary + ghost CTAs, dotted-divider proof strip with **real** GitHub stars + CC version.
- **Value-prop strip**: 3 personas in a unified rounded container, emerald left-border on hover, mono eyebrows numbered 01/02/03.
- **Cookbook**: Primitives (3-col spec cards with glyph + count + unit + 2-line desc) above Recipes (responsive 1/2/3/4-col grid, numbered headers, command footer, **NEW** badge on `/ork:design-ship`).
- **Demo Showcase**: kept from the prior landing — unique functionality the design didn't cover.
- **Footer**: credits Claude Design + Fumadocs.

### Functional preservation
- `getStarCount()` — real, formatted (`2.4k`)
- `CopyInstallButton` — kept
- `AnimateOnView` — kept on hero entry
- `COMPOSITIONS` — kept for demo strip
- All hrefs go to real Next.js routes
- Recipe `/ork:` commands map to real shipped skills
- Geist + Geist Mono retained (existing brand type — design intent comes through via `font-mono`)

### Out of scope (intentionally dropped)
- Tweaks panel — design-time only
- Sticky nav from prototype — fumadocs already provides one
- Theme toggle — fumadocs handles it
- Inter + JetBrains Mono — would mean replacing brand type for one page

## Test Plan

- [x] `npx tsc --noEmit` — no errors in the new file (the 1 reported error is a pre-existing `@types/react` toolchain issue, unrelated)
- [ ] Vercel preview deploy — visually verify hero, value-prop, cookbook on light + dark
- [ ] Mobile viewport — primitives collapse to 1 col, recipes to 1, value-prop to 1
- [ ] Dark mode — token mapping validates against fumadocs's `.dark` overrides
- [ ] All 8 recipe links resolve to real cookbook pages

## Live Preview

**[Open the original Claude Design prototype](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/docs-landing-claude-design-1247/docs/feat--docs-landing-claude-design-1247/playground.html)**

This is the source-of-truth HTML the React implementation was ported from. Open it side-by-side with the Vercel preview to compare fidelity. The prototype's Tweaks panel (dot opacity, gradient intensity, hue shift, density, theme) is design-time only and not in the React port.

## Pipeline self-test

This PR exercises the full Bet A pipeline that just merged. Limitations confirmed:
- Bundle schema is a **tarball with `project/` HTML + `chats/` transcripts + README** (our orchestrator agent's spec assumed JSON `components[]` — needs a follow-up update).
- No public Claude Design API yet — bundle is one-shot, exactly as designed.
- The first chat exchange (yesterday) had no `project/` dir because the assistant was waiting for clarification — the second exchange (today) produced the actual prototype after we provided brand colors + content + copy via the hybrid prompt.

Follow-ups from this run:
- Update `claude-design-orchestrator` agent's expected schema (HTML prototypes, not JSON manifests). Will open as a separate issue.

## Closes

Closes #1247

---

🤖 Implemented via the Claude Design pipeline shipped in #1390.