### PR TITLE
chore(ci): update cc-version-matrix for 2.1.138 floor (#1683)

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -289,11 +289,11 @@ jobs:
         id: install-cc
         run: |
           # Pin to exact version + --ignore-scripts (supply chain mitigation — Scorecard #130, #132)
-          # Pinned to our floor (2.1.132) — older versions don't recognize the
+          # Pinned to our floor (2.1.138) — older versions don't recognize the
           # experimental.{monitors,themes} block format introduced in CC 2.1.129
           # and emit a hard error during plugin validate.
           # nosemgrep: pinned-dependencies (npm packages cannot be SHA-pinned; --ignore-scripts mitigates)
-          npm install -g @anthropic-ai/claude-code@2.1.132 --ignore-scripts 2>/dev/null || true
+          npm install -g @anthropic-ai/claude-code@2.1.138 --ignore-scripts 2>/dev/null || true
           # `--ignore-scripts` skips the package's own postinstall which
           # fetches the native `claude` binary. Without this explicit
           # invocation, the wrapper installs but `command -v claude` finds

--- a/docs/chore--ci-matrix-update-cc-2.1.138/playground.html
+++ b/docs/chore--ci-matrix-update-cc-2.1.138/playground.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>W5 CI matrix update playground</title>
+<style>body{font:14px ui-monospace,monospace;background:#0b0b0b;color:#e8e8e8;padding:32px;max-width:760px;margin:auto}h1{color:#7aa2f7}pre{background:#161616;padding:16px;border-radius:6px}.ok{color:#9ece6a}.bad{color:#f7768e}</style></head><body>
+<h1>W5 — CI matrix update for 2.1.138 floor</h1>
+<p>Aligns CI test fixtures and pinned versions to the new 2.1.138 floor (W4).</p>
+<h2>Changes</h2>
+<ul>
+<li><code>.github/workflows/plugin-validation.yml</code> — npm install pin <span class="bad">2.1.132</span> → <span class="ok">2.1.138</span></li>
+<li><code>tests/integration/test-cc-release-watch.sh</code> — synthetic test version <span class="bad">2.1.133</span> → <span class="ok">2.1.139</span> (above floor); pre-populate list updated to include 2.1.136/137/138 (real merged snapshots)</li>
+<li><code>tests/fixtures/cc-changelogs/synthetic.md</code> — fixture header <span class="bad">2.1.133</span> → <span class="ok">2.1.139</span></li>
+<li><code>tests/security/test-mcp-deny-case.sh</code> — guidance comment floor 2.1.132 → 2.1.138</li>
+</ul>
+<h2>Tests</h2>
+<pre class="ok">test-cc-release-watch.sh: 14/14 passed
+test:security: 14/14 passed
+test:manifests: 108 skills, 0 orphans
+actionlint: clean for plugin-validation.yml (only pre-existing info-level shellcheck on unrelated workflows)</pre>
+</body></html>

--- a/tests/fixtures/cc-changelogs/synthetic.md
+++ b/tests/fixtures/cc-changelogs/synthetic.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.1.133
+## 2.1.139
 
 - `EnterWorktree` now creates the new branch from local HEAD instead of `origin/<default-branch>`, so unpushed commits are no longer dropped (synthetic placeholder; the real upstream behaviour landed in 2.1.128 — kept here as the test fixture's "new version" detection target)
 - `--plugin-dir` now accepts `.zip` plugin archives, enabling offline distribution alongside directory-based loads

--- a/tests/integration/test-cc-release-watch.sh
+++ b/tests/integration/test-cc-release-watch.sh
@@ -63,13 +63,13 @@ rm -rf shared/cc-snapshots/*.md shared/cc-adoption-gaps.json shared/gh-issue-arg
 
 # Pre-populate snapshots for every prior version that's <= cc-support.json.latest
 # to simulate the production steady state. This isolates Test 1 to the "one new
-# version" scenario (2.1.133 — a synthetic future version above the current
-# floor of 2.1.132) without triggering the M130-hotfix recovery path that
+# version" scenario (2.1.139 — a synthetic future version above the current
+# floor of 2.1.138) without triggering the M130-hotfix recovery path that
 # re-snapshots equal-version-but-missing-on-disk entries (covered by a
-# dedicated test below). The fixture pins 2.1.133 specifically so this test
+# dedicated test below). The fixture pins 2.1.139 specifically so this test
 # is resilient to future floor bumps in shared/cc-support.json.
 mkdir -p shared/cc-snapshots
-for v in 2.1.126 2.1.127 2.1.128 2.1.129 2.1.131 2.1.132; do
+for v in 2.1.126 2.1.127 2.1.128 2.1.129 2.1.131 2.1.132 2.1.136 2.1.137 2.1.138; do
   echo "# Claude Code $v (placeholder for test)" > "shared/cc-snapshots/$v.md"
 done
 
@@ -79,13 +79,13 @@ done
 CC_RELEASE_WATCH_FIXTURE=tests/fixtures/cc-changelogs/synthetic.md \
   node scripts/cc-release-watch.mjs > /tmp/watch-out.txt 2>&1
 
-if [ -f shared/cc-snapshots/2.1.133.md ]; then
-  log_pass "Snapshot written for new version 2.1.133"
+if [ -f shared/cc-snapshots/2.1.139.md ]; then
+  log_pass "Snapshot written for new version 2.1.139"
 else
-  log_fail "Snapshot missing" "expected shared/cc-snapshots/2.1.133.md (see /tmp/watch-out.txt)"
+  log_fail "Snapshot missing" "expected shared/cc-snapshots/2.1.139.md (see /tmp/watch-out.txt)"
 fi
 
-if [ -f shared/cc-snapshots/2.1.133.md ] && grep -qF "EnterWorktree" shared/cc-snapshots/2.1.133.md; then
+if [ -f shared/cc-snapshots/2.1.139.md ] && grep -qF "EnterWorktree" shared/cc-snapshots/2.1.139.md; then
   log_pass "Snapshot body contains expected feature bullet"
 else
   log_fail "Snapshot body" "missing 'EnterWorktree' from fixture"
@@ -96,10 +96,10 @@ if [ -f shared/cc-adoption-gaps.json ]; then
   if [ "$COUNT" = "1" ]; then
     log_pass "Gaps JSON has exactly 1 entry"
     GAP_VERSION=$(jq -r '.[0].version' shared/cc-adoption-gaps.json)
-    if [ "$GAP_VERSION" = "2.1.133" ]; then
-      log_pass "Gap entry version = 2.1.133"
+    if [ "$GAP_VERSION" = "2.1.139" ]; then
+      log_pass "Gap entry version = 2.1.139"
     else
-      log_fail "Gap entry version" "expected 2.1.133, got '$GAP_VERSION'"
+      log_fail "Gap entry version" "expected 2.1.139, got '$GAP_VERSION'"
     fi
   else
     log_fail "Gaps JSON entry count" "expected 1, got $COUNT"
@@ -110,10 +110,10 @@ fi
 
 if [ -f shared/gh-issue-args.json ]; then
   TITLE=$(jq -r '.milestone' shared/gh-issue-args.json)
-  if [ "$TITLE" = "CC 2.1.133 adoption" ]; then
-    log_pass "gh-issue-args milestone title = 'CC 2.1.133 adoption'"
+  if [ "$TITLE" = "CC 2.1.139 adoption" ]; then
+    log_pass "gh-issue-args milestone title = 'CC 2.1.139 adoption'"
   else
-    log_fail "milestone title" "expected 'CC 2.1.133 adoption', got '$TITLE'"
+    log_fail "milestone title" "expected 'CC 2.1.139 adoption', got '$TITLE'"
   fi
 else
   log_fail "gh-issue-args.json missing" "expected emitted by watch script"
@@ -148,7 +148,7 @@ fi
 
 # ============================================================================
 # Test 4: recovery path — equal-version + missing snapshot is re-included
-# (M130 hotfix). Pinned to cc-support.json.latest's value (2.1.132 today) so
+# (M130 hotfix). Pinned to cc-support.json.latest's value (2.1.138 today) so
 # this test stays aligned with the floor whenever the support window bumps.
 # Removes the latest's snapshot from disk; rerunning must re-snapshot it
 # instead of silently skipping.

--- a/tests/security/test-mcp-deny-case.sh
+++ b/tests/security/test-mcp-deny-case.sh
@@ -7,7 +7,7 @@
 # Asserts that documentation about deniedMcpServers correctly tells users
 # they no longer need to enumerate hostname case variants. The real fix is
 # upstream in CC 2.1.129; this test guards against a regression in our
-# guidance (since we floor at 2.1.132).
+# guidance (since we floor at 2.1.138).
 #
 # Test Count: 2
 # Priority: LOW (documentation contract)


### PR DESCRIPTION
Closes #1683 (W5 of M134).

## Summary

Aligns CI fixtures and pinned versions to the new 2.1.138 floor that W4 (#1682) is bumping in parallel. The synthetic test version moves from 2.1.133 → 2.1.139 to remain above the new floor.

## Changes

- `.github/workflows/plugin-validation.yml` — npm install pin 2.1.132 → 2.1.138
- `tests/integration/test-cc-release-watch.sh` — synthetic test version 2.1.133 → 2.1.139, pre-populate list updated to reflect real merged snapshots (2.1.136/137/138)
- `tests/fixtures/cc-changelogs/synthetic.md` — fixture header 2.1.133 → 2.1.139
- `tests/security/test-mcp-deny-case.sh` — guidance comment floor 2.1.132 → 2.1.138

## Tests

- test-cc-release-watch.sh: 14/14 passed
- test:security: 14/14 passed
- test:manifests: clean
- actionlint: clean for the touched workflow

## Playground

docs/chore--ci-matrix-update-cc-2.1.138/playground.html

## Coordination

Lands alongside W4 (#1682). Once both merge, W6 (release-please) follows naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)