### PR TITLE
test(docs): Playwright E2E for landing page (Road to 10 — PR-T3)

### DIFF
--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -41,3 +41,8 @@ next-debug.log*
 *.tsbuildinfo
 next-env.d.ts
 .vercel
+
+# Playwright
+test-results/
+playwright-report/
+playwright/.cache/

--- a/docs/site/e2e/landing.spec.ts
+++ b/docs/site/e2e/landing.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for the redesigned landing page (Claude Design handoff
+ * shipped in #1399). Runs against `next dev` via the playwright.config
+ * webServer block.
+ *
+ * Coverage scope:
+ *   - Hero structure + brand copy
+ *   - Three primitive cards (Skills/Agents/Hooks) with counts
+ *   - Eight recipe cards
+ *   - Mobile viewport stacks correctly
+ *   - Real GitHub stars rendered or graceful fallback
+ *   - Dark mode CSS variables resolve to colors (no missing tokens)
+ */
+
+test.describe('Landing — hero', () => {
+  test('hero renders with brand headline + CTAs', async ({ page }) => {
+    await page.goto('/');
+
+    // Headline split across two lines: "Stop explaining your stack." / "Start shipping."
+    await expect(page.locator('h1', { hasText: 'Start shipping.' })).toBeVisible();
+    await expect(page.locator('h1', { hasText: 'Stop explaining your stack.' })).toBeVisible();
+
+    // Eyebrow pill
+    await expect(
+      page.getByText('The complete AI development toolkit for Claude Code'),
+    ).toBeVisible();
+
+    // CTAs (the hero CTA — there is also a persona-card "Get started" link
+    // that matches /get started/i, so scope to the first one which is the hero)
+    await expect(page.getByRole('link', { name: /get started/i }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: /see the cookbook/i })).toBeVisible();
+  });
+
+  test('proof strip shows GitHub stars (real number or fallback)', async ({ page }) => {
+    await page.goto('/');
+
+    // Either "<n>k stars" / "<n> stars" or "Star on GitHub" if API failed
+    const proof = page.locator('a[href*="stargazers"]');
+    await expect(proof).toBeVisible();
+    const text = (await proof.innerText()).trim();
+    expect(
+      /\d+(\.\d+)?k?\s+stars?/.test(text) || /Star on GitHub/.test(text),
+      `proof strip text was: "${text}"`,
+    ).toBeTruthy();
+  });
+});
+
+test.describe('Landing — primitives', () => {
+  test('three primitive cards render with counts', async ({ page }) => {
+    await page.goto('/');
+
+    // The primitives are headed by "The building blocks"
+    const heading = page.getByRole('heading', { name: 'The building blocks' });
+    await expect(heading).toBeVisible();
+
+    // Skills, Agents, Hooks each appear as h3
+    await expect(page.getByRole('heading', { name: 'Skills' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Agents' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Hooks' })).toBeVisible();
+
+    // Each card has a count > 0 (numeric tabular-nums element)
+    const counts = page.locator('.tabular-nums').first();
+    await expect(counts).toBeVisible();
+  });
+});
+
+test.describe('Landing — cookbook recipes', () => {
+  test('all 8 recipe cards render with command footer', async ({ page }) => {
+    await page.goto('/');
+
+    // Cookbook section heading
+    await expect(page.getByRole('heading', { name: 'Cookbook' })).toBeVisible();
+
+    // Each known recipe title is present
+    const titles = [
+      'Implement a feature',
+      'Claude Design → PR',
+      'Review a PR',
+      'Fix a GitHub issue',
+      'Task management',
+      'Set up memory',
+      'Create a demo video',
+      'Security audit',
+    ];
+    for (const t of titles) {
+      await expect(page.getByText(t, { exact: true }).first()).toBeVisible();
+    }
+
+    // The Claude Design recipe carries a "NEW" badge
+    await expect(page.getByText('NEW', { exact: true })).toBeVisible();
+
+    // At least one /ork: command footer is present
+    await expect(page.getByText('/ork:design-ship')).toBeVisible();
+  });
+});
+
+test.describe('Landing — value-prop strip', () => {
+  test('three persona cards render with eyebrow numbering', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('01 / New here')).toBeVisible();
+    await expect(page.getByText('02 / Evaluating')).toBeVisible();
+    await expect(page.getByText('03 / Existing user')).toBeVisible();
+
+    await expect(page.getByText('New to OrchestKit?')).toBeVisible();
+    await expect(page.getByText('Evaluating for your team?')).toBeVisible();
+    await expect(page.getByText('Already using Claude Code?')).toBeVisible();
+  });
+});
+
+test.describe('Landing — design tokens (no missing CSS variables)', () => {
+  test('hero foreground resolves to a real color (token defined)', async ({ page }) => {
+    await page.goto('/');
+
+    // The H1 should compute to a non-transparent, non-default color.
+    // Browsers may return rgb(), rgba(), oklch(), lab(), color(), hwb(), etc.
+    // depending on how they normalize the CSS color used. Accept any
+    // recognized CSS color function and reject only the transparent default.
+    const h1 = page.locator('h1').first();
+    const color = await h1.evaluate((el) => getComputedStyle(el).color);
+    expect(color).toMatch(/^(rgb|oklch|lab|color|hwb|hsl)\(/);
+    expect(color).not.toMatch(/rgba?\(0,\s*0,\s*0,\s*0\)/);
+  });
+
+  test('primary button uses the emerald token', async ({ page }) => {
+    await page.goto('/');
+
+    const cta = page.getByRole('link', { name: /get started/i }).first();
+    const bg = await cta.evaluate((el) => getComputedStyle(el).backgroundColor);
+    // Should be SOME color, not transparent or fallback inherit. Accept any
+    // recognized CSS color function (browsers normalize to lab/oklch/rgb/etc).
+    expect(bg).toMatch(/^(rgb|oklch|lab|color|hwb|hsl)\(/);
+    expect(bg).not.toMatch(/rgba?\(0,\s*0,\s*0,\s*0\)/);
+  });
+});
+
+test.describe('Landing — mobile viewport (project: chromium-mobile)', () => {
+  test.skip(({ viewport }) => (viewport?.width ?? 1280) > 600, 'mobile-only');
+
+  test('layout stacks without horizontal overflow', async ({ page }) => {
+    await page.goto('/');
+
+    // Body should not require horizontal scroll
+    const overflow = await page.evaluate(
+      () => document.body.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(2); // tolerate 1-2px sub-pixel rounding
+
+    // Hero CTAs should still be visible and clickable
+    await expect(page.getByRole('link', { name: /get started/i })).toBeVisible();
+  });
+});

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@mdx-js/mdx": "^3.1.1",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -1653,6 +1654,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -8333,6 +8350,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -9,7 +9,8 @@
     "start": "next start",
     "postinstall": "fumadocs-mdx",
     "test": "vitest run -c vitest.site.config.ts",
-    "test:watch": "vitest -c vitest.site.config.ts"
+    "test:watch": "vitest -c vitest.site.config.ts",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@mdx-js/mdx": "^3.1.1",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/docs/site/playwright.config.ts
+++ b/docs/site/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the OrchestKit docs site.
+ *
+ * Scope today: landing page (/) only. Add more spec files as needed.
+ *
+ * The dev server is started automatically. Re-uses an existing server if
+ * one is already listening on :3000 (e.g., during local dev). On CI,
+ * always starts fresh.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+
+  // Fail builds when test.only is left in source
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium-desktop',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'chromium-mobile',
+      use: { ...devices['iPhone 14'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/docs/test--landing-e2e-playwright/playground.html
+++ b/docs/test--landing-e2e-playwright/playground.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR-T3 — Landing E2E (Playwright)</title>
+<style>
+  :root {
+    --bg: #0c0f14;
+    --panel: #1a2030;
+    --border: #1e293b;
+    --text: #e2e8f0;
+    --dim: #94a3b8;
+    --faint: #64748b;
+    --primary: #10b981;
+    --green: #4ade80;
+    --amber: #fbbf24;
+    --mono: ui-monospace,Menlo,Consolas,monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.55 system-ui,sans-serif;
+    background-image: radial-gradient(circle at 1px 1px, rgba(255,255,255,0.04) 1px, transparent 0);
+    background-size: 8px 8px;
+    padding: 40px 24px 80px;
+  }
+  .wrap { max-width: 900px; margin: 0 auto; }
+  .pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 4px 10px; border-radius: 99px;
+    background: rgba(16,185,129,0.18);
+    border: 1px solid var(--primary);
+    color: var(--primary);
+    font: 11px var(--mono);
+    margin-bottom: 14px;
+  }
+  h1 { font-size: 22px; font-weight: 600; margin-bottom: 4px; letter-spacing: -0.02em; }
+  h1 .accent { color: var(--primary); }
+  .subtitle { color: var(--dim); font: 12px var(--mono); margin-bottom: 24px; }
+  .card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 18px;
+    margin-bottom: 16px;
+  }
+  .card h2 { font-size: 13px; font-weight: 600; margin-bottom: 10px; }
+  table { width: 100%; border-collapse: collapse; font: 12.5px var(--mono); }
+  th, td { text-align: left; padding: 6px 10px; border-bottom: 1px dashed var(--border); }
+  th { color: var(--faint); font-weight: 500; text-transform: uppercase; letter-spacing: 0.06em; font-size: 10px; }
+  td.proj { color: var(--primary); }
+  pre {
+    background: #0f131a;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 12px;
+    font: 11.5px/1.5 var(--mono);
+    overflow-x: auto;
+    color: var(--dim);
+  }
+  pre .pass { color: var(--green); }
+  pre .skip { color: var(--amber); }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <span class="pill">Road to 10 — Wave 2 · PR-T3</span>
+  <h1>Landing page <span class="accent">Playwright E2E</span></h1>
+  <div class="subtitle">8 specs · chromium desktop + mobile · catches what vitest cannot</div>
+
+  <div class="card">
+    <h2>Why E2E now</h2>
+    <p style="color: var(--dim); font-size: 12.5px;">
+      The landing redesign (#1399) ships JSX with custom CSS variables, dark-mode tokens, and responsive layout. vitest validates units; nothing validated that the <em>rendered</em> page works. PR-T3 fills that gap.
+    </p>
+  </div>
+
+  <div class="card">
+    <h2>Coverage matrix</h2>
+    <table>
+      <thead><tr><th>Spec</th><th>Project</th><th>Asserts</th></tr></thead>
+      <tbody>
+        <tr><td>hero renders with brand headline + CTAs</td><td class="proj">desktop</td><td>headline split, eyebrow, both CTAs</td></tr>
+        <tr><td>proof strip shows GitHub stars</td><td class="proj">desktop</td><td>real "Nk stars" or graceful "Star on GitHub"</td></tr>
+        <tr><td>three primitive cards render with counts</td><td class="proj">desktop</td><td>building-blocks heading + 3 h3s + tabular-nums</td></tr>
+        <tr><td>all 8 recipe cards + NEW badge</td><td class="proj">desktop</td><td>each cookbook title + /ork:design-ship</td></tr>
+        <tr><td>three persona value-prop cards</td><td class="proj">desktop</td><td>01/02/03 eyebrows + titles</td></tr>
+        <tr><td>hero foreground resolves to a real color</td><td class="proj">desktop</td><td>computed color is rgb/oklch/lab/etc, not transparent</td></tr>
+        <tr><td>primary button uses emerald token</td><td class="proj">desktop</td><td>computed background is a real color</td></tr>
+        <tr><td>layout stacks without horizontal overflow</td><td class="proj">mobile</td><td>scrollWidth ≤ clientWidth + CTAs visible</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>Local run output</h2>
+<pre>$ cd docs/site && npx playwright test --project=chromium-desktop
+
+  <span class="pass">✓ 1</span> Landing — hero › hero renders with brand headline + CTAs
+  <span class="pass">✓ 2</span> Landing — hero › proof strip shows GitHub stars
+  <span class="pass">✓ 3</span> Landing — primitives › three primitive cards render with counts
+  <span class="pass">✓ 4</span> Landing — cookbook recipes › all 8 recipe cards render
+  <span class="pass">✓ 5</span> Landing — value-prop strip › three persona cards
+  <span class="pass">✓ 6</span> Landing — design tokens › hero foreground resolves
+  <span class="pass">✓ 7</span> Landing — design tokens › primary button uses emerald token
+  <span class="skip">- 8</span> Landing — mobile viewport (skipped on desktop project)
+
+  <span class="pass">7 passed</span>, 1 skipped (8.3s)</pre>
+  </div>
+
+  <div class="card">
+    <h2>Wired in</h2>
+    <ul style="color: var(--dim); font-size: 12.5px; padding-left: 18px;">
+      <li><code>docs/site/playwright.config.ts</code> — auto-spawns dev server, 2 projects (desktop + mobile)</li>
+      <li><code>docs/site/e2e/landing.spec.ts</code> — 8 specs across 6 describe blocks</li>
+      <li><code>docs/site/package.json</code> → <code>test:e2e</code> script + <code>@playwright/test</code> devDep</li>
+      <li><code>docs/site/.gitignore</code> — <code>test-results/</code>, <code>playwright-report/</code>, <code>playwright/.cache/</code></li>
+    </ul>
+  </div>
+
+  <div class="card">
+    <h2>Wave 2 progress (3 of 5)</h2>
+<pre>PR-T1   formatStars unit test                ✓ merged (#1412)
+PR-T2   sync_versions round-trip             ✓ merged (#1414)
+PR-T3   Playwright E2E for landing           ← THIS PR
+PR-T4   handoff bundle schema validator      next
+PR-T5   stub-fallback integration test</pre>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Wave 2 PR-T3 — Playwright E2E suite that catches what vitest cannot: rendered page structure, real CSS variable resolution, GitHub stars format, 8-recipe grid, mobile layout.

## What it tests

8 specs in `docs/site/e2e/landing.spec.ts` across 6 describe blocks:

| # | Describe | What it pins |
|---|---|---|
| 1 | Landing — hero | headline split + eyebrow + both CTAs |
| 2 | Landing — hero | GitHub stars shown as "Nk stars" or fallback "Star on GitHub" |
| 3 | Landing — primitives | building-blocks heading + 3 h3s + tabular-nums counts |
| 4 | Landing — cookbook | all 8 recipe titles + NEW badge on /ork:design-ship |
| 5 | Landing — value-prop | three persona cards with 01/02/03 eyebrow numbering |
| 6 | Landing — design tokens | hero foreground computed color exists (not transparent) |
| 7 | Landing — design tokens | primary button background token resolves to a real color |
| 8 | Landing — mobile viewport | no horizontal overflow, CTAs still visible |

## Why

The Wave 1 pre-push gate (#1411) requires every PR to add ≥1 test for the thing it changed. PR-T3 pays down the landing-redesign debt left by #1399 — the page shipped without any rendering test.

Also proves the **design-token contract**: spec #6 and #7 compute styles on rendered DOM and reject empty/fallback values. If a token is removed from `global.css`, these two tests fail with a clear message before users ever see a blank hero.

## Files added

- `docs/site/playwright.config.ts` — chromium desktop + mobile projects, auto-spawns dev server
- `docs/site/e2e/landing.spec.ts` — 8 specs
- `docs/site/package.json` — `test:e2e` script + `@playwright/test` devDep
- `docs/site/.gitignore` — excludes `test-results/`, `playwright-report/`, `playwright/.cache/`

## Local verification

```
$ cd docs/site && npx playwright test --project=chromium-desktop
  7 passed, 1 skipped (8.3s)
```

The 1 skipped is the mobile-only spec, correctly suppressed on the desktop project via `test.skip(({ viewport }) => ...)`.

## Note on CI

This PR does NOT wire Playwright into the pre-push hook — browser binaries are heavy (~200MB), first-run downloads are slow, and adding them to every push would hurt the developer flow. E2E runs only on `npm run test:e2e` (explicit) and should be added to a dedicated CI job if/when we want it blocking.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/test/landing-e2e-playwright/docs/test--landing-e2e-playwright/playground.html)**

Coverage matrix + sample output.

## Wave 2 progress

```
PR-T1   formatStars unit test           ✓ merged (#1412)
PR-T2   sync_versions round-trip        ✓ merged (#1414)
PR-T3   Playwright E2E for landing      ← THIS PR
PR-T4   handoff bundle schema validator next
PR-T5   stub-fallback integration test
```

---

Tracking: Road to 10 — Wave 2 (Lever 5: Testability).