### PR TITLE
feat(cc): bump CC floor 2.1.132 → 2.1.138 (#1682)

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -289,11 +289,11 @@ jobs:
         id: install-cc
         run: |
           # Pin to exact version + --ignore-scripts (supply chain mitigation — Scorecard #130, #132)
-          # Pinned to our floor (2.1.132) — older versions don't recognize the
+          # Pinned to our floor (2.1.138) — older versions don't recognize the
           # experimental.{monitors,themes} block format introduced in CC 2.1.129
           # and emit a hard error during plugin validate.
           # nosemgrep: pinned-dependencies (npm packages cannot be SHA-pinned; --ignore-scripts mitigates)
-          npm install -g @anthropic-ai/claude-code@2.1.132 --ignore-scripts 2>/dev/null || true
+          npm install -g @anthropic-ai/claude-code@2.1.138 --ignore-scripts 2>/dev/null || true
           # `--ignore-scripts` skips the package's own postinstall which
           # fetches the native `claude` binary. Without this explicit
           # invocation, the wrapper installs but `command -v claude` finds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,6 @@ Live in `src/monitors/monitors.json`, registered via `manifests/ork.json`. See `
 
 ## Version
 
-- **Current**: 7.85.0 · **Claude Code**: >= 2.1.132 <!-- x-release-please-version -->
+- **Current**: 7.85.0 · **Claude Code**: >= 2.1.138 <!-- x-release-please-version -->
 
 See `CHANGELOG.md` for history. See `src/hooks/README.md` for hook architecture.

--- a/docs/feat--cc-floor-bump-2.1.132-to-2.1.138/floor-bump-playground.html
+++ b/docs/feat--cc-floor-bump-2.1.132-to-2.1.138/floor-bump-playground.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>CC 2.1.138 floor bump (W4 / M134) — playground</title>
+<style>
+  :root {
+    --bg:#0d1117; --bg2:#161b22; --bg3:#21262d; --border:#30363d;
+    --text:#e6edf3; --text2:#8b949e; --accent:#58a6ff;
+    --green:#3fb950; --red:#f85149; --orange:#d29922; --yellow:#e3b341;
+    --mono:'SF Mono','Fira Code',Consolas,monospace;
+    --font:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  }
+  * { box-sizing:border-box; margin:0; padding:0 }
+  body { font-family:var(--font); background:var(--bg); color:var(--text); padding:32px; max-width:1100px; margin:0 auto; line-height:1.5 }
+  h1 { font-size:22px; margin-bottom:6px }
+  .lead { color:var(--text2); font-size:14px; margin-bottom:24px }
+  .timeline { display:flex; align-items:center; gap:8px; margin:24px 0; padding:14px; background:var(--bg2); border:1px solid var(--border); border-radius:8px; flex-wrap:wrap }
+  .pill { padding:6px 12px; border-radius:20px; background:var(--bg3); font-family:var(--mono); font-size:12px; color:var(--text2); border:1px solid var(--border) }
+  .pill.old { opacity:0.5 }
+  .pill.gap { opacity:0.3; text-decoration:line-through }
+  .pill.new { background:var(--accent); color:#0d1117; font-weight:700; border-color:var(--accent); box-shadow:0 0 12px rgba(88,166,255,0.5) }
+  .arrow { color:var(--text2); font-family:var(--mono) }
+  .panel { background:var(--bg2); border:1px solid var(--border); border-radius:8px; padding:18px; margin-bottom:18px }
+  .panel h2 { font-size:16px; margin-bottom:12px; display:flex; align-items:center; gap:8px }
+  .badge { display:inline-block; padding:2px 8px; border-radius:10px; font-size:11px; font-family:var(--mono); background:var(--bg3); color:var(--text2) }
+  .badge.green { background:rgba(63,185,80,0.15); color:var(--green) }
+  .badge.blue  { background:rgba(88,166,255,0.15); color:var(--accent) }
+  .badge.orange{ background:rgba(210,153,34,0.15); color:var(--orange) }
+  table { width:100%; border-collapse:collapse; font-size:13px; margin-top:8px }
+  th, td { text-align:left; padding:8px 10px; border-bottom:1px solid var(--border); vertical-align:top }
+  th { color:var(--text2); font-weight:600; text-transform:uppercase; font-size:11px; letter-spacing:0.5px }
+  td.ver { font-family:var(--mono); color:var(--text2); white-space:nowrap }
+  pre { font-family:var(--mono); font-size:12px; background:#000; padding:12px; border-radius:4px; overflow-x:auto; line-height:1.55; color:var(--text) }
+  .grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:14px }
+  .card { background:var(--bg3); border:1px solid var(--border); border-radius:6px; padding:14px }
+  .card h3 { font-family:var(--mono); font-size:12px; text-transform:uppercase; letter-spacing:0.5px; margin-bottom:8px; color:var(--text2); display:flex; gap:8px; align-items:center }
+  .dot { width:8px; height:8px; border-radius:50%; display:inline-block }
+  .dot.green{ background:var(--green)} .dot.blue{ background:var(--accent)} .dot.orange{ background:var(--orange)}
+  .footer { color:var(--text2); font-size:12px; margin-top:24px; padding-top:18px; border-top:1px solid var(--border) }
+  a { color:var(--accent); text-decoration:none }
+  details { margin-top:12px; background:var(--bg3); border:1px solid var(--border); border-radius:4px; padding:8px 12px }
+  summary { cursor:pointer; font-size:12px; color:var(--text2); font-family:var(--mono) }
+  details[open] summary { color:var(--text); margin-bottom:8px }
+</style>
+</head>
+<body>
+
+<h1>CC 2.1.138 floor bump &mdash; W4 closeout (M134)</h1>
+<p class="lead">Bumps OrchestKit's CC support floor from <code>2.1.132</code> to <code>2.1.138</code> &mdash; the closeout for milestone <strong>M134</strong>. Versions 2.1.133, 2.1.136, 2.1.137, 2.1.138 exist upstream; 2.1.134 and 2.1.135 do not. The original 2026-05-07 <code>manual_override</code> (latest-only, 12-week window) carries forward unchanged &mdash; expires 2026-08-07.</p>
+
+<div class="timeline">
+  <span class="pill old">2.1.132</span>
+  <span class="pill old">2.1.133</span>
+  <span class="pill gap">2.1.134</span>
+  <span class="pill gap">2.1.135</span>
+  <span class="pill old">2.1.136</span>
+  <span class="pill old">2.1.137</span>
+  <span class="arrow">&rarr;</span>
+  <span class="pill new">2.1.138 &middot; NEW FLOOR</span>
+</div>
+
+<div class="panel">
+  <h2>What changes <span class="badge">floor bump only &mdash; no new feature entries</span></h2>
+  <table>
+    <thead><tr><th>File</th><th>Change</th></tr></thead>
+    <tbody>
+      <tr><td><code>shared/cc-support.json</code></td><td><code>latest</code> &amp; <code>supported_floor</code> &rarr; <code>2.1.138</code>, <code>drop_after</code> &rarr; <code>2.1.137</code>. <code>manual_override</code> (expires 2026-08-07) untouched.</td></tr>
+      <tr><td><code>src/hooks/src/lib/cc-version-matrix.ts</code></td><td><code>MIN_CC_VERSION</code> &rarr; <code>2.1.138</code> (stamper). No feature entries added &mdash; matrix still ends at 2.1.132.</td></tr>
+      <tr><td><code>CLAUDE.md</code></td><td>Version section CC floor &rarr; <code>2.1.138</code> (stamper).</td></tr>
+      <tr><td><code>src/skills/doctor/references/version-compatibility.md</code></td><td>Overview line &rarr; <code>2.1.138</code> (stamper).</td></tr>
+      <tr><td><code>.github/workflows/plugin-validation.yml</code></td><td>Plugin-validate CC pin &rarr; <code>2.1.138</code>.</td></tr>
+      <tr><td><code>src/hooks/src/__tests__/lib/cc-version-matrix.test.ts</code></td><td>"is 2.1.132" &rarr; "is 2.1.138". "no missing features" probe &rarr; 2.1.138. Counts unchanged (392).</td></tr>
+      <tr><td><code>src/hooks/src/__tests__/lifecycle/cc-version-check.test.ts</code></td><td>"matrix latest" probe &rarr; 2.1.138.</td></tr>
+      <tr><td><code>tests/fixtures/cc-changelogs/synthetic.md</code></td><td>Synthetic above-floor heading: 2.1.133 &rarr; 2.1.139 (must stay above current latest).</td></tr>
+      <tr><td><code>tests/integration/test-cc-release-watch.sh</code></td><td>Pre-populates 133/136/137/138 alongside earlier versions; new-version probe &rarr; 2.1.139.</td></tr>
+      <tr><td><code>tests/security/test-mcp-deny-case.sh</code></td><td>"floor at 2.1.132" comment &rarr; "floor at 2.1.138".</td></tr>
+      <tr><td>4 skill <code>references/*.md</code> + SKILL.md</td><td>Inline "our floor is 2.1.132" load-bearing lines &rarr; 2.1.138. Section headers about features added in 2.1.132 (historical) untouched.</td></tr>
+      <tr><td><code>plugins/ork/&hellip;</code> + <code>docs/site/lib/generated/&hellip;</code></td><td>Auto-regenerated by <code>npm run build</code>.</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="panel">
+  <h2>Source-of-truth diff</h2>
+  <pre>{
+  "latest": "2.1.132",            // &rarr; "2.1.138"
+  "supported_floor": "2.1.132",   // &rarr; "2.1.138"
+  "drop_after": "2.1.131",        // &rarr; "2.1.137"
+  "manual_override": {
+    "reason": "Bolder bump per 2026-05-07 decision &mdash; gates on
+       CLAUDE_CODE_SESSION_ID (2.1.132) ...",   // unchanged (historical)
+    "expires": "2026-08-07"                     // unchanged (still future)
+  }
+}</pre>
+  <p class="lead" style="margin-top:12px">
+    <code>cc-support-window-bump.yml</code> honors the unexpired override and would have opened an info-only PR; this PR is a manual closeout for M134 instead.
+    The original override reasoning (CLAUDE_CODE_SESSION_ID, parallel-shell fanout, sub-agent prompt-cache reduction) still applies &mdash; all gated features are now strictly older than the new floor.
+  </p>
+</div>
+
+<div class="panel">
+  <h2>Versions in scope</h2>
+  <div class="grid">
+    <div class="card">
+      <h3><span class="dot blue"></span>2.1.133</h3>
+      <p style="font-size:13px;color:var(--text2);margin-top:6px">Adoption tracked under <strong>M132</strong>. Issues filed against the per-version "CC 2.1.133 adoption" milestone via cc-release-watch.</p>
+    </div>
+    <div class="card">
+      <h3><span class="dot orange"></span>2.1.134 / 2.1.135</h3>
+      <p style="font-size:13px;color:var(--text2);margin-top:6px">No upstream release. Skipped &mdash; not in <code>shared/cc-snapshots/</code>, not in CC GitHub Releases.</p>
+    </div>
+    <div class="card">
+      <h3><span class="dot blue"></span>2.1.136</h3>
+      <p style="font-size:13px;color:var(--text2);margin-top:6px">Adoption tracked under <strong>M135</strong>.</p>
+    </div>
+    <div class="card">
+      <h3><span class="dot blue"></span>2.1.137</h3>
+      <p style="font-size:13px;color:var(--text2);margin-top:6px">Adoption tracked under <strong>M133</strong> (W3 recovery).</p>
+    </div>
+    <div class="card">
+      <h3><span class="dot green"></span>2.1.138 &mdash; new floor</h3>
+      <p style="font-size:13px;color:var(--text2);margin-top:6px">Closeout. Adoption issues continue in their respective milestones; the floor declaration here just unlocks reliance on those features without compat checks.</p>
+    </div>
+  </div>
+</div>
+
+<details>
+  <summary>Risk: who breaks?</summary>
+  <p style="font-size:13px;color:var(--text2);margin-top:8px">
+    Anyone running CC <code>&le; 2.1.137</code> sees the doctor warning <code>Claude Code X.Y.Z is below OrchestKit's supported floor (2.1.138)</code>. Hooks degrade gracefully via fallback paths.
+    The <code>manual_override</code> still expires 2026-08-07 (~3 months). After expiry, <code>cc-support-window-bump.yml</code> resumes the standard <code>latest + 3</code> policy &mdash; whichever version is latest at that point becomes the floor under default arithmetic.
+  </p>
+</details>
+
+<details>
+  <summary>Test status</summary>
+  <p style="font-size:13px;color:var(--text2);margin-top:8px">
+    <code>npm run build</code> &middot; <code>npm run test:skills</code> &middot; <code>npm run test:agents</code> &middot; <code>npm run test:manifests</code> &middot; <code>npm run test:security</code> &middot; <code>npm run typecheck</code> all green pre-push. Hook unit tests (<code>cc-version-matrix.test.ts</code>, <code>cc-version-check.test.ts</code>) updated to match new floor &mdash; matrix entry count assertion unchanged (no new feature entries in this PR).
+  </p>
+</details>
+
+<p class="footer">
+  Closes <a href="https://github.com/yonatangross/orchestkit/issues/1682">#1682</a>. Predecessor: <a href="https://github.com/yonatangross/orchestkit/pull/1623">PR #1623</a> (2.1.125 &rarr; 2.1.132 bolder bump).
+</p>
+
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/chain-patterns.mdx
+++ b/docs/site/content/docs/reference/skills/chain-patterns.mdx
@@ -1648,7 +1648,7 @@ Agent(
 - No need to `git push` before spawning isolated agents
 - Parent and child see the same uncommitted history
 
-CC ≤ 2.1.127 branched from `origin/&lt;default-branch&gt;`, which silently dropped local-only commits. We floor at `2.1.132` so this concern is gone — your worktree starts from wherever your tree is now.
+CC ≤ 2.1.127 branched from `origin/&lt;default-branch&gt;`, which silently dropped local-only commits. We floor at `2.1.138` so this concern is gone — your worktree starts from wherever your tree is now.
 
 ## Limitations
 

--- a/docs/site/content/docs/reference/skills/configure.mdx
+++ b/docs/site/content/docs/reference/skills/configure.mdx
@@ -1009,7 +1009,7 @@ The `claude_code.pull_request.count` OTel metric counted PRs/MRs created via the
 Before 2.1.132, the `--permission-mode` flag was silently ignored when resuming a plan-mode session via `-p --continue` or `--resume`, and `ExitPlanMode` did not re-apply plan mode for the rest of the same session. Both gaps closed the wrong way (more permissive than declared), so this is a security-relevant fix, not just UX.
 
 ```bash
-# At our floor (CC ≥ 2.1.132): plan mode survives resume as declared
+# At our floor (CC ≥ 2.1.138): plan mode survives resume as declared
 claude --resume <session-id> --permission-mode plan
 ```
 
@@ -1438,7 +1438,7 @@ For browser automation and testing, use the `agent-browser` skill instead of an 
 
 ## CC 2.1.128/129 changes that affect `.mcp.json` and plugin manifests
 
-We floor at `2.1.132`, so all of these apply by default.
+We floor at `2.1.138`, so all of these apply by default.
 
 ### Reserved server name: `workspace` (CC 2.1.128)
 

--- a/docs/site/content/docs/reference/skills/doctor.mdx
+++ b/docs/site/content/docs/reference/skills/doctor.mdx
@@ -1386,7 +1386,7 @@ claude plugin validate
 
 ### "Stale plugin paths in PATH"
 
-CC ≤ 2.1.127 occasionally left `installed_plugins.json` entries pointing at deleted cache directories, polluting `PATH` for subprocesses. CC 2.1.128+ scrubs those automatically — no maintenance needed at our floor (2.1.132). If you see plugin commands failing with `command not found` after uninstalling a plugin on CC &lt; 2.1.128, upgrade.
+CC ≤ 2.1.127 occasionally left `installed_plugins.json` entries pointing at deleted cache directories, polluting `PATH` for subprocesses. CC 2.1.128+ scrubs those automatically — no maintenance needed at our floor (2.1.138). If you see plugin commands failing with `command not found` after uninstalling a plugin on CC &lt; 2.1.128, upgrade.
 
 ### "Auto mode unable to evaluate"
 
@@ -1403,7 +1403,7 @@ Pick whichever applies — `/compact` if context is full, `--debug` to see the c
 
 If multiple CC sessions all logged themselves out at the same moment after the laptop woke from sleep, that is the pre-2.1.129 OAuth refresh race — concurrent wake-time refreshes invalidated the active token across every running session.
 
-**Fix**: upgrade to CC ≥ 2.1.129 (our floor is 2.1.132, so anyone on the supported window is already fixed). Recover the session with:
+**Fix**: upgrade to CC ≥ 2.1.129 (our floor is 2.1.138, so anyone on the supported window is already fixed). Recover the session with:
 
 ```bash
 claude /login
@@ -1710,7 +1710,7 @@ Ensure file exists at `references/filename.md`.
 
 ## Overview
 
-OrchestKit requires Claude Code >= 2.1.132. This matrix documents which CC features OrchestKit depends on and their minimum version requirements.
+OrchestKit requires Claude Code >= 2.1.138. This matrix documents which CC features OrchestKit depends on and their minimum version requirements.
 
 ## Feature Matrix
 

--- a/docs/site/lib/generated/shared-data.ts
+++ b/docs/site/lib/generated/shared-data.ts
@@ -13,7 +13,7 @@ export const TOTALS: Totals = {
 };
 
 // Extracted from src/hooks/src/lib/cc-version-matrix.ts
-export const MIN_CC_VERSION = "2.1.132";
+export const MIN_CC_VERSION = "2.1.138";
 
 export const AGENTS: AgentSummary[] = [
   {

--- a/plugins/ork/skills/chain-patterns/references/worktree-agent-pattern.md
+++ b/plugins/ork/skills/chain-patterns/references/worktree-agent-pattern.md
@@ -54,7 +54,7 @@ Agent(
 - No need to `git push` before spawning isolated agents
 - Parent and child see the same uncommitted history
 
-CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. We floor at `2.1.132` so this concern is gone — your worktree starts from wherever your tree is now.
+CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. We floor at `2.1.138` so this concern is gone — your worktree starts from wherever your tree is now.
 
 ## Limitations
 

--- a/plugins/ork/skills/configure/references/cc-version-settings.md
+++ b/plugins/ork/skills/configure/references/cc-version-settings.md
@@ -543,7 +543,7 @@ The `claude_code.pull_request.count` OTel metric counted PRs/MRs created via the
 Before 2.1.132, the `--permission-mode` flag was silently ignored when resuming a plan-mode session via `-p --continue` or `--resume`, and `ExitPlanMode` did not re-apply plan mode for the rest of the same session. Both gaps closed the wrong way (more permissive than declared), so this is a security-relevant fix, not just UX.
 
 ```bash
-# At our floor (CC ≥ 2.1.132): plan mode survives resume as declared
+# At our floor (CC ≥ 2.1.138): plan mode survives resume as declared
 claude --resume <session-id> --permission-mode plan
 ```
 

--- a/plugins/ork/skills/configure/references/mcp-config.md
+++ b/plugins/ork/skills/configure/references/mcp-config.md
@@ -242,7 +242,7 @@ For browser automation and testing, use the `agent-browser` skill instead of an 
 
 ## CC 2.1.128/129 changes that affect `.mcp.json` and plugin manifests
 
-We floor at `2.1.132`, so all of these apply by default.
+We floor at `2.1.138`, so all of these apply by default.
 
 ### Reserved server name: `workspace` (CC 2.1.128)
 

--- a/plugins/ork/skills/doctor/references/remediation-guide.md
+++ b/plugins/ork/skills/doctor/references/remediation-guide.md
@@ -52,7 +52,7 @@ claude plugin validate
 
 ### "Stale plugin paths in PATH"
 
-CC ≤ 2.1.127 occasionally left `installed_plugins.json` entries pointing at deleted cache directories, polluting `PATH` for subprocesses. CC 2.1.128+ scrubs those automatically — no maintenance needed at our floor (2.1.132). If you see plugin commands failing with `command not found` after uninstalling a plugin on CC < 2.1.128, upgrade.
+CC ≤ 2.1.127 occasionally left `installed_plugins.json` entries pointing at deleted cache directories, polluting `PATH` for subprocesses. CC 2.1.128+ scrubs those automatically — no maintenance needed at our floor (2.1.138). If you see plugin commands failing with `command not found` after uninstalling a plugin on CC < 2.1.128, upgrade.
 
 ### "Auto mode unable to evaluate"
 
@@ -69,7 +69,7 @@ Pick whichever applies — `/compact` if context is full, `--debug` to see the c
 
 If multiple CC sessions all logged themselves out at the same moment after the laptop woke from sleep, that is the pre-2.1.129 OAuth refresh race — concurrent wake-time refreshes invalidated the active token across every running session.
 
-**Fix**: upgrade to CC ≥ 2.1.129 (our floor is 2.1.132, so anyone on the supported window is already fixed). Recover the session with:
+**Fix**: upgrade to CC ≥ 2.1.129 (our floor is 2.1.138, so anyone on the supported window is already fixed). Recover the session with:
 
 ```bash
 claude /login

--- a/plugins/ork/skills/doctor/references/version-compatibility.md
+++ b/plugins/ork/skills/doctor/references/version-compatibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-OrchestKit requires Claude Code >= 2.1.132. This matrix documents which CC features OrchestKit depends on and their minimum version requirements.
+OrchestKit requires Claude Code >= 2.1.138. This matrix documents which CC features OrchestKit depends on and their minimum version requirements.
 
 ## Feature Matrix
 

--- a/shared/cc-support.json
+++ b/shared/cc-support.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./cc-support.schema.json",
-  "latest": "2.1.132",
-  "supported_floor": "2.1.132",
-  "drop_after": "2.1.131",
+  "latest": "2.1.138",
+  "supported_floor": "2.1.138",
+  "drop_after": "2.1.137",
   "policy": "latest + 3 previous minors",
   "policy_doc": "shared/rules/cc-support-policy.md",
   "manual_override": {

--- a/src/hooks/src/__tests__/lib/cc-version-matrix.test.ts
+++ b/src/hooks/src/__tests__/lib/cc-version-matrix.test.ts
@@ -17,11 +17,12 @@ import {
 
 describe('cc-version-matrix', () => {
   describe('MIN_CC_VERSION', () => {
-    test('is 2.1.132', () => {
-      // 2026-05-07 bolder bump: floor jumped 2.1.125 -> 2.1.132 with manual_override
-      // (CLAUDE_CODE_SESSION_ID + sub-agent prompt cache + parallel-shell fanout). Stamper
-      // propagates supported_floor from shared/cc-support.json. Expires 2026-08-07.
-      expect(MIN_CC_VERSION).toBe('2.1.132');
+    test('is 2.1.138', () => {
+      // 2026-05-10 W4 floor bump (M134): 2.1.132 -> 2.1.138 (closeout). Versions 133/136/137/138
+      // upstream — 2.1.134/135 don't exist. Original 2026-05-07 bolder-bump manual_override
+      // still in force (expires 2026-08-07). Stamper propagates supported_floor from
+      // shared/cc-support.json.
+      expect(MIN_CC_VERSION).toBe('2.1.138');
     });
   });
 
@@ -76,7 +77,7 @@ describe('cc-version-matrix', () => {
 
   describe('getAvailableFeatures', () => {
     test('all features available at latest version', () => {
-      const features = getAvailableFeatures('2.1.132');
+      const features = getAvailableFeatures('2.1.138');
       expect(features.length).toBe(CC_FEATURE_MATRIX.length);
     });
 
@@ -102,8 +103,10 @@ describe('cc-version-matrix', () => {
   });
 
   describe('getMissingFeatures', () => {
-    test('no missing features at 2.1.132', () => {
-      const missing = getMissingFeatures('2.1.132');
+    test('no missing features at 2.1.138', () => {
+      // No new feature entries added in W4 — matrix still ends at 2.1.132.
+      // Adoption issues for 133/136/137/138 are tracked under M132/M135/M133.
+      const missing = getMissingFeatures('2.1.138');
       expect(missing.length).toBe(0);
     });
 

--- a/src/hooks/src/__tests__/lifecycle/cc-version-check.test.ts
+++ b/src/hooks/src/__tests__/lifecycle/cc-version-check.test.ts
@@ -81,8 +81,9 @@ describe('cc-version-check', () => {
     // Pick a version that exists in the current matrix snapshot and is
     // >= the support floor. Updating both values is required when floor
     // or latest moves: M128 set 2.1.122 floor, M131 set 2.1.125 floor /
-    // 2.1.128 latest, 2026-05-07 bolder bump set 2.1.132 floor / latest.
-    process.env.CLAUDE_CODE_VERSION = '2.1.132';
+    // 2.1.128 latest, 2026-05-07 bolder bump set 2.1.132 floor / latest,
+    // M134 W4 closeout (2026-05-10) bumped to 2.1.138 floor / latest.
+    process.env.CLAUDE_CODE_VERSION = '2.1.138';
     const result = ccVersionCheck(makeInput('in-range-test'), createTestContext());
     expect(result.continue).toBe(true);
     expect(result.systemMessage).toBeUndefined();

--- a/src/hooks/src/lib/cc-version-matrix.ts
+++ b/src/hooks/src/lib/cc-version-matrix.ts
@@ -7,7 +7,7 @@
  * Keep in sync with: src/skills/doctor/references/version-compatibility.md
  */
 
-export const MIN_CC_VERSION = '2.1.132';
+export const MIN_CC_VERSION = '2.1.138';
 
 export interface CCFeatureEntry {
   readonly feature: string;

--- a/src/skills/chain-patterns/references/worktree-agent-pattern.md
+++ b/src/skills/chain-patterns/references/worktree-agent-pattern.md
@@ -54,7 +54,7 @@ Agent(
 - No need to `git push` before spawning isolated agents
 - Parent and child see the same uncommitted history
 
-CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. We floor at `2.1.132` so this concern is gone — your worktree starts from wherever your tree is now.
+CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. We floor at `2.1.138` so this concern is gone — your worktree starts from wherever your tree is now.
 
 ## Limitations
 

--- a/src/skills/configure/references/cc-version-settings.md
+++ b/src/skills/configure/references/cc-version-settings.md
@@ -543,7 +543,7 @@ The `claude_code.pull_request.count` OTel metric counted PRs/MRs created via the
 Before 2.1.132, the `--permission-mode` flag was silently ignored when resuming a plan-mode session via `-p --continue` or `--resume`, and `ExitPlanMode` did not re-apply plan mode for the rest of the same session. Both gaps closed the wrong way (more permissive than declared), so this is a security-relevant fix, not just UX.
 
 ```bash
-# At our floor (CC ≥ 2.1.132): plan mode survives resume as declared
+# At our floor (CC ≥ 2.1.138): plan mode survives resume as declared
 claude --resume <session-id> --permission-mode plan
 ```
 

--- a/src/skills/configure/references/mcp-config.md
+++ b/src/skills/configure/references/mcp-config.md
@@ -242,7 +242,7 @@ For browser automation and testing, use the `agent-browser` skill instead of an 
 
 ## CC 2.1.128/129 changes that affect `.mcp.json` and plugin manifests
 
-We floor at `2.1.132`, so all of these apply by default.
+We floor at `2.1.138`, so all of these apply by default.
 
 ### Reserved server name: `workspace` (CC 2.1.128)
 

--- a/src/skills/doctor/references/remediation-guide.md
+++ b/src/skills/doctor/references/remediation-guide.md
@@ -52,7 +52,7 @@ claude plugin validate
 
 ### "Stale plugin paths in PATH"
 
-CC ≤ 2.1.127 occasionally left `installed_plugins.json` entries pointing at deleted cache directories, polluting `PATH` for subprocesses. CC 2.1.128+ scrubs those automatically — no maintenance needed at our floor (2.1.132). If you see plugin commands failing with `command not found` after uninstalling a plugin on CC < 2.1.128, upgrade.
+CC ≤ 2.1.127 occasionally left `installed_plugins.json` entries pointing at deleted cache directories, polluting `PATH` for subprocesses. CC 2.1.128+ scrubs those automatically — no maintenance needed at our floor (2.1.138). If you see plugin commands failing with `command not found` after uninstalling a plugin on CC < 2.1.128, upgrade.
 
 ### "Auto mode unable to evaluate"
 
@@ -69,7 +69,7 @@ Pick whichever applies — `/compact` if context is full, `--debug` to see the c
 
 If multiple CC sessions all logged themselves out at the same moment after the laptop woke from sleep, that is the pre-2.1.129 OAuth refresh race — concurrent wake-time refreshes invalidated the active token across every running session.
 
-**Fix**: upgrade to CC ≥ 2.1.129 (our floor is 2.1.132, so anyone on the supported window is already fixed). Recover the session with:
+**Fix**: upgrade to CC ≥ 2.1.129 (our floor is 2.1.138, so anyone on the supported window is already fixed). Recover the session with:
 
 ```bash
 claude /login

--- a/src/skills/doctor/references/version-compatibility.md
+++ b/src/skills/doctor/references/version-compatibility.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-OrchestKit requires Claude Code >= 2.1.132. This matrix documents which CC features OrchestKit depends on and their minimum version requirements.
+OrchestKit requires Claude Code >= 2.1.138. This matrix documents which CC features OrchestKit depends on and their minimum version requirements.
 
 ## Feature Matrix
 

--- a/tests/fixtures/cc-changelogs/synthetic.md
+++ b/tests/fixtures/cc-changelogs/synthetic.md
@@ -1,10 +1,14 @@
 # Changelog
 
-## 2.1.133
+## 2.1.139
 
-- `EnterWorktree` now creates the new branch from local HEAD instead of `origin/<default-branch>`, so unpushed commits are no longer dropped (synthetic placeholder; the real upstream behaviour landed in 2.1.128 — kept here as the test fixture's "new version" detection target)
+- `EnterWorktree` now creates the new branch from local HEAD instead of `origin/<default-branch>`, so unpushed commits are no longer dropped (synthetic placeholder; the real upstream behaviour landed in 2.1.128 — kept here as the test fixture's "new version" detection target, pinned above the current 2.1.138 floor)
 - `--plugin-dir` now accepts `.zip` plugin archives, enabling offline distribution alongside directory-based loads
 - MCP server name `workspace` is now reserved; conflicting `.mcp.json` entries are silently skipped with a warning
+
+## 2.1.138
+
+- Internal fixes (synthetic placeholder mirroring upstream — pinned at the current floor so Test 4 can exercise the equal-version recovery path)
 
 ## 2.1.132
 

--- a/tests/integration/test-cc-release-watch.sh
+++ b/tests/integration/test-cc-release-watch.sh
@@ -63,13 +63,13 @@ rm -rf shared/cc-snapshots/*.md shared/cc-adoption-gaps.json shared/gh-issue-arg
 
 # Pre-populate snapshots for every prior version that's <= cc-support.json.latest
 # to simulate the production steady state. This isolates Test 1 to the "one new
-# version" scenario (2.1.133 — a synthetic future version above the current
-# floor of 2.1.132) without triggering the M130-hotfix recovery path that
+# version" scenario (2.1.139 — a synthetic future version above the current
+# floor of 2.1.138) without triggering the M130-hotfix recovery path that
 # re-snapshots equal-version-but-missing-on-disk entries (covered by a
-# dedicated test below). The fixture pins 2.1.133 specifically so this test
+# dedicated test below). The fixture pins 2.1.139 specifically so this test
 # is resilient to future floor bumps in shared/cc-support.json.
 mkdir -p shared/cc-snapshots
-for v in 2.1.126 2.1.127 2.1.128 2.1.129 2.1.131 2.1.132; do
+for v in 2.1.126 2.1.127 2.1.128 2.1.129 2.1.131 2.1.132 2.1.133 2.1.136 2.1.137 2.1.138; do
   echo "# Claude Code $v (placeholder for test)" > "shared/cc-snapshots/$v.md"
 done
 
@@ -79,13 +79,13 @@ done
 CC_RELEASE_WATCH_FIXTURE=tests/fixtures/cc-changelogs/synthetic.md \
   node scripts/cc-release-watch.mjs > /tmp/watch-out.txt 2>&1
 
-if [ -f shared/cc-snapshots/2.1.133.md ]; then
-  log_pass "Snapshot written for new version 2.1.133"
+if [ -f shared/cc-snapshots/2.1.139.md ]; then
+  log_pass "Snapshot written for new version 2.1.139"
 else
-  log_fail "Snapshot missing" "expected shared/cc-snapshots/2.1.133.md (see /tmp/watch-out.txt)"
+  log_fail "Snapshot missing" "expected shared/cc-snapshots/2.1.139.md (see /tmp/watch-out.txt)"
 fi
 
-if [ -f shared/cc-snapshots/2.1.133.md ] && grep -qF "EnterWorktree" shared/cc-snapshots/2.1.133.md; then
+if [ -f shared/cc-snapshots/2.1.139.md ] && grep -qF "EnterWorktree" shared/cc-snapshots/2.1.139.md; then
   log_pass "Snapshot body contains expected feature bullet"
 else
   log_fail "Snapshot body" "missing 'EnterWorktree' from fixture"
@@ -96,10 +96,10 @@ if [ -f shared/cc-adoption-gaps.json ]; then
   if [ "$COUNT" = "1" ]; then
     log_pass "Gaps JSON has exactly 1 entry"
     GAP_VERSION=$(jq -r '.[0].version' shared/cc-adoption-gaps.json)
-    if [ "$GAP_VERSION" = "2.1.133" ]; then
-      log_pass "Gap entry version = 2.1.133"
+    if [ "$GAP_VERSION" = "2.1.139" ]; then
+      log_pass "Gap entry version = 2.1.139"
     else
-      log_fail "Gap entry version" "expected 2.1.133, got '$GAP_VERSION'"
+      log_fail "Gap entry version" "expected 2.1.139, got '$GAP_VERSION'"
     fi
   else
     log_fail "Gaps JSON entry count" "expected 1, got $COUNT"
@@ -110,10 +110,10 @@ fi
 
 if [ -f shared/gh-issue-args.json ]; then
   TITLE=$(jq -r '.milestone' shared/gh-issue-args.json)
-  if [ "$TITLE" = "CC 2.1.133 adoption" ]; then
-    log_pass "gh-issue-args milestone title = 'CC 2.1.133 adoption'"
+  if [ "$TITLE" = "CC 2.1.139 adoption" ]; then
+    log_pass "gh-issue-args milestone title = 'CC 2.1.139 adoption'"
   else
-    log_fail "milestone title" "expected 'CC 2.1.133 adoption', got '$TITLE'"
+    log_fail "milestone title" "expected 'CC 2.1.139 adoption', got '$TITLE'"
   fi
 else
   log_fail "gh-issue-args.json missing" "expected emitted by watch script"
@@ -148,7 +148,7 @@ fi
 
 # ============================================================================
 # Test 4: recovery path — equal-version + missing snapshot is re-included
-# (M130 hotfix). Pinned to cc-support.json.latest's value (2.1.132 today) so
+# (M130 hotfix). Pinned to cc-support.json.latest's value (2.1.138 today) so
 # this test stays aligned with the floor whenever the support window bumps.
 # Removes the latest's snapshot from disk; rerunning must re-snapshot it
 # instead of silently skipping.

--- a/tests/security/test-mcp-deny-case.sh
+++ b/tests/security/test-mcp-deny-case.sh
@@ -7,7 +7,7 @@
 # Asserts that documentation about deniedMcpServers correctly tells users
 # they no longer need to enumerate hostname case variants. The real fix is
 # upstream in CC 2.1.129; this test guards against a regression in our
-# guidance (since we floor at 2.1.132).
+# guidance (since we floor at 2.1.138).
 #
 # Test Count: 2
 # Priority: LOW (documentation contract)


### PR DESCRIPTION
Closes #1682
Closes #1683

## Summary

Bumps the OrchestKit Claude Code floor from **2.1.132 → 2.1.138**, finishing M134.

W3 recovery filed 31 adoption issues (M132: 11, M135: 20). 2.1.137/138 require no OrchestKit work (VS Code Windows fix + Internal fixes).

Folds in W5 (#1683 / PR #1733) since CI fixture changes overlap completely.

## Test plan

- [x] test-cc-release-watch.sh: 14/14
- [x] test:security: 14/14
- [x] test:manifests: 0 orphans
- [x] typecheck: clean

## Playground

docs/feat--cc-floor-bump-2.1.132-to-2.1.138/floor-bump-playground.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)