### PR TITLE
test(build): round-trip test for sync_versions function (Road to 10 — PR-T2)

### DIFF
--- a/docs/test--sync-versions-round-trip/playground.html
+++ b/docs/test--sync-versions-round-trip/playground.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR-T2 — sync_versions round-trip test</title>
+<style>
+  :root {
+    --bg: #0c0f14;
+    --panel: #1a2030;
+    --border: #1e293b;
+    --text: #e2e8f0;
+    --dim: #94a3b8;
+    --faint: #64748b;
+    --primary: #10b981;
+    --green: #4ade80;
+    --amber: #fbbf24;
+    --red: #f87171;
+    --mono: ui-monospace,Menlo,Consolas,monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.55 system-ui,sans-serif;
+    background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.04) 1px, transparent 0);
+    background-size: 8px 8px;
+    padding: 40px 24px 80px;
+  }
+  .wrap { max-width: 900px; margin: 0 auto; }
+  .pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 10px; border-radius: 99px;
+    background: rgba(16,185,129,0.18);
+    border: 1px solid var(--primary);
+    color: var(--primary);
+    font: 11px var(--mono);
+    margin-bottom: 14px;
+  }
+  h1 { font-size: 22px; font-weight: 600; margin-bottom: 4px; letter-spacing: -0.02em; }
+  h1 .accent { color: var(--primary); }
+  .subtitle { color: var(--dim); font: 12px var(--mono); margin-bottom: 24px; }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 18px;
+    margin-bottom: 16px;
+  }
+  .card h2 { font-size: 13px; font-weight: 600; margin-bottom: 10px; }
+  .flow {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    gap: 12px;
+    align-items: center;
+    font: 12px var(--mono);
+  }
+  .phase {
+    background: #0f131a;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 10px 12px;
+    min-height: 120px;
+  }
+  .phase h3 { font-size: 11px; font-weight: 600; color: var(--primary); margin-bottom: 6px; text-transform: uppercase; letter-spacing: 0.06em; }
+  .phase ul { list-style: none; padding: 0; color: var(--dim); font-size: 11.5px; line-height: 1.5; }
+  .arrow { color: var(--faint); font-size: 20px; text-align: center; }
+  pre {
+    background: #0f131a;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+    font: 11.5px/1.5 var(--mono);
+    overflow-x: auto;
+    color: var(--dim);
+  }
+  pre .pass { color: var(--green); }
+  pre .section { color: var(--text); font-weight: 600; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <span class="pill">Road to 10 — Wave 2 · PR-T2</span>
+  <h1><span class="accent">sync_versions</span> round-trip test</h1>
+  <div class="subtitle">14 assertions · bash · locks in #1407 behavior</div>
+
+  <div class="card">
+    <h2>What it locks</h2>
+    <p style="color: var(--dim); font-size: 12.5px;">
+      Lane 2 #1407 added a function to <code>scripts/stamp-counts.sh</code> that reads <code>package.json</code> and propagates the version to 6 sibling files. No test existed for it. If someone later refactors and breaks the propagation, the next release would silently drift across files (exactly the bug Lane 2 was designed to prevent).
+    </p>
+  </div>
+
+  <div class="card">
+    <h2>Round-trip flow</h2>
+    <div class="flow">
+      <div class="phase">
+        <h3>1 — Pre-flight</h3>
+        <ul>
+          <li>Capture all 7 file versions</li>
+          <li>Refuse to run if any mismatch</li>
+          <li>Arm EXIT trap to restore</li>
+        </ul>
+      </div>
+      <div class="arrow">→</div>
+      <div class="phase">
+        <h3>2 — Bump + sync</h3>
+        <ul>
+          <li>pkg.json → 999.888.777</li>
+          <li>Run stamp-counts.sh</li>
+          <li>Assert all 6 siblings match</li>
+        </ul>
+      </div>
+      <div class="arrow">→</div>
+      <div class="phase">
+        <h3>3 — Restore</h3>
+        <ul>
+          <li>pkg.json → original</li>
+          <li>Run stamp-counts.sh again</li>
+          <li>Assert all restored</li>
+          <li>validate-counts agrees</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Local run output</h2>
+<pre><span class="section">▶ Test 1: sync propagates a bump</span>
+  <span class="pass">✓ pyproject synced to 999.888.777</span>
+  <span class="pass">✓ manifest synced to 999.888.777</span>
+  <span class="pass">✓ market-top synced to 999.888.777</span>
+  <span class="pass">✓ market-plugin synced to 999.888.777</span>
+  <span class="pass">✓ release-please synced to 999.888.777</span>
+  <span class="pass">✓ CLAUDE synced to 999.888.777</span>
+
+<span class="section">▶ Test 2: sync propagates the restoration back</span>
+  <span class="pass">✓ pyproject restored to 7.56.0</span>
+  <span class="pass">✓ manifest restored to 7.56.0</span>
+  ...
+
+<span class="section">▶ Test 3: validate-counts.sh accepts the final state</span>
+  <span class="pass">✓ validate-counts passes after round-trip</span>
+
+════════════════════════════════════════════════════════════════
+  Total: <span class="pass">14  |  Passed: 14  |  Failed: 0</span>
+════════════════════════════════════════════════════════════════</pre>
+  </div>
+
+  <div class="card">
+    <h2>Safety</h2>
+    <ul style="color: var(--dim); font-size: 12.5px; padding-left: 18px;">
+      <li>Trap on EXIT + INT + TERM restores the original version regardless of how the test exits (including Ctrl-C). No wedged states.</li>
+      <li>Pre-flight guard aborts if any file is already mismatched — the test refuses to run on a dirty baseline.</li>
+      <li>Wired into <code>tests/run-all-tests.sh</code> under UNIT TESTS, so <code>npm test</code> runs it.</li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -169,6 +169,7 @@ if [[ "$RUN_UNIT" == "true" ]]; then
     run_test "Context Schema Validation" "$SCRIPT_DIR/unit/test-context-schemas.sh" || true
     run_test "Graph Utils Unit Tests" "$SCRIPT_DIR/unit/test-graph-utils.sh" || true
     run_test "MDX Compile Guard" "$SCRIPT_DIR/unit/test-mdx-compile.sh" || true
+    run_test "Version Sync Round-Trip" "$SCRIPT_DIR/unit/test-sync-versions.sh" || true
 
     # TypeScript hook tests (vitest)
     if [[ -n "${CI:-}" ]]; then

--- a/tests/unit/test-sync-versions.sh
+++ b/tests/unit/test-sync-versions.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Round-trip test for the sync_versions function in scripts/stamp-counts.sh
+# (introduced in #1407, Lane 2).
+#
+# The function reads package.json's version and propagates it to:
+#   - pyproject.toml
+#   - manifests/ork.json
+#   - .claude-plugin/marketplace.json (top-level + plugins[0].version)
+#   - .release-please-manifest.json
+#   - CLAUDE.md ("**Current**: X.Y.Z" line)
+#
+# This test pins that behavior: bump, sync, assert all synced, restore.
+#
+# Part of Road to 10 — Wave 2 PR-T2.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo "  ${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo "════════════════════════════════════════════════════════════════"
+echo "  sync_versions round-trip (Lane 2 #1407)"
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+
+# ─── Pre-flight: capture original versions so we can restore everything ─
+ORIG_PKG=$(jq -r '.version' package.json)
+ORIG_PYPROJ=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/.*"([^"]*)".*/\1/')
+ORIG_MANIFEST=$(jq -r '.version' manifests/ork.json)
+ORIG_MARKET_TOP=$(jq -r '.version' .claude-plugin/marketplace.json)
+ORIG_MARKET_PLUGIN=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+ORIG_RP=$(jq -r '.["."]' .release-please-manifest.json)
+ORIG_CLAUDE=$(grep -E '^\- \*\*Current\*\*:' CLAUDE.md | sed -E 's/.*Current\*\*: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
+
+echo "Original version:     $ORIG_PKG"
+echo ""
+
+# Guard: refuse to run if any file is already mismatched — we need a
+# clean baseline so a post-test restoration leaves the repo pristine.
+for pair in "pyproject:$ORIG_PYPROJ" "manifest:$ORIG_MANIFEST" "market-top:$ORIG_MARKET_TOP" "market-plugin:$ORIG_MARKET_PLUGIN" "release-please:$ORIG_RP" "CLAUDE:$ORIG_CLAUDE"; do
+  IFS=: read -r label value <<<"$pair"
+  if [[ "$value" != "$ORIG_PKG" ]]; then
+    fail "Pre-flight: $label shows $value, expected $ORIG_PKG — repo is in a mismatched state before the test"
+    echo ""
+    echo "Run \`npm run build\` to reconcile, then retry."
+    exit 1
+  fi
+done
+pass "Pre-flight: all 7 files match at $ORIG_PKG"
+echo ""
+
+# ─── Always restore, even on failure or interrupt ──────────────────
+cleanup() {
+  local ec=$?
+  echo ""
+  echo "─── restoring original version $ORIG_PKG ──────────────────────────"
+  jq --arg v "$ORIG_PKG" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+  bash scripts/stamp-counts.sh >/dev/null 2>&1 || true
+  exit $ec
+}
+trap cleanup EXIT INT TERM
+
+# ─── Test 1: bump synthetic version + sync + assert ────────────────
+FAKE_VER="999.888.777"
+echo "▶ Test 1: sync propagates a bump"
+echo "────────────────────────────────────────────────────────────────"
+
+jq --arg v "$FAKE_VER" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+bash scripts/stamp-counts.sh >/dev/null 2>&1
+
+# Assert each sibling now shows FAKE_VER
+declare -A POST
+POST[pyproject]=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/.*"([^"]*)".*/\1/')
+POST[manifest]=$(jq -r '.version' manifests/ork.json)
+POST[market-top]=$(jq -r '.version' .claude-plugin/marketplace.json)
+POST[market-plugin]=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+POST[release-please]=$(jq -r '.["."]' .release-please-manifest.json)
+POST[CLAUDE]=$(grep -E '^\- \*\*Current\*\*:' CLAUDE.md | sed -E 's/.*Current\*\*: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
+
+ALL_MATCHED=1
+for key in pyproject manifest market-top market-plugin release-please CLAUDE; do
+  if [[ "${POST[$key]}" == "$FAKE_VER" ]]; then
+    pass "$key synced to $FAKE_VER"
+  else
+    fail "$key stuck at ${POST[$key]} (expected $FAKE_VER)"
+    ALL_MATCHED=0
+  fi
+done
+
+if [[ $ALL_MATCHED -ne 1 ]]; then
+  echo ""
+  echo "sync_versions failed to propagate. Check scripts/stamp-counts.sh."
+  exit 1
+fi
+echo ""
+
+# ─── Test 2: restore original + assert ──────────────────────────────
+echo "▶ Test 2: sync propagates the restoration back"
+echo "────────────────────────────────────────────────────────────────"
+
+jq --arg v "$ORIG_PKG" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+bash scripts/stamp-counts.sh >/dev/null 2>&1
+
+declare -A RESTORED
+RESTORED[pyproject]=$(grep -E '^version\s*=' pyproject.toml | sed -E 's/.*"([^"]*)".*/\1/')
+RESTORED[manifest]=$(jq -r '.version' manifests/ork.json)
+RESTORED[market-top]=$(jq -r '.version' .claude-plugin/marketplace.json)
+RESTORED[market-plugin]=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+RESTORED[release-please]=$(jq -r '.["."]' .release-please-manifest.json)
+RESTORED[CLAUDE]=$(grep -E '^\- \*\*Current\*\*:' CLAUDE.md | sed -E 's/.*Current\*\*: ([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
+
+for key in pyproject manifest market-top market-plugin release-please CLAUDE; do
+  if [[ "${RESTORED[$key]}" == "$ORIG_PKG" ]]; then
+    pass "$key restored to $ORIG_PKG"
+  else
+    fail "$key stuck at ${RESTORED[$key]} (expected $ORIG_PKG)"
+  fi
+done
+echo ""
+
+# ─── Test 3: validate-counts.sh agrees with the round-trip ──────────
+echo "▶ Test 3: validate-counts.sh accepts the final state"
+echo "────────────────────────────────────────────────────────────────"
+
+if bash bin/validate-counts.sh >/dev/null 2>&1; then
+  pass "validate-counts passes after round-trip"
+else
+  fail "validate-counts rejects the state after round-trip"
+fi
+echo ""
+
+# ─── Summary ────────────────────────────────────────────────────────
+echo "════════════════════════════════════════════════════════════════"
+echo "  Total: $((PASS + FAIL))  |  Passed: ${GREEN}${PASS}${NC}  |  Failed: ${RED}${FAIL}${NC}"
+echo "════════════════════════════════════════════════════════════════"
+
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Wave 2 PR-T2 — second test debt paydown PR. Locks in the `sync_versions` function introduced by #1407 (Lane 2). Without this test, a future refactor could silently break version propagation — exactly the drift Lane 2 was built to prevent.

## What it tests

Three-phase round-trip in `tests/unit/test-sync-versions.sh`:

1. **Pre-flight** — capture original versions across all 7 files; refuse to run if any are already mismatched; arm EXIT/INT/TERM trap so a Ctrl-C does not wedge the repo.
2. **Bump + sync** — set `package.json` to a synthetic `999.888.777`, run `scripts/stamp-counts.sh`, assert all 6 siblings now show the new version.
3. **Restore** — set `package.json` back to the original, run sync again, assert all 6 siblings restored, then assert `bin/validate-counts.sh` agrees with the final state.

14 assertions total. Wired into `tests/run-all-tests.sh` under UNIT TESTS so `npm test` runs it.

## Local verification

```
$ bash tests/unit/test-sync-versions.sh
  Total: 14 | Passed: 14 | Failed: 0
```

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/test/sync-versions-round-trip/docs/test--sync-versions-round-trip/playground.html)**

Three-phase flow diagram + sample output.

## Wave 2 progress

```
PR-T1   formatStars unit test                 ✓ merged (#1412, sha bc94b64d7)
PR-T2   sync_versions round-trip              ← THIS PR
PR-T3   Playwright E2E for redesigned landing next
PR-T4   handoff bundle schema validator
PR-T5   stub-fallback integration test
```

---

Tracking: Road to 10 — Wave 2 (Lever 5: Testability).