### PR TITLE
chore(adopt): M132 Group G CC 2.1.133 perm+sandbox+settings

### DIFF
--- a/docs/chore--m132-group-g-cc-133-perm-sandbox-settings/group-g-playground.html
+++ b/docs/chore--m132-group-g-cc-133-perm-sandbox-settings/group-g-playground.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>M132 Group G — CC 2.1.133 perm + sandbox + settings adoption</title>
+<style>
+body{font:14px ui-monospace,monospace;background:#0b0b0b;color:#e8e8e8;padding:32px;max-width:760px;margin:auto}
+h1{color:#7aa2f7;border-bottom:1px solid #333;padding-bottom:6px}
+h2{color:#bb9af7;margin-top:28px}
+table{width:100%;border-collapse:collapse;margin:12px 0}
+th,td{text-align:left;padding:6px 10px;border-bottom:1px solid #2a2a2a;vertical-align:top}
+th{color:#bb9af7}
+.muted{color:#888}
+.ok{color:#9ece6a}
+.warn{color:#e0af68}
+.alert{background:#2a1f1f;border-left:3px solid #f7768e;padding:10px 14px;margin:10px 0}
+pre{background:#161616;padding:14px;border-radius:6px;overflow-x:auto;line-height:1.4}
+code{background:#161616;padding:1px 5px;border-radius:3px}
+</style>
+</head>
+<body>
+<h1>M132 Group G — CC 2.1.133 perm + sandbox + settings</h1>
+<p class="muted">Second adoption PR for M132 (CC 2.1.133). 3 new-perm features + 1 breaking permission-rule fix. Stacked on Group F (#1747) which introduced the <code>## CC 2.1.133 Settings</code> parent header.</p>
+
+<div class="alert">
+<strong class="warn">⚠ Behavior change for OrchestKit</strong> — CC 2.1.133 added <code>worktree.baseRef</code> with default <code>"fresh"</code>, which branches new worktrees from <code>origin/&lt;default&gt;</code> instead of local <code>HEAD</code>. OrchestKit's agent-isolation pattern needs unpushed commits visible to spawned agents. <strong>Set <code>worktree.baseRef: "head"</code></strong> in <code>.claude/settings.json</code> or you will lose in-progress work when agents spawn.
+</div>
+
+<h2>Issues closed</h2>
+<table>
+<tr><th>#</th><th>Slug</th><th>Category</th><th>What it does</th></tr>
+<tr><td>1699</td><td>worktree-base-ref-setting</td><td>new_perm</td><td>New <code>worktree.baseRef</code> setting — default <code>"fresh"</code> regresses 2.1.128–2.1.132 local-HEAD behavior. OrchestKit must set <code>"head"</code>.</td></tr>
+<tr><td>1700</td><td>sandbox-bwrap-socat-managed-settings</td><td>new_perm</td><td>New <code>sandbox.bwrapPath</code> / <code>sandbox.socatPath</code> managed settings for Linux/WSL custom binary locations.</td></tr>
+<tr><td>1701</td><td>parent-settings-behavior-admin-key</td><td>new_perm</td><td>New <code>parentSettingsBehavior</code> admin key (<code>first-wins</code>|<code>merge</code>) for SDK <code>managedSettings</code> precedence.</td></tr>
+<tr><td>1704</td><td>edit-write-drive-root-allow-rules-fix</td><td>breaking</td><td><code>Edit</code>/<code>Write</code> allow rules at drive root (<code>C:\</code>) or POSIX <code>/</code> now match correctly instead of always prompting.</td></tr>
+</table>
+
+<h2>Files touched</h2>
+<ul>
+<li><code>src/skills/configure/references/cc-version-settings.md</code> — 4 new subsections under existing <code>## CC 2.1.133 Settings</code> parent (Group F)</li>
+<li><code>src/skills/chain-patterns/references/worktree-agent-pattern.md</code> — Required Setting callout + corrected branch-base prose</li>
+<li><code>src/skills/doctor/references/remediation-guide.md</code> — "EnterWorktree drops my unpushed commits" entry</li>
+<li><code>src/hooks/src/lib/cc-version-matrix.ts</code> — 4 new entries at <code>minVersion: '2.1.133'</code></li>
+</ul>
+
+<h2>Recommended setting</h2>
+<pre>{
+  "worktree": {
+    "baseRef": "head"
+  }
+}</pre>
+
+<h2>Verification</h2>
+<pre class="ok">test:security    14/14 PASS
+test:agents      37/37 valid
+test:skills      PASSED
+test:manifests   108 skills, 0 orphans
+typecheck        clean
+build            107 skills / 37 agents / 188 hooks (no count drift)</pre>
+
+<h2>Stacking notes</h2>
+<p class="muted">This PR is stacked on Group F (#1747). When F squash-merges to main, rebase G onto main: <code>git rebase --onto main &lt;F-tip-sha&gt;</code> (per <a href="../../agent-memory/feedback_stacked_pr_squash_rebase.md">stacked-PR squash-rebase memory</a>).</p>
+
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/chain-patterns.mdx
+++ b/docs/site/content/docs/reference/skills/chain-patterns.mdx
@@ -1640,15 +1640,29 @@ Agent(
 - `SubagentStart` → `unified-dispatcher` (logs agent spawn)
 - `SubagentStop` → `unified-dispatcher` (logs completion)
 
-## Branch base (CC 2.1.128+)
+## Required Setting (CC ≥ 2.1.133)
 
-`EnterWorktree` creates the new branch from **local `HEAD`**, not from `origin/&lt;default-branch&gt;`. This means:
+CC 2.1.133 reintroduced a `worktree.baseRef` setting whose default `"fresh"` branches new worktrees from `origin/&lt;default-branch&gt;` — **not** from local `HEAD`. OrchestKit's agent-isolation pattern needs unpushed commits to be visible to spawned agents, so set:
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+Add this to `.claude/settings.json` (project) or `~/.claude/settings.json` (user). Without it, agents spawned via `Task(... isolation: "worktree")` start from origin and miss every unpushed local commit — `tsc` will fail with "cannot find module" for code you just wrote, and tests will run against stale source.
+
+## Branch base (CC 2.1.128–2.1.132 default, CC 2.1.133+ with `baseRef: "head"`)
+
+With `worktree.baseRef: "head"` (or any CC in the 2.1.128–2.1.132 window where this was the default), `EnterWorktree` creates the new branch from **local `HEAD`**, not from `origin/&lt;default-branch&gt;`. This means:
 
 - Unpushed commits in the parent worktree are preserved in the new worktree
 - No need to `git push` before spawning isolated agents
 - Parent and child see the same uncommitted history
 
-CC ≤ 2.1.127 branched from `origin/&lt;default-branch&gt;`, which silently dropped local-only commits. We floor at `2.1.138` so this concern is gone — your worktree starts from wherever your tree is now.
+CC ≤ 2.1.127 branched from `origin/&lt;default-branch&gt;`, which silently dropped local-only commits. CC 2.1.128–2.1.132 changed the default to local `HEAD`. CC 2.1.133 added the explicit `worktree.baseRef` setting and reverted the default back to `"fresh"` (origin/&lt;default&gt;) — see "Required Setting" above. We floor at `2.1.138`, so the setting is the single source of truth.
 
 > **CC 2.1.133 — concurrent-session stability**: Running multiple worktree-isolated agents in parallel shares one refresh token across sessions. Before 2.1.133 a refresh-token race could 401 every session at once. At our floor this is fixed — concurrent worktree sessions are stable. See `$\{CLAUDE_SKILL_DIR\}/../configure/references/cc-version-settings.md` (CC 2.1.133 section) for the full fix description.
 

--- a/docs/site/content/docs/reference/skills/configure.mdx
+++ b/docs/site/content/docs/reference/skills/configure.mdx
@@ -1081,6 +1081,91 @@ claude --add-dir Z:\share\project
 
 **Impact for OrchestKit**: Windows users running CC against shared team drives — common in Citrix/VDI corporate setups, dev-shared NAS mounts, and OneDrive/SharePoint-as-drive workflows — can now use `--add-dir` and the SDK's `additionalDirectories` without a UNC-vs-letter workaround. No OrchestKit skill change required — the fix is implicit at our floor.
 
+### `worktree.baseRef` Setting — Default Changed to `"fresh"` ⚠ behavior change
+
+CC 2.1.133 adds the `worktree.baseRef` setting (`"fresh"` | `"head"`) that controls where `--worktree`, `EnterWorktree`, and agent-isolation worktrees branch from. **The default is `"fresh"`**, which means new worktrees branch from `origin/&lt;default-branch&gt;` — **not** from your local `HEAD`.
+
+This is a regression for OrchestKit users. From CC 2.1.128 through 2.1.132, `EnterWorktree` branched from local `HEAD`, which is what OrchestKit's worktree-isolation pattern (`chain-patterns/references/worktree-agent-pattern.md`) relies on: unpushed commits in the parent worktree need to be visible to spawned agents. With the new `"fresh"` default, those unpushed commits are silently dropped when the worktree is created.
+
+**Recommended OrchestKit setting** — in `.claude/settings.json`:
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+```json
+// All three forms re-acquire the 2.1.128–2.1.132 behavior:
+//   --worktree
+//   EnterWorktree tool
+//   agent-isolation worktrees (Task tool, isolation: "worktree")
+{ "worktree": { "baseRef": "head" } }
+```
+
+**Choose `"fresh"` only if** you intentionally want every new worktree to start from `origin/&lt;default&gt;` (e.g., clean-room agent runs that should never inherit local WIP). For the common OrchestKit flow — spawn an agent in a worktree to do work on top of an in-progress local branch — `"head"` is the only correct value.
+
+**Impact for OrchestKit**: All of `ork:implement`, `ork:cover`, `ork:fix-issue`, `ork:verify`, and any custom skill that calls `Task(... isolation: "worktree")` is affected. Without `worktree.baseRef: "head"`, agents start from origin and miss every unpushed local commit — `tsc` will fail with "cannot find module" for code you just wrote, tests will run against stale source, and PRs will appear empty of your in-progress work. `ork:doctor` flags this — see `$\{CLAUDE_SKILL_DIR\}/../doctor/references/remediation-guide.md` ("EnterWorktree drops my unpushed commits").
+
+### `sandbox.bwrapPath` / `sandbox.socatPath` Managed Settings (Linux/WSL)
+
+CC 2.1.133 adds two managed-tier settings for Linux and WSL sandbox deployments: `sandbox.bwrapPath` (custom **bubblewrap** binary location) and `sandbox.socatPath` (custom **socat** binary location). These let enterprise admins point the sandbox at vendored binaries on hosts where `bwrap` / `socat` are not on `$PATH`, are at non-standard paths (e.g., `/opt/corp-tools/bin/bwrap`), or where the default-PATH copy is too old / has the wrong capability set.
+
+```json
+// /etc/claude-code/managed-settings.json (or equivalent managed path)
+{
+  "sandbox": {
+    "bwrapPath": "/opt/corp-tools/bin/bwrap",
+    "socatPath": "/opt/corp-tools/bin/socat"
+  }
+}
+```
+
+**Tier**: managed (admin-only) — these are not user-settable in `.claude/settings.json`. They live in `managed-settings.json` (or any of the `managed-settings.d/` fragments, CC 2.1.83+).
+
+**Impact for OrchestKit**: None for personal use — OrchestKit doesn't ship a sandbox config. For enterprise rollouts that bundle OrchestKit with a corporate `claude` install on Linux/WSL fleets, add `sandbox.bwrapPath` / `sandbox.socatPath` to the managed-settings bundle if `bwrap` / `socat` are not on the default `$PATH` for the target hosts. macOS and native Windows are unaffected (no bwrap/socat dependency).
+
+### `parentSettingsBehavior` Admin Key — Opt SDK `managedSettings` into Policy Merge
+
+CC 2.1.133 adds the `parentSettingsBehavior` admin-tier key with values `"first-wins"` | `"merge"`. SDK hosts can pass a `managedSettings` block as the "parent tier" of the precedence chain — this key controls whether that parent tier participates in the merge against the admin-managed policy, or is overridden first-wins-style by the admin tier.
+
+```json
+// /etc/claude-code/managed-settings.json
+{
+  "parentSettingsBehavior": "merge"
+  // or
+  // "parentSettingsBehavior": "first-wins"
+}
+```
+
+| Value | Effect |
+|-------|--------|
+| `"first-wins"` (default) | Admin-managed settings win — SDK-passed `managedSettings` are ignored where keys conflict |
+| `"merge"` | SDK `managedSettings` participate in the precedence merge alongside the admin tier — useful when the SDK host needs to declare a stricter policy than the admin baseline |
+
+**Impact for OrchestKit**: None for the CLI host. Relevant only for SDK consumers (`claude-code-sdk-*` integrations) that ship their own `managedSettings` and need that policy to compose with an org-level managed-settings bundle rather than be overridden by it. If you build an SDK host on top of OrchestKit, set `parentSettingsBehavior: "merge"` on the admin side so your host's `managedSettings` block isn't silently dropped.
+
+### `Edit`/`Write` Allow Rules at Drive Root or POSIX `/` Now Match Correctly
+
+Before 2.1.133, `Edit` and `Write` allow rules scoped to a Windows **drive root** (e.g., `Edit(C:\\**)`) or to the POSIX root (`Edit(/**)`) matched incorrectly and always fired the permission prompt anyway — the rule was syntactically valid and accepted but the path-match step misclassified the rule as not covering the target path. CC 2.1.133 fixes the match logic so these rules now behave as documented.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Edit(/**)",
+      "Write(/**)",
+      "Edit(C:\\**)",
+      "Write(C:\\**)"
+    ]
+  }
+}
+```
+
+**Impact for OrchestKit**: None for the standard OrchestKit setup — OrchestKit recommends per-project allow rules under `.claude/settings.json` for the project directory, not a system-wide drive-root grant. Relevant if you've added a drive-root rule as a workaround in `.claude/settings.local.json` to silence the prompt-every-time symptom of this bug — at our floor the workaround is no longer needed and the rule actually means what it says. Audit any `Edit(C:\\**)`-shaped rules with that history; if they were added as workarounds, narrow them now that the canonical glob form works.
+
 
 ### Http Hooks
 

--- a/docs/site/content/docs/reference/skills/doctor.mdx
+++ b/docs/site/content/docs/reference/skills/doctor.mdx
@@ -1427,6 +1427,24 @@ Then `claude --resume` the affected sessions. Worktree state in each agent's bra
 
 If "all sessions 401 at once" still reproduces on CC ≥ 2.1.133, the cause is no longer this race — check the refresh token itself (expired, revoked by the IdP, keychain ACL changed, 1Password locked). See also the "Logged out after laptop wake" entry above for the related 2.1.129 wake-from-sleep race.
 
+### "EnterWorktree drops my unpushed commits"
+
+If a worktree spawned via `EnterWorktree`, `--worktree`, or an agent run with `isolation: "worktree"` is missing commits you made locally but never pushed — and `git log` in the new worktree starts from `origin/&lt;default-branch&gt;` instead of your current `HEAD` — that is CC 2.1.133's new `worktree.baseRef` default at work. CC 2.1.133 added the setting with default `"fresh"`, which branches new worktrees from `origin/&lt;default&gt;` rather than local `HEAD` (the 2.1.128–2.1.132 behavior).
+
+**Fix**: set `worktree.baseRef: "head"` in `.claude/settings.json` (project) or `~/.claude/settings.json` (user):
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+After adding the setting, spawn a fresh worktree — the new one will branch from local `HEAD` and include your unpushed commits. Existing worktrees that were created without the setting need to be recreated; you can recover their work by cherry-picking commits from the original branch first.
+
+See `$\{CLAUDE_SKILL_DIR\}/../chain-patterns/references/worktree-agent-pattern.md` for the full agent-isolation context, and `$\{CLAUDE_SKILL_DIR\}/../configure/references/cc-version-settings.md` (CC 2.1.133 section) for the upstream change description.
+
 
 ### Report Format
 

--- a/docs/site/lib/generated/changelog-data.ts
+++ b/docs/site/lib/generated/changelog-data.ts
@@ -17,6 +17,52 @@ export interface ChangelogEntry {
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    "version": "7.86.3",
+    "date": "2026-05-11",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "changed",
+        "items": [
+          "bump anthropics/claude-code-action from 1.0.111 to 1.0.119 ([#1743](https://github.com/yonatangross/orchestkit/issues/1743)) ([c672ae8](https://github.com/yonatangross/orchestkit/commit/c672ae8e313f965bbf0c700a0f9edc48e108345d))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.86.2",
+    "date": "2026-05-11",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "changed",
+        "items": [
+          "bump github/codeql-action from 4.35.3 to 4.35.4 ([#1744](https://github.com/yonatangross/orchestkit/issues/1744)) ([f99744e](https://github.com/yonatangross/orchestkit/commit/f99744eec682f5f8e7ebc5538540e6e622c29407))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "7.86.1",
+    "date": "2026-05-10",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**cc-watch:** skip cc-triage for versions below supported floor ([#1739](https://github.com/yonatangross/orchestkit/issues/1739)) ([#1740](https://github.com/yonatangross/orchestkit/issues/1740)) ([5e551a6](https://github.com/yonatangross/orchestkit/commit/5e551a6ce24780b782dd25c31714fb0248733a1a))",
+          "**ci:** cc-watch uses GH App token ([#1735](https://github.com/yonatangross/orchestkit/issues/1735)) ([#1736](https://github.com/yonatangross/orchestkit/issues/1736)) ([e726b8d](https://github.com/yonatangross/orchestkit/commit/e726b8d2a0c1bb4c4a63601663ab36ae90bc368c))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**cc-watch:** snapshot upstream CHANGELOG (2.1.123) ([#1741](https://github.com/yonatangross/orchestkit/issues/1741)) ([8f9099e](https://github.com/yonatangross/orchestkit/commit/8f9099e3e188542e4d2949168a1217a12c13cd1b))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "7.86.0",
     "date": "2026-05-10",
     "compareUrl": "",

--- a/plugins/ork/skills/chain-patterns/references/worktree-agent-pattern.md
+++ b/plugins/ork/skills/chain-patterns/references/worktree-agent-pattern.md
@@ -46,15 +46,29 @@ Agent(
 - `SubagentStart` → `unified-dispatcher` (logs agent spawn)
 - `SubagentStop` → `unified-dispatcher` (logs completion)
 
-## Branch base (CC 2.1.128+)
+## Required Setting (CC ≥ 2.1.133)
 
-`EnterWorktree` creates the new branch from **local `HEAD`**, not from `origin/<default-branch>`. This means:
+CC 2.1.133 reintroduced a `worktree.baseRef` setting whose default `"fresh"` branches new worktrees from `origin/<default-branch>` — **not** from local `HEAD`. OrchestKit's agent-isolation pattern needs unpushed commits to be visible to spawned agents, so set:
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+Add this to `.claude/settings.json` (project) or `~/.claude/settings.json` (user). Without it, agents spawned via `Task(... isolation: "worktree")` start from origin and miss every unpushed local commit — `tsc` will fail with "cannot find module" for code you just wrote, and tests will run against stale source.
+
+## Branch base (CC 2.1.128–2.1.132 default, CC 2.1.133+ with `baseRef: "head"`)
+
+With `worktree.baseRef: "head"` (or any CC in the 2.1.128–2.1.132 window where this was the default), `EnterWorktree` creates the new branch from **local `HEAD`**, not from `origin/<default-branch>`. This means:
 
 - Unpushed commits in the parent worktree are preserved in the new worktree
 - No need to `git push` before spawning isolated agents
 - Parent and child see the same uncommitted history
 
-CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. We floor at `2.1.138` so this concern is gone — your worktree starts from wherever your tree is now.
+CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. CC 2.1.128–2.1.132 changed the default to local `HEAD`. CC 2.1.133 added the explicit `worktree.baseRef` setting and reverted the default back to `"fresh"` (origin/<default>) — see "Required Setting" above. We floor at `2.1.138`, so the setting is the single source of truth.
 
 > **CC 2.1.133 — concurrent-session stability**: Running multiple worktree-isolated agents in parallel shares one refresh token across sessions. Before 2.1.133 a refresh-token race could 401 every session at once. At our floor this is fixed — concurrent worktree sessions are stable. See `${CLAUDE_SKILL_DIR}/../configure/references/cc-version-settings.md` (CC 2.1.133 section) for the full fix description.
 

--- a/plugins/ork/skills/configure/references/cc-version-settings.md
+++ b/plugins/ork/skills/configure/references/cc-version-settings.md
@@ -614,3 +614,88 @@ claude --add-dir Z:\share\project
 ```
 
 **Impact for OrchestKit**: Windows users running CC against shared team drives — common in Citrix/VDI corporate setups, dev-shared NAS mounts, and OneDrive/SharePoint-as-drive workflows — can now use `--add-dir` and the SDK's `additionalDirectories` without a UNC-vs-letter workaround. No OrchestKit skill change required — the fix is implicit at our floor.
+
+### `worktree.baseRef` Setting — Default Changed to `"fresh"` ⚠ behavior change
+
+CC 2.1.133 adds the `worktree.baseRef` setting (`"fresh"` | `"head"`) that controls where `--worktree`, `EnterWorktree`, and agent-isolation worktrees branch from. **The default is `"fresh"`**, which means new worktrees branch from `origin/<default-branch>` — **not** from your local `HEAD`.
+
+This is a regression for OrchestKit users. From CC 2.1.128 through 2.1.132, `EnterWorktree` branched from local `HEAD`, which is what OrchestKit's worktree-isolation pattern (`chain-patterns/references/worktree-agent-pattern.md`) relies on: unpushed commits in the parent worktree need to be visible to spawned agents. With the new `"fresh"` default, those unpushed commits are silently dropped when the worktree is created.
+
+**Recommended OrchestKit setting** — in `.claude/settings.json`:
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+```json
+// All three forms re-acquire the 2.1.128–2.1.132 behavior:
+//   --worktree
+//   EnterWorktree tool
+//   agent-isolation worktrees (Task tool, isolation: "worktree")
+{ "worktree": { "baseRef": "head" } }
+```
+
+**Choose `"fresh"` only if** you intentionally want every new worktree to start from `origin/<default>` (e.g., clean-room agent runs that should never inherit local WIP). For the common OrchestKit flow — spawn an agent in a worktree to do work on top of an in-progress local branch — `"head"` is the only correct value.
+
+**Impact for OrchestKit**: All of `ork:implement`, `ork:cover`, `ork:fix-issue`, `ork:verify`, and any custom skill that calls `Task(... isolation: "worktree")` is affected. Without `worktree.baseRef: "head"`, agents start from origin and miss every unpushed local commit — `tsc` will fail with "cannot find module" for code you just wrote, tests will run against stale source, and PRs will appear empty of your in-progress work. `ork:doctor` flags this — see `${CLAUDE_SKILL_DIR}/../doctor/references/remediation-guide.md` ("EnterWorktree drops my unpushed commits").
+
+### `sandbox.bwrapPath` / `sandbox.socatPath` Managed Settings (Linux/WSL)
+
+CC 2.1.133 adds two managed-tier settings for Linux and WSL sandbox deployments: `sandbox.bwrapPath` (custom **bubblewrap** binary location) and `sandbox.socatPath` (custom **socat** binary location). These let enterprise admins point the sandbox at vendored binaries on hosts where `bwrap` / `socat` are not on `$PATH`, are at non-standard paths (e.g., `/opt/corp-tools/bin/bwrap`), or where the default-PATH copy is too old / has the wrong capability set.
+
+```json
+// /etc/claude-code/managed-settings.json (or equivalent managed path)
+{
+  "sandbox": {
+    "bwrapPath": "/opt/corp-tools/bin/bwrap",
+    "socatPath": "/opt/corp-tools/bin/socat"
+  }
+}
+```
+
+**Tier**: managed (admin-only) — these are not user-settable in `.claude/settings.json`. They live in `managed-settings.json` (or any of the `managed-settings.d/` fragments, CC 2.1.83+).
+
+**Impact for OrchestKit**: None for personal use — OrchestKit doesn't ship a sandbox config. For enterprise rollouts that bundle OrchestKit with a corporate `claude` install on Linux/WSL fleets, add `sandbox.bwrapPath` / `sandbox.socatPath` to the managed-settings bundle if `bwrap` / `socat` are not on the default `$PATH` for the target hosts. macOS and native Windows are unaffected (no bwrap/socat dependency).
+
+### `parentSettingsBehavior` Admin Key — Opt SDK `managedSettings` into Policy Merge
+
+CC 2.1.133 adds the `parentSettingsBehavior` admin-tier key with values `"first-wins"` | `"merge"`. SDK hosts can pass a `managedSettings` block as the "parent tier" of the precedence chain — this key controls whether that parent tier participates in the merge against the admin-managed policy, or is overridden first-wins-style by the admin tier.
+
+```json
+// /etc/claude-code/managed-settings.json
+{
+  "parentSettingsBehavior": "merge"
+  // or
+  // "parentSettingsBehavior": "first-wins"
+}
+```
+
+| Value | Effect |
+|-------|--------|
+| `"first-wins"` (default) | Admin-managed settings win — SDK-passed `managedSettings` are ignored where keys conflict |
+| `"merge"` | SDK `managedSettings` participate in the precedence merge alongside the admin tier — useful when the SDK host needs to declare a stricter policy than the admin baseline |
+
+**Impact for OrchestKit**: None for the CLI host. Relevant only for SDK consumers (`claude-code-sdk-*` integrations) that ship their own `managedSettings` and need that policy to compose with an org-level managed-settings bundle rather than be overridden by it. If you build an SDK host on top of OrchestKit, set `parentSettingsBehavior: "merge"` on the admin side so your host's `managedSettings` block isn't silently dropped.
+
+### `Edit`/`Write` Allow Rules at Drive Root or POSIX `/` Now Match Correctly
+
+Before 2.1.133, `Edit` and `Write` allow rules scoped to a Windows **drive root** (e.g., `Edit(C:\\**)`) or to the POSIX root (`Edit(/**)`) matched incorrectly and always fired the permission prompt anyway — the rule was syntactically valid and accepted but the path-match step misclassified the rule as not covering the target path. CC 2.1.133 fixes the match logic so these rules now behave as documented.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Edit(/**)",
+      "Write(/**)",
+      "Edit(C:\\**)",
+      "Write(C:\\**)"
+    ]
+  }
+}
+```
+
+**Impact for OrchestKit**: None for the standard OrchestKit setup — OrchestKit recommends per-project allow rules under `.claude/settings.json` for the project directory, not a system-wide drive-root grant. Relevant if you've added a drive-root rule as a workaround in `.claude/settings.local.json` to silence the prompt-every-time symptom of this bug — at our floor the workaround is no longer needed and the rule actually means what it says. Audit any `Edit(C:\\**)`-shaped rules with that history; if they were added as workarounds, narrow them now that the canonical glob form works.

--- a/plugins/ork/skills/doctor/references/remediation-guide.md
+++ b/plugins/ork/skills/doctor/references/remediation-guide.md
@@ -92,3 +92,21 @@ claude /login
 Then `claude --resume` the affected sessions. Worktree state in each agent's branch is unaffected.
 
 If "all sessions 401 at once" still reproduces on CC ≥ 2.1.133, the cause is no longer this race — check the refresh token itself (expired, revoked by the IdP, keychain ACL changed, 1Password locked). See also the "Logged out after laptop wake" entry above for the related 2.1.129 wake-from-sleep race.
+
+### "EnterWorktree drops my unpushed commits"
+
+If a worktree spawned via `EnterWorktree`, `--worktree`, or an agent run with `isolation: "worktree"` is missing commits you made locally but never pushed — and `git log` in the new worktree starts from `origin/<default-branch>` instead of your current `HEAD` — that is CC 2.1.133's new `worktree.baseRef` default at work. CC 2.1.133 added the setting with default `"fresh"`, which branches new worktrees from `origin/<default>` rather than local `HEAD` (the 2.1.128–2.1.132 behavior).
+
+**Fix**: set `worktree.baseRef: "head"` in `.claude/settings.json` (project) or `~/.claude/settings.json` (user):
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+After adding the setting, spawn a fresh worktree — the new one will branch from local `HEAD` and include your unpushed commits. Existing worktrees that were created without the setting need to be recreated; you can recover their work by cherry-picking commits from the original branch first.
+
+See `${CLAUDE_SKILL_DIR}/../chain-patterns/references/worktree-agent-pattern.md` for the full agent-isolation context, and `${CLAUDE_SKILL_DIR}/../configure/references/cc-version-settings.md` (CC 2.1.133 section) for the upstream change description.

--- a/src/hooks/src/lib/cc-version-matrix.ts
+++ b/src/hooks/src/lib/cc-version-matrix.ts
@@ -461,6 +461,10 @@ export const CC_FEATURE_MATRIX: readonly CCFeatureEntry[] = [
   { feature: 'remote_control_stop_interrupt_fix',       minVersion: '2.1.133', description: 'claude.ai Remote Control stop/interrupt now matches local Esc cancellation' },
   { feature: 'mcp_oauth_proxy_mtls_fix',                minVersion: '2.1.133', description: 'MCP OAuth full flow respects HTTP(S)_PROXY/NO_PROXY/mTLS' },
   { feature: 'mapped_network_drive_add_dir_fix',        minVersion: '2.1.133', description: '--add-dir / SDK additionalDirectories works for Windows mapped network drives' },
+  { feature: 'worktree_base_ref_setting',               minVersion: '2.1.133', description: 'worktree.baseRef setting (fresh|head) — default changed to fresh in 2.1.133' },
+  { feature: 'sandbox_bwrap_socat_managed_settings',    minVersion: '2.1.133', description: 'sandbox.bwrapPath / sandbox.socatPath managed settings (Linux/WSL)' },
+  { feature: 'parent_settings_behavior_admin_key',      minVersion: '2.1.133', description: 'parentSettingsBehavior admin-tier key (first-wins|merge) for SDK managedSettings' },
+  { feature: 'edit_write_drive_root_allow_rules_fix',   minVersion: '2.1.133', description: 'Edit/Write allow rules scoped to drive root (C:\\\\) or POSIX / now match correctly' },
 ] as const;
 
 export type CCFeature = typeof CC_FEATURE_MATRIX[number]['feature'];

--- a/src/skills/chain-patterns/references/worktree-agent-pattern.md
+++ b/src/skills/chain-patterns/references/worktree-agent-pattern.md
@@ -46,15 +46,29 @@ Agent(
 - `SubagentStart` → `unified-dispatcher` (logs agent spawn)
 - `SubagentStop` → `unified-dispatcher` (logs completion)
 
-## Branch base (CC 2.1.128+)
+## Required Setting (CC ≥ 2.1.133)
 
-`EnterWorktree` creates the new branch from **local `HEAD`**, not from `origin/<default-branch>`. This means:
+CC 2.1.133 reintroduced a `worktree.baseRef` setting whose default `"fresh"` branches new worktrees from `origin/<default-branch>` — **not** from local `HEAD`. OrchestKit's agent-isolation pattern needs unpushed commits to be visible to spawned agents, so set:
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+Add this to `.claude/settings.json` (project) or `~/.claude/settings.json` (user). Without it, agents spawned via `Task(... isolation: "worktree")` start from origin and miss every unpushed local commit — `tsc` will fail with "cannot find module" for code you just wrote, and tests will run against stale source.
+
+## Branch base (CC 2.1.128–2.1.132 default, CC 2.1.133+ with `baseRef: "head"`)
+
+With `worktree.baseRef: "head"` (or any CC in the 2.1.128–2.1.132 window where this was the default), `EnterWorktree` creates the new branch from **local `HEAD`**, not from `origin/<default-branch>`. This means:
 
 - Unpushed commits in the parent worktree are preserved in the new worktree
 - No need to `git push` before spawning isolated agents
 - Parent and child see the same uncommitted history
 
-CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. We floor at `2.1.138` so this concern is gone — your worktree starts from wherever your tree is now.
+CC ≤ 2.1.127 branched from `origin/<default-branch>`, which silently dropped local-only commits. CC 2.1.128–2.1.132 changed the default to local `HEAD`. CC 2.1.133 added the explicit `worktree.baseRef` setting and reverted the default back to `"fresh"` (origin/<default>) — see "Required Setting" above. We floor at `2.1.138`, so the setting is the single source of truth.
 
 > **CC 2.1.133 — concurrent-session stability**: Running multiple worktree-isolated agents in parallel shares one refresh token across sessions. Before 2.1.133 a refresh-token race could 401 every session at once. At our floor this is fixed — concurrent worktree sessions are stable. See `${CLAUDE_SKILL_DIR}/../configure/references/cc-version-settings.md` (CC 2.1.133 section) for the full fix description.
 

--- a/src/skills/configure/references/cc-version-settings.md
+++ b/src/skills/configure/references/cc-version-settings.md
@@ -614,3 +614,88 @@ claude --add-dir Z:\share\project
 ```
 
 **Impact for OrchestKit**: Windows users running CC against shared team drives — common in Citrix/VDI corporate setups, dev-shared NAS mounts, and OneDrive/SharePoint-as-drive workflows — can now use `--add-dir` and the SDK's `additionalDirectories` without a UNC-vs-letter workaround. No OrchestKit skill change required — the fix is implicit at our floor.
+
+### `worktree.baseRef` Setting — Default Changed to `"fresh"` ⚠ behavior change
+
+CC 2.1.133 adds the `worktree.baseRef` setting (`"fresh"` | `"head"`) that controls where `--worktree`, `EnterWorktree`, and agent-isolation worktrees branch from. **The default is `"fresh"`**, which means new worktrees branch from `origin/<default-branch>` — **not** from your local `HEAD`.
+
+This is a regression for OrchestKit users. From CC 2.1.128 through 2.1.132, `EnterWorktree` branched from local `HEAD`, which is what OrchestKit's worktree-isolation pattern (`chain-patterns/references/worktree-agent-pattern.md`) relies on: unpushed commits in the parent worktree need to be visible to spawned agents. With the new `"fresh"` default, those unpushed commits are silently dropped when the worktree is created.
+
+**Recommended OrchestKit setting** — in `.claude/settings.json`:
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+```json
+// All three forms re-acquire the 2.1.128–2.1.132 behavior:
+//   --worktree
+//   EnterWorktree tool
+//   agent-isolation worktrees (Task tool, isolation: "worktree")
+{ "worktree": { "baseRef": "head" } }
+```
+
+**Choose `"fresh"` only if** you intentionally want every new worktree to start from `origin/<default>` (e.g., clean-room agent runs that should never inherit local WIP). For the common OrchestKit flow — spawn an agent in a worktree to do work on top of an in-progress local branch — `"head"` is the only correct value.
+
+**Impact for OrchestKit**: All of `ork:implement`, `ork:cover`, `ork:fix-issue`, `ork:verify`, and any custom skill that calls `Task(... isolation: "worktree")` is affected. Without `worktree.baseRef: "head"`, agents start from origin and miss every unpushed local commit — `tsc` will fail with "cannot find module" for code you just wrote, tests will run against stale source, and PRs will appear empty of your in-progress work. `ork:doctor` flags this — see `${CLAUDE_SKILL_DIR}/../doctor/references/remediation-guide.md` ("EnterWorktree drops my unpushed commits").
+
+### `sandbox.bwrapPath` / `sandbox.socatPath` Managed Settings (Linux/WSL)
+
+CC 2.1.133 adds two managed-tier settings for Linux and WSL sandbox deployments: `sandbox.bwrapPath` (custom **bubblewrap** binary location) and `sandbox.socatPath` (custom **socat** binary location). These let enterprise admins point the sandbox at vendored binaries on hosts where `bwrap` / `socat` are not on `$PATH`, are at non-standard paths (e.g., `/opt/corp-tools/bin/bwrap`), or where the default-PATH copy is too old / has the wrong capability set.
+
+```json
+// /etc/claude-code/managed-settings.json (or equivalent managed path)
+{
+  "sandbox": {
+    "bwrapPath": "/opt/corp-tools/bin/bwrap",
+    "socatPath": "/opt/corp-tools/bin/socat"
+  }
+}
+```
+
+**Tier**: managed (admin-only) — these are not user-settable in `.claude/settings.json`. They live in `managed-settings.json` (or any of the `managed-settings.d/` fragments, CC 2.1.83+).
+
+**Impact for OrchestKit**: None for personal use — OrchestKit doesn't ship a sandbox config. For enterprise rollouts that bundle OrchestKit with a corporate `claude` install on Linux/WSL fleets, add `sandbox.bwrapPath` / `sandbox.socatPath` to the managed-settings bundle if `bwrap` / `socat` are not on the default `$PATH` for the target hosts. macOS and native Windows are unaffected (no bwrap/socat dependency).
+
+### `parentSettingsBehavior` Admin Key — Opt SDK `managedSettings` into Policy Merge
+
+CC 2.1.133 adds the `parentSettingsBehavior` admin-tier key with values `"first-wins"` | `"merge"`. SDK hosts can pass a `managedSettings` block as the "parent tier" of the precedence chain — this key controls whether that parent tier participates in the merge against the admin-managed policy, or is overridden first-wins-style by the admin tier.
+
+```json
+// /etc/claude-code/managed-settings.json
+{
+  "parentSettingsBehavior": "merge"
+  // or
+  // "parentSettingsBehavior": "first-wins"
+}
+```
+
+| Value | Effect |
+|-------|--------|
+| `"first-wins"` (default) | Admin-managed settings win — SDK-passed `managedSettings` are ignored where keys conflict |
+| `"merge"` | SDK `managedSettings` participate in the precedence merge alongside the admin tier — useful when the SDK host needs to declare a stricter policy than the admin baseline |
+
+**Impact for OrchestKit**: None for the CLI host. Relevant only for SDK consumers (`claude-code-sdk-*` integrations) that ship their own `managedSettings` and need that policy to compose with an org-level managed-settings bundle rather than be overridden by it. If you build an SDK host on top of OrchestKit, set `parentSettingsBehavior: "merge"` on the admin side so your host's `managedSettings` block isn't silently dropped.
+
+### `Edit`/`Write` Allow Rules at Drive Root or POSIX `/` Now Match Correctly
+
+Before 2.1.133, `Edit` and `Write` allow rules scoped to a Windows **drive root** (e.g., `Edit(C:\\**)`) or to the POSIX root (`Edit(/**)`) matched incorrectly and always fired the permission prompt anyway — the rule was syntactically valid and accepted but the path-match step misclassified the rule as not covering the target path. CC 2.1.133 fixes the match logic so these rules now behave as documented.
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Edit(/**)",
+      "Write(/**)",
+      "Edit(C:\\**)",
+      "Write(C:\\**)"
+    ]
+  }
+}
+```
+
+**Impact for OrchestKit**: None for the standard OrchestKit setup — OrchestKit recommends per-project allow rules under `.claude/settings.json` for the project directory, not a system-wide drive-root grant. Relevant if you've added a drive-root rule as a workaround in `.claude/settings.local.json` to silence the prompt-every-time symptom of this bug — at our floor the workaround is no longer needed and the rule actually means what it says. Audit any `Edit(C:\\**)`-shaped rules with that history; if they were added as workarounds, narrow them now that the canonical glob form works.

--- a/src/skills/doctor/references/remediation-guide.md
+++ b/src/skills/doctor/references/remediation-guide.md
@@ -92,3 +92,21 @@ claude /login
 Then `claude --resume` the affected sessions. Worktree state in each agent's branch is unaffected.
 
 If "all sessions 401 at once" still reproduces on CC ≥ 2.1.133, the cause is no longer this race — check the refresh token itself (expired, revoked by the IdP, keychain ACL changed, 1Password locked). See also the "Logged out after laptop wake" entry above for the related 2.1.129 wake-from-sleep race.
+
+### "EnterWorktree drops my unpushed commits"
+
+If a worktree spawned via `EnterWorktree`, `--worktree`, or an agent run with `isolation: "worktree"` is missing commits you made locally but never pushed — and `git log` in the new worktree starts from `origin/<default-branch>` instead of your current `HEAD` — that is CC 2.1.133's new `worktree.baseRef` default at work. CC 2.1.133 added the setting with default `"fresh"`, which branches new worktrees from `origin/<default>` rather than local `HEAD` (the 2.1.128–2.1.132 behavior).
+
+**Fix**: set `worktree.baseRef: "head"` in `.claude/settings.json` (project) or `~/.claude/settings.json` (user):
+
+```json
+{
+  "worktree": {
+    "baseRef": "head"
+  }
+}
+```
+
+After adding the setting, spawn a fresh worktree — the new one will branch from local `HEAD` and include your unpushed commits. Existing worktrees that were created without the setting need to be recreated; you can recover their work by cherry-picking commits from the original branch first.
+
+See `${CLAUDE_SKILL_DIR}/../chain-patterns/references/worktree-agent-pattern.md` for the full agent-isolation context, and `${CLAUDE_SKILL_DIR}/../configure/references/cc-version-settings.md` (CC 2.1.133 section) for the upstream change description.


### PR DESCRIPTION
Closes #1699
Closes #1700
Closes #1701
Closes #1704

> **Stacked on #1747 (Group F).** Base is `chore/m132-group-f-cc-133-oauth-session-network`. After F squash-merges to main, rebase G onto main per the [stacked-PR squash-rebase pattern](https://github.com/yonatangross/orchestkit/blob/main/agent-memory/feedback_stacked_pr_squash_rebase.md).

## ⚠ Behavior change for OrchestKit — #1699

CC 2.1.133 introduces `worktree.baseRef` (`"fresh"` | `"head"`) and **defaults to `"fresh"`** — new worktrees branch from `origin/<default-branch>` instead of local `HEAD`. This **reverts** the 2.1.128–2.1.132 behavior that OrchestKit's agent-isolation pattern (`chain-patterns/references/worktree-agent-pattern.md`) relies on: unpushed parent-worktree commits need to be visible to spawned agents.

**Recommended setting** — add to `.claude/settings.json`:

```json
{ "worktree": { "baseRef": "head" } }
```

Without it, every `Task(... isolation: "worktree")` call drops your in-progress local commits — `tsc` fails with "cannot find module" on code you just wrote, tests run against stale source, and PRs appear empty of your in-progress work.

This is the only one of the four that needs a user action.

## Summary

Second adoption PR for M132 (CC 2.1.133). 3 new-perm features + 1 breaking permission-rule fix, appended under the `## CC 2.1.133 Settings` parent header that Group F (#1747) introduced.

## Issues closed

| # | Slug | Cat | What it does |
|---|------|-----|--------------|
| #1699 | worktree-base-ref-setting | new_perm | New `worktree.baseRef` setting — default `"fresh"` regresses 2.1.128–2.1.132 local-HEAD behavior. **OrchestKit must set `"head"`.** |
| #1700 | sandbox-bwrap-socat-managed-settings | new_perm | New `sandbox.bwrapPath` / `sandbox.socatPath` managed settings (Linux/WSL). |
| #1701 | parent-settings-behavior-admin-key | new_perm | New `parentSettingsBehavior` admin key (`first-wins` \| `merge`) for SDK `managedSettings` precedence. |
| #1704 | edit-write-drive-root-allow-rules-fix | breaking | `Edit`/`Write` allow rules at drive root (`C:\`) or POSIX `/` now match correctly instead of always prompting. |

## Files

- `src/skills/configure/references/cc-version-settings.md` — 4 new subsections under existing `## CC 2.1.133 Settings` parent (Group F)
- `src/skills/chain-patterns/references/worktree-agent-pattern.md` — Required Setting callout + corrected branch-base prose (the old "EnterWorktree branches from local HEAD" claim is no longer true by default on 2.1.133+)
- `src/skills/doctor/references/remediation-guide.md` — "EnterWorktree drops my unpushed commits" entry
- `src/hooks/src/lib/cc-version-matrix.ts` — 4 new entries with `minVersion: '2.1.133'`
- `plugins/ork/**` + `docs/site/**` — regenerated by `npm run build`

## Playground

`docs/chore--m132-group-g-cc-133-perm-sandbox-settings/group-g-playground.html`

## Test plan

- [x] `npm run build` — 107 skills / 37 agents / 188 hooks, no count drift
- [x] `npm run test:security` — 14/14 PASS
- [x] `npm run test:agents` — 37/37 valid
- [x] `npm run test:skills` — PASS
- [x] `npm run test:manifests` — 108 skills, 0 orphans
- [x] `npm run typecheck` — clean