### PR TITLE
fix(#1525): bump invocable caps + /ork:dev argument-hint

### DIFF
--- a/plugins/ork/skills/dev/SKILL.md
+++ b/plugins/ork/skills/dev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev
 description: "One-command dev loop boot. Spins up portless (named HTTPS subdomain), emulate (stateful API mocks), the project's dev server, and an agent-browser session — all using the current git branch as the namespace key. Replaces the 4-terminal manual setup with a single `/ork:dev` invocation. Use when starting a new feature branch, switching worktrees, or returning to a project after a break. Skip silently when prerequisite binaries (portless, emulate, agent-browser) are missing — emits install hints."
+argument-hint: "[start|stop|status]"
 tags: [dev-loop, portless, emulate, agent-browser, vercel-labs, lab-stack, m125]
 version: 1.0.0
 author: OrchestKit

--- a/src/skills/dev/SKILL.md
+++ b/src/skills/dev/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: dev
 description: "One-command dev loop boot. Spins up portless (named HTTPS subdomain), emulate (stateful API mocks), the project's dev server, and an agent-browser session — all using the current git branch as the namespace key. Replaces the 4-terminal manual setup with a single `/ork:dev` invocation. Use when starting a new feature branch, switching worktrees, or returning to a project after a break. Skip silently when prerequisite binaries (portless, emulate, agent-browser) are missing — emits install hints."
+argument-hint: "[start|stop|status]"
 tags: [dev-loop, portless, emulate, agent-browser, vercel-labs, lab-stack, m125]
 version: 1.0.0
 author: OrchestKit

--- a/tests/performance/test-token-overhead.sh
+++ b/tests/performance/test-token-overhead.sh
@@ -78,7 +78,7 @@ CLAUDE_MD_MAX_BYTES=4800       # ~1,200 tokens — project instructions
 MEMORY_MD_MAX_BYTES=5000       # ~1,250 tokens — auto-memory (trim the bloat)
 AGENT_DESC_TOTAL_MAX_BYTES=6000  # ~1,500 tokens — all 38 agent descriptions combined
 AGENT_DESC_SINGLE_MAX_BYTES=250  # ~62 tokens — no single agent description > 250 bytes
-MAX_USER_INVOCABLE_SKILLS=26   # Each adds ~50-100 tokens to system prompt (23→25: +design-import, +design-ship, Bet A #113; 25→26: +telemetry-inspect, M121 #1491)
+MAX_USER_INVOCABLE_SKILLS=27   # Each adds ~50-100 tokens to system prompt (23→25: +design-import, +design-ship, Bet A #113; 25→26: +telemetry-inspect, M121 #1491; 26→27: +dev, M125 Lane B #1525)
 HOOK_BUDGET_MAX_TOKENS=800     # Per-turn dispatcher cap
 TOTAL_SESSION_MAX_TOKENS=5200  # Combined session overhead budget (bumped for CC 2.1.90 version matrix growth)
 

--- a/tests/skills/structure/test-skill-md.sh
+++ b/tests/skills/structure/test-skill-md.sh
@@ -509,7 +509,7 @@ echo -e "${CYAN}Test 10: user-invocable Field Validation${NC}"
 echo "────────────────────────────────────────────────────────────────────────────"
 
 # Expected counts
-EXPECTED_USER_INVOCABLE=26
+EXPECTED_USER_INVOCABLE=27  # M125 Lane B added /ork:dev (#1525)
 EXPECTED_INTERNAL=80
 
 missing_user_invocable=()


### PR DESCRIPTION
## Summary

Three test/skill changes stranded after Lane B PR #1534 squash-merged before all follow-up fix commits had landed.

| Change | Reason |
|---|---|
| EXPECTED_USER_INVOCABLE 26 → 27 in test-skill-md.sh | M125 Lane B added /ork:dev |
| MAX_USER_INVOCABLE_SKILLS 26 → 27 in test-token-overhead.sh | same |
| argument-hint added to dev SKILL.md | test-skill-cc-features.sh requires it |

Same fixes as commit 30bf4f9bb on the (closed) Lane B branch.

## Verification
- test-token-overhead.sh → 7/0
- test-skill-md.sh → all critical tests pass
- test-skill-cc-features.sh → 8/0

## Unblocks
#1533 (release 7.73.0) which is currently failing on these same tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)