### PR TITLE
chore(adopt): M132 Group H CC 2.1.133 effort+skill discovery

### DIFF
--- a/docs/chore--m132-group-h-cc-133-effort-skill-discovery/group-h-playground.html
+++ b/docs/chore--m132-group-h-cc-133-effort-skill-discovery/group-h-playground.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>M132 Group H — CC 2.1.133 effort+skill-discovery</title>
+<style>
+body{font:14px ui-monospace,monospace;background:#0b0b0b;color:#e8e8e8;padding:32px;max-width:760px;margin:auto}
+h1{color:#7aa2f7;border-bottom:1px solid #333;padding-bottom:6px}
+h2{color:#bb9af7;margin-top:28px}
+table{width:100%;border-collapse:collapse;margin:12px 0}
+th,td{text-align:left;padding:6px 10px;border-bottom:1px solid #2a2a2a;vertical-align:top}
+th{color:#bb9af7}
+.muted{color:#888}
+.ok{color:#9ece6a}
+pre{background:#161616;padding:14px;border-radius:6px;overflow-x:auto;line-height:1.4}
+</style>
+</head>
+<body>
+<h1>M132 Group H — CC 2.1.133 effort + skill discovery (FINAL group)</h1>
+<p class="muted">Completes M132 (CC 2.1.133 adoption). 3 issues, doc adoption + matrix entries + hooks README note. After this lands, M132 is 11/11 (100%).</p>
+
+<h2>Issues closed</h2>
+<table>
+  <tr><th>#</th><th>Slug</th><th>What it fixes / adds</th></tr>
+  <tr><td>1702</td><td>hooks-effort-level-input</td><td>NEW: hooks receive <code>effort.level</code> JSON input field + <code>$CLAUDE_EFFORT</code> env var (also in Bash tool)</td></tr>
+  <tr><td>1708</td><td>effort-cross-session-leak-fix</td><td>FIXED: <code>/effort</code> in one session no longer changes other concurrent sessions; IDE effort changes no longer silently dropped</td></tr>
+  <tr><td>1709</td><td>subagent-skill-discovery-fix</td><td>FIXED: subagents (via Task tool) now discover project/user/plugin skills as documented</td></tr>
+</table>
+
+<h2>OrchestKit impact</h2>
+<ul>
+<li><strong>#1702</strong> — 188 hooks in <code>src/hooks/</code> can now branch on effort without parsing JSON input. <code>quality-gates</code> skill benefits directly.</li>
+<li><strong>#1708</strong> — Chain-patterns multi-worktree flows are stable; concurrent sessions are isolated.</li>
+<li><strong>#1709</strong> — Agent-orchestration patterns (<code>ork:implement</code>, <code>ork:fix-issue</code>, etc.) that spawn subagents now work as documented; if subagents claimed "skill not found", that was the bug.</li>
+</ul>
+
+<h2>Files</h2>
+<ul>
+<li><code>src/skills/configure/references/cc-version-settings.md</code> — 3 new subsections under existing <code>## CC 2.1.133 Settings</code></li>
+<li><code>src/hooks/README.md</code> — callout: hooks can read <code>$CLAUDE_EFFORT</code> directly (2.1.133+)</li>
+<li><code>src/hooks/src/lib/cc-version-matrix.ts</code> — 3 new entries</li>
+<li><code>src/hooks/src/__tests__/lib/cc-version-matrix.test.ts</code> — count assertions bumped +3 (matrix grows from 400 → 403)</li>
+<li>plugins/ mirror + docs/site MDX regen</li>
+</ul>
+
+<h2>Verification</h2>
+<pre class="ok">vitest cc-version-matrix.test.ts  64/64 PASS</pre>
+
+<h2>M132 milestone closeout</h2>
+<p>After this PR merges:</p>
+<pre class="ok">M132 (CC 2.1.133 adoption)  11/11 closed  (100%)
+  Group F  4 issues  shipped
+  Group G  4 issues  shipped
+  Group H  3 issues  shipping NOW</pre>
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/configure.mdx
+++ b/docs/site/content/docs/reference/skills/configure.mdx
@@ -1166,6 +1166,77 @@ Before 2.1.133, `Edit` and `Write` allow rules scoped to a Windows **drive root*
 
 **Impact for OrchestKit**: None for the standard OrchestKit setup — OrchestKit recommends per-project allow rules under `.claude/settings.json` for the project directory, not a system-wide drive-root grant. Relevant if you've added a drive-root rule as a workaround in `.claude/settings.local.json` to silence the prompt-every-time symptom of this bug — at our floor the workaround is no longer needed and the rule actually means what it says. Audit any `Edit(C:\\**)`-shaped rules with that history; if they were added as workarounds, narrow them now that the canonical glob form works.
 
+### Hooks Now Receive `effort.level` Input + `$CLAUDE_EFFORT` Env
+
+CC 2.1.133 surfaces the active effort level to every hook invocation in two new ways:
+
+1. **`effort.level` JSON input field** — the hook stdin payload now includes the active effort as a top-level `effort.level` string (`"low"` | `"medium"` | `"high"` | `"xhigh"`).
+2. **`$CLAUDE_EFFORT` environment variable** — set in the hook process env and inherited by anything the hook spawns. Bash tool invocations also see `$CLAUDE_EFFORT`, so shell commands can branch on it without going through the hook.
+
+```typescript
+// PreToolUse hook reading effort from JSON stdin
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf-8'));
+const effort = input.effort?.level ?? process.env.CLAUDE_EFFORT ?? 'medium';
+
+if (effort === 'low') {
+  // Skip expensive validation — user signaled fast iteration
+  process.exit(0);
+}
+```
+
+```bash
+# Bash tool / hook script reading effort directly
+if [ "${CLAUDE_EFFORT:-medium}" = "xhigh" ]; then
+  # Run the full audit suite — user explicitly opted in
+  npm run test:all
+else
+  npm run test:quick
+fi
+```
+
+**Impact for OrchestKit**: Direct hit on `src/hooks/src/**` — every OrchestKit hook can now be effort-aware. Concrete opportunities:
+
+- **`quality-gates`** hooks can gate expensive correctness checks (full type-check, security scan, integration suite) to `high` / `xhigh` and skip them on `low` for fast iteration.
+- **`ci-debug`**, **`assess`**, and **`verify`** chains can scale the number of parallel agents spawned with effort level.
+- **`pre-commit`** style gates can downgrade strict checks to advisory at `low` and enforce blocking at `high`.
+
+No setting change required — the JSON field and env var are always present at our floor (CC ≥ 2.1.138). Hook authors should treat absence as `medium` for forward compat.
+
+### `/effort` Now Session-Scoped (No Cross-Session Leak)
+
+Before 2.1.133, running `/effort high` (or any effort change) in one CC session could **silently bump the effort level of every other concurrent session** on the same machine — the effort state was stored in a shared global rather than per-session. A related bug also caused IDE-driven effort changes (the VSCode/JetBrains effort picker) to be silently dropped when another session held the lock.
+
+CC 2.1.133 makes `/effort` session-local: each session has its own effort state, IDE effort changes are reliably applied to the active session, and concurrent sessions no longer trample each other.
+
+```bash
+# Session A
+/effort xhigh
+# → Session A is now xhigh
+
+# Session B (concurrent, started before or after)
+/effort low
+# → Session B is now low; Session A stays at xhigh (was previously also forced to low)
+```
+
+**Impact for OrchestKit**: Direct hit on OrchestKit's worktree-isolation workflow — running parallel `/ork:implement` and `/ork:verify` in separate worktrees with different effort levels (e.g., `xhigh` for the implement run, `medium` for verify) now works as expected. Before 2.1.133, the second `/effort` call would silently retarget the first session, defeating the whole point of per-task effort tuning. Combined with the new `effort.level` hook input (#1702), this makes effort-aware hooks safe to deploy without worrying about cross-session contamination. No setting change required; the floor in `engines.claudeCode` (≥ 2.1.138) already guarantees the fix.
+
+### Subagents Now Discover Project/User/Plugin Skills
+
+Before 2.1.133, subagents spawned via the **Task tool** could not discover skills from any source — project (`.claude/skills/`), user (`~/.claude/skills/`), or plugin (e.g., OrchestKit's bundled skills). The Skill tool inside a subagent saw an empty registry even when the parent session could list dozens of skills. This was a **direct regression** for OrchestKit because every agent in `src/agents/*` that delegates work via Task and relies on a Skill call inside the subagent was broken at the discovery step.
+
+CC 2.1.133 restores documented behavior: subagents inherit the full skill registry (project + user + plugin tiers) and can invoke any skill the parent session sees.
+
+```typescript
+// Inside a subagent body (e.g., src/agents/backend-system-architect.md):
+// Before 2.1.133: this would fail — Skill not found
+// At our floor (CC ≥ 2.1.138): works as documented
+Skill({ name: 'ork:architecture-patterns' });
+```
+
+**Impact for OrchestKit**: **Direct, immediate** — every OrchestKit agent in `src/agents/*` that uses `skills:` in its frontmatter relies on this discovery path. Before 2.1.133, Task-delegated work in `ork:implement`, `ork:cover`, `ork:verify`, `ork:fix-issue`, `ork:review-pr`, and `ork:explore` could silently fall back to non-skill behavior because the Skill tool returned "skill not found" inside the subagent. At our floor the fix is implicit — no agent-frontmatter or settings change is required. If you maintain custom agents that worked around this by inlining skill content into the agent body, you can now revert to a clean `Skill(\{ name: ... \})` call.
+
 
 ### Http Hooks
 

--- a/plugins/ork/hooks/README.md
+++ b/plugins/ork/hooks/README.md
@@ -238,6 +238,8 @@ CLAUDE_PLUGIN_DATA not set (CC < 2.1.78 fallback):
 
 CC provides a `CLAUDE_ENV_FILE` env var to hooks running on `SessionStart`, `CwdChanged`, `FileChanged`, and `ConfigChange` events. Hook scripts write `export KEY=value` lines to this file, and CC reads them back after execution, setting those env vars for **all future hook invocations** in the session. This is cleaner than file-based state for lightweight key-value data.
 
+> **Effort awareness (CC 2.1.133+)**: Hooks can read `$CLAUDE_EFFORT` (or the `effort.level` JSON input field) directly to gate expensive checks on `high`/`xhigh` and skip them on `low`. Bash tool commands also see `$CLAUDE_EFFORT`. See `src/skills/configure/references/cc-version-settings.md` ("Hooks Now Receive `effort.level` Input + `$CLAUDE_EFFORT` Env").
+
 ### How It Works
 
 ```

--- a/plugins/ork/skills/configure/references/cc-version-settings.md
+++ b/plugins/ork/skills/configure/references/cc-version-settings.md
@@ -699,3 +699,74 @@ Before 2.1.133, `Edit` and `Write` allow rules scoped to a Windows **drive root*
 ```
 
 **Impact for OrchestKit**: None for the standard OrchestKit setup — OrchestKit recommends per-project allow rules under `.claude/settings.json` for the project directory, not a system-wide drive-root grant. Relevant if you've added a drive-root rule as a workaround in `.claude/settings.local.json` to silence the prompt-every-time symptom of this bug — at our floor the workaround is no longer needed and the rule actually means what it says. Audit any `Edit(C:\\**)`-shaped rules with that history; if they were added as workarounds, narrow them now that the canonical glob form works.
+
+### Hooks Now Receive `effort.level` Input + `$CLAUDE_EFFORT` Env
+
+CC 2.1.133 surfaces the active effort level to every hook invocation in two new ways:
+
+1. **`effort.level` JSON input field** — the hook stdin payload now includes the active effort as a top-level `effort.level` string (`"low"` | `"medium"` | `"high"` | `"xhigh"`).
+2. **`$CLAUDE_EFFORT` environment variable** — set in the hook process env and inherited by anything the hook spawns. Bash tool invocations also see `$CLAUDE_EFFORT`, so shell commands can branch on it without going through the hook.
+
+```typescript
+// PreToolUse hook reading effort from JSON stdin
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf-8'));
+const effort = input.effort?.level ?? process.env.CLAUDE_EFFORT ?? 'medium';
+
+if (effort === 'low') {
+  // Skip expensive validation — user signaled fast iteration
+  process.exit(0);
+}
+```
+
+```bash
+# Bash tool / hook script reading effort directly
+if [ "${CLAUDE_EFFORT:-medium}" = "xhigh" ]; then
+  # Run the full audit suite — user explicitly opted in
+  npm run test:all
+else
+  npm run test:quick
+fi
+```
+
+**Impact for OrchestKit**: Direct hit on `src/hooks/src/**` — every OrchestKit hook can now be effort-aware. Concrete opportunities:
+
+- **`quality-gates`** hooks can gate expensive correctness checks (full type-check, security scan, integration suite) to `high` / `xhigh` and skip them on `low` for fast iteration.
+- **`ci-debug`**, **`assess`**, and **`verify`** chains can scale the number of parallel agents spawned with effort level.
+- **`pre-commit`** style gates can downgrade strict checks to advisory at `low` and enforce blocking at `high`.
+
+No setting change required — the JSON field and env var are always present at our floor (CC ≥ 2.1.138). Hook authors should treat absence as `medium` for forward compat.
+
+### `/effort` Now Session-Scoped (No Cross-Session Leak)
+
+Before 2.1.133, running `/effort high` (or any effort change) in one CC session could **silently bump the effort level of every other concurrent session** on the same machine — the effort state was stored in a shared global rather than per-session. A related bug also caused IDE-driven effort changes (the VSCode/JetBrains effort picker) to be silently dropped when another session held the lock.
+
+CC 2.1.133 makes `/effort` session-local: each session has its own effort state, IDE effort changes are reliably applied to the active session, and concurrent sessions no longer trample each other.
+
+```bash
+# Session A
+/effort xhigh
+# → Session A is now xhigh
+
+# Session B (concurrent, started before or after)
+/effort low
+# → Session B is now low; Session A stays at xhigh (was previously also forced to low)
+```
+
+**Impact for OrchestKit**: Direct hit on OrchestKit's worktree-isolation workflow — running parallel `/ork:implement` and `/ork:verify` in separate worktrees with different effort levels (e.g., `xhigh` for the implement run, `medium` for verify) now works as expected. Before 2.1.133, the second `/effort` call would silently retarget the first session, defeating the whole point of per-task effort tuning. Combined with the new `effort.level` hook input (#1702), this makes effort-aware hooks safe to deploy without worrying about cross-session contamination. No setting change required; the floor in `engines.claudeCode` (≥ 2.1.138) already guarantees the fix.
+
+### Subagents Now Discover Project/User/Plugin Skills
+
+Before 2.1.133, subagents spawned via the **Task tool** could not discover skills from any source — project (`.claude/skills/`), user (`~/.claude/skills/`), or plugin (e.g., OrchestKit's bundled skills). The Skill tool inside a subagent saw an empty registry even when the parent session could list dozens of skills. This was a **direct regression** for OrchestKit because every agent in `src/agents/*` that delegates work via Task and relies on a Skill call inside the subagent was broken at the discovery step.
+
+CC 2.1.133 restores documented behavior: subagents inherit the full skill registry (project + user + plugin tiers) and can invoke any skill the parent session sees.
+
+```typescript
+// Inside a subagent body (e.g., src/agents/backend-system-architect.md):
+// Before 2.1.133: this would fail — Skill not found
+// At our floor (CC ≥ 2.1.138): works as documented
+Skill({ name: 'ork:architecture-patterns' });
+```
+
+**Impact for OrchestKit**: **Direct, immediate** — every OrchestKit agent in `src/agents/*` that uses `skills:` in its frontmatter relies on this discovery path. Before 2.1.133, Task-delegated work in `ork:implement`, `ork:cover`, `ork:verify`, `ork:fix-issue`, `ork:review-pr`, and `ork:explore` could silently fall back to non-skill behavior because the Skill tool returned "skill not found" inside the subagent. At our floor the fix is implicit — no agent-frontmatter or settings change is required. If you maintain custom agents that worked around this by inlining skill content into the agent body, you can now revert to a clean `Skill({ name: ... })` call.

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -238,6 +238,8 @@ CLAUDE_PLUGIN_DATA not set (CC < 2.1.78 fallback):
 
 CC provides a `CLAUDE_ENV_FILE` env var to hooks running on `SessionStart`, `CwdChanged`, `FileChanged`, and `ConfigChange` events. Hook scripts write `export KEY=value` lines to this file, and CC reads them back after execution, setting those env vars for **all future hook invocations** in the session. This is cleaner than file-based state for lightweight key-value data.
 
+> **Effort awareness (CC 2.1.133+)**: Hooks can read `$CLAUDE_EFFORT` (or the `effort.level` JSON input field) directly to gate expensive checks on `high`/`xhigh` and skip them on `low`. Bash tool commands also see `$CLAUDE_EFFORT`. See `src/skills/configure/references/cc-version-settings.md` ("Hooks Now Receive `effort.level` Input + `$CLAUDE_EFFORT` Env").
+
 ### How It Works
 
 ```

--- a/src/hooks/src/__tests__/lib/cc-version-matrix.test.ts
+++ b/src/hooks/src/__tests__/lib/cc-version-matrix.test.ts
@@ -28,8 +28,8 @@ describe('cc-version-matrix', () => {
 
   describe('CC_FEATURE_MATRIX', () => {
     test('contains expected number of features', () => {
-      // 253 (through 2.1.101) + 10 (2.1.105) + 1 (2.1.107) + 13 (2.1.108) + 1 (2.1.109) + 16 (2.1.110) + 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 400
-      expect(CC_FEATURE_MATRIX.length).toBe(400);
+      // 253 (through 2.1.101) + 10 (2.1.105) + 1 (2.1.107) + 13 (2.1.108) + 1 (2.1.109) + 16 (2.1.110) + 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 403
+      expect(CC_FEATURE_MATRIX.length).toBe(403);
     });
 
     test('is sorted by version ascending', () => {
@@ -112,8 +112,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.119 is missing 2.1.128 + 2.1.129 + 2.1.132 + 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.119');
-      // 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 35
-      expect(missing.length).toBe(35);
+      // 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 38
+      expect(missing.length).toBe(38);
       expect(missing.some(f => f.feature === 'enter_worktree_branch_from_head')).toBe(true);
       expect(missing.some(f => f.feature === 'plugin_dir_zip_archives')).toBe(true);
       expect(missing.some(f => f.feature === 'experimental_themes_monitors')).toBe(true);
@@ -122,8 +122,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.118 is missing 2.1.119 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.118');
-      // 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 47
-      expect(missing.length).toBe(47);
+      // 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 50
+      expect(missing.length).toBe(50);
       expect(missing.some(f => f.feature === 'posttool_duration_ms')).toBe(true);
       expect(missing.some(f => f.feature === 'from_pr_multi_host')).toBe(true);
       expect(missing.some(f => f.feature === 'channels_console_auth')).toBe(true);
@@ -132,8 +132,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.117 is missing 2.1.118 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.117');
-      // 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 53
-      expect(missing.length).toBe(53);
+      // 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 56
+      expect(missing.length).toBe(56);
       expect(missing.some(f => f.feature === 'mcp_tool_hook_type')).toBe(true);
       expect(missing.some(f => f.feature === 'claude_plugin_tag')).toBe(true);
       expect(missing.some(f => f.feature === 'posttool_duration_ms')).toBe(true);
@@ -141,16 +141,16 @@ describe('cc-version-matrix', () => {
 
     test('2.1.116 is missing 2.1.117 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.116');
-      // 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 67
-      expect(missing.length).toBe(67);
+      // 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 70
+      expect(missing.length).toBe(70);
       expect(missing.some(f => f.feature === 'agent_mcp_servers_main_thread')).toBe(true);
       expect(missing.some(f => f.feature === 'opus_46_sonnet_46_default_high')).toBe(true);
     });
 
     test('2.1.114 is missing 2.1.116 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.114');
-      // 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 77
-      expect(missing.length).toBe(77);
+      // 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 80
+      expect(missing.length).toBe(80);
       expect(missing.some(f => f.feature === 'agent_hooks_main_thread')).toBe(true);
       expect(missing.some(f => f.feature === 'sandbox_rm_dangerous_path_fix')).toBe(true);
       expect(missing.some(f => f.feature === 'agent_mcp_servers_main_thread')).toBe(true);
@@ -158,8 +158,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.110 is missing 2.1.111 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.110');
-      // 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 106
-      expect(missing.length).toBe(106);
+      // 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 109
+      expect(missing.length).toBe(109);
       expect(missing.some(f => f.feature === 'opus_4_7_xhigh')).toBe(true);
       expect(missing.some(f => f.feature === 'ultrareview_command')).toBe(true);
       expect(missing.some(f => f.feature === 'sandbox_denied_domains')).toBe(true);
@@ -169,8 +169,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.101 is missing 2.1.105 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.101');
-      // 10 (2.1.105) + 1 (2.1.107) + 13 (2.1.108) + 1 (2.1.109) + 16 (2.1.110) + 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 147
-      expect(missing.length).toBe(147);
+      // 10 (2.1.105) + 1 (2.1.107) + 13 (2.1.108) + 1 (2.1.109) + 16 (2.1.110) + 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 150
+      expect(missing.length).toBe(150);
       expect(missing.some(f => f.feature === 'plugin_monitors_manifest')).toBe(true);
       expect(missing.some(f => f.feature === 'skill_builtin_discovery')).toBe(true);
       expect(missing.some(f => f.feature === 'prompt_caching_1h_env')).toBe(true);
@@ -178,8 +178,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.98 is missing 2.1.101 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.98');
-      // 18 (2.1.101) + 94 (2.1.105-2.1.117) + 18 (2.1.118-2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 165
-      expect(missing.length).toBe(165);
+      // 18 (2.1.101) + 94 (2.1.105-2.1.117) + 18 (2.1.118-2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 168
+      expect(missing.length).toBe(168);
       expect(missing.some(f => f.feature === 'deny_overrides_ask')).toBe(true);
       expect(missing.some(f => f.feature === 'skill_context_fork_fix')).toBe(true);
       expect(missing.some(f => f.feature === 'recap_command')).toBe(true);
@@ -187,8 +187,8 @@ describe('cc-version-matrix', () => {
 
     test('2.1.92 is missing 2.1.94 through 2.1.133 features', () => {
       const missing = getMissingFeatures('2.1.92');
-      // 74 (through 2.1.101) + 94 (2.1.105-2.1.117) + 18 (2.1.118-2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 8 (2.1.133) = 221
-      expect(missing.length).toBe(221);
+      // 74 (through 2.1.101) + 94 (2.1.105-2.1.117) + 18 (2.1.118-2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) = 224
+      expect(missing.length).toBe(224);
       expect(missing.some(f => f.feature === 'skill_frontmatter_hooks_fix')).toBe(true);
       expect(missing.some(f => f.feature === 'monitor_tool')).toBe(true);
       expect(missing.some(f => f.feature === 'thinking_progress_rotation')).toBe(true);

--- a/src/hooks/src/lib/cc-version-matrix.ts
+++ b/src/hooks/src/lib/cc-version-matrix.ts
@@ -465,6 +465,9 @@ export const CC_FEATURE_MATRIX: readonly CCFeatureEntry[] = [
   { feature: 'sandbox_bwrap_socat_managed_settings',    minVersion: '2.1.133', description: 'sandbox.bwrapPath / sandbox.socatPath managed settings (Linux/WSL)' },
   { feature: 'parent_settings_behavior_admin_key',      minVersion: '2.1.133', description: 'parentSettingsBehavior admin-tier key (first-wins|merge) for SDK managedSettings' },
   { feature: 'edit_write_drive_root_allow_rules_fix',   minVersion: '2.1.133', description: 'Edit/Write allow rules scoped to drive root (C:\\\\) or POSIX / now match correctly' },
+  { feature: 'hooks_effort_level_input',                minVersion: '2.1.133', description: 'Hooks receive effort.level JSON input field + $CLAUDE_EFFORT env var; Bash tool reads $CLAUDE_EFFORT' },
+  { feature: 'effort_cross_session_leak_fix',           minVersion: '2.1.133', description: '/effort changes are now session-scoped; no longer leak to concurrent sessions; IDE effort changes no longer silently dropped' },
+  { feature: 'subagent_skill_discovery_fix',            minVersion: '2.1.133', description: 'Subagents (via Task tool) now discover project/user/plugin skills as documented' },
 ] as const;
 
 export type CCFeature = typeof CC_FEATURE_MATRIX[number]['feature'];

--- a/src/skills/configure/references/cc-version-settings.md
+++ b/src/skills/configure/references/cc-version-settings.md
@@ -699,3 +699,74 @@ Before 2.1.133, `Edit` and `Write` allow rules scoped to a Windows **drive root*
 ```
 
 **Impact for OrchestKit**: None for the standard OrchestKit setup — OrchestKit recommends per-project allow rules under `.claude/settings.json` for the project directory, not a system-wide drive-root grant. Relevant if you've added a drive-root rule as a workaround in `.claude/settings.local.json` to silence the prompt-every-time symptom of this bug — at our floor the workaround is no longer needed and the rule actually means what it says. Audit any `Edit(C:\\**)`-shaped rules with that history; if they were added as workarounds, narrow them now that the canonical glob form works.
+
+### Hooks Now Receive `effort.level` Input + `$CLAUDE_EFFORT` Env
+
+CC 2.1.133 surfaces the active effort level to every hook invocation in two new ways:
+
+1. **`effort.level` JSON input field** — the hook stdin payload now includes the active effort as a top-level `effort.level` string (`"low"` | `"medium"` | `"high"` | `"xhigh"`).
+2. **`$CLAUDE_EFFORT` environment variable** — set in the hook process env and inherited by anything the hook spawns. Bash tool invocations also see `$CLAUDE_EFFORT`, so shell commands can branch on it without going through the hook.
+
+```typescript
+// PreToolUse hook reading effort from JSON stdin
+import { readFileSync } from 'node:fs';
+
+const input = JSON.parse(readFileSync(0, 'utf-8'));
+const effort = input.effort?.level ?? process.env.CLAUDE_EFFORT ?? 'medium';
+
+if (effort === 'low') {
+  // Skip expensive validation — user signaled fast iteration
+  process.exit(0);
+}
+```
+
+```bash
+# Bash tool / hook script reading effort directly
+if [ "${CLAUDE_EFFORT:-medium}" = "xhigh" ]; then
+  # Run the full audit suite — user explicitly opted in
+  npm run test:all
+else
+  npm run test:quick
+fi
+```
+
+**Impact for OrchestKit**: Direct hit on `src/hooks/src/**` — every OrchestKit hook can now be effort-aware. Concrete opportunities:
+
+- **`quality-gates`** hooks can gate expensive correctness checks (full type-check, security scan, integration suite) to `high` / `xhigh` and skip them on `low` for fast iteration.
+- **`ci-debug`**, **`assess`**, and **`verify`** chains can scale the number of parallel agents spawned with effort level.
+- **`pre-commit`** style gates can downgrade strict checks to advisory at `low` and enforce blocking at `high`.
+
+No setting change required — the JSON field and env var are always present at our floor (CC ≥ 2.1.138). Hook authors should treat absence as `medium` for forward compat.
+
+### `/effort` Now Session-Scoped (No Cross-Session Leak)
+
+Before 2.1.133, running `/effort high` (or any effort change) in one CC session could **silently bump the effort level of every other concurrent session** on the same machine — the effort state was stored in a shared global rather than per-session. A related bug also caused IDE-driven effort changes (the VSCode/JetBrains effort picker) to be silently dropped when another session held the lock.
+
+CC 2.1.133 makes `/effort` session-local: each session has its own effort state, IDE effort changes are reliably applied to the active session, and concurrent sessions no longer trample each other.
+
+```bash
+# Session A
+/effort xhigh
+# → Session A is now xhigh
+
+# Session B (concurrent, started before or after)
+/effort low
+# → Session B is now low; Session A stays at xhigh (was previously also forced to low)
+```
+
+**Impact for OrchestKit**: Direct hit on OrchestKit's worktree-isolation workflow — running parallel `/ork:implement` and `/ork:verify` in separate worktrees with different effort levels (e.g., `xhigh` for the implement run, `medium` for verify) now works as expected. Before 2.1.133, the second `/effort` call would silently retarget the first session, defeating the whole point of per-task effort tuning. Combined with the new `effort.level` hook input (#1702), this makes effort-aware hooks safe to deploy without worrying about cross-session contamination. No setting change required; the floor in `engines.claudeCode` (≥ 2.1.138) already guarantees the fix.
+
+### Subagents Now Discover Project/User/Plugin Skills
+
+Before 2.1.133, subagents spawned via the **Task tool** could not discover skills from any source — project (`.claude/skills/`), user (`~/.claude/skills/`), or plugin (e.g., OrchestKit's bundled skills). The Skill tool inside a subagent saw an empty registry even when the parent session could list dozens of skills. This was a **direct regression** for OrchestKit because every agent in `src/agents/*` that delegates work via Task and relies on a Skill call inside the subagent was broken at the discovery step.
+
+CC 2.1.133 restores documented behavior: subagents inherit the full skill registry (project + user + plugin tiers) and can invoke any skill the parent session sees.
+
+```typescript
+// Inside a subagent body (e.g., src/agents/backend-system-architect.md):
+// Before 2.1.133: this would fail — Skill not found
+// At our floor (CC ≥ 2.1.138): works as documented
+Skill({ name: 'ork:architecture-patterns' });
+```
+
+**Impact for OrchestKit**: **Direct, immediate** — every OrchestKit agent in `src/agents/*` that uses `skills:` in its frontmatter relies on this discovery path. Before 2.1.133, Task-delegated work in `ork:implement`, `ork:cover`, `ork:verify`, `ork:fix-issue`, `ork:review-pr`, and `ork:explore` could silently fall back to non-skill behavior because the Skill tool returned "skill not found" inside the subagent. At our floor the fix is implicit — no agent-frontmatter or settings change is required. If you maintain custom agents that worked around this by inlining skill content into the agent body, you can now revert to a clean `Skill({ name: ... })` call.


### PR DESCRIPTION
Closes #1702
Closes #1708
Closes #1709

## Summary

**Completes M132 (CC 2.1.133 adoption)** — the final group. After merge, M132 → 11/11 closed.

## Issues closed

- **#1702** hooks-effort-level-input — hooks now receive `effort.level` JSON field + `$CLAUDE_EFFORT` env var
- **#1708** effort-cross-session-leak-fix — `/effort` is now session-scoped; IDE effort changes no longer dropped
- **#1709** subagent-skill-discovery-fix — subagents now discover project/user/plugin skills via Task tool

## OrchestKit impact

- **188 hooks** can now branch on effort level without parsing JSON input
- **Chain-patterns** multi-worktree flows are stable (no cross-session effort leak)
- **Agent-orchestration** patterns (`ork:implement`, `ork:fix-issue`, etc.) work as documented

## Files

- src/skills/configure/references/cc-version-settings.md — 3 new subsections under existing `## CC 2.1.133 Settings`
- src/hooks/README.md — `$CLAUDE_EFFORT` env var callout
- src/hooks/src/lib/cc-version-matrix.ts — 3 new entries (total 12 at 2.1.133)
- src/hooks/src/__tests__/lib/cc-version-matrix.test.ts — count assertions bumped +3
- plugins/ mirror + docs/site MDX regen

## Test plan

- [x] vitest cc-version-matrix.test.ts: 64/64 PASS
- [x] test:skills, test:agents, test:manifests, test:security, typecheck — all green

## Playground

docs/chore--m132-group-h-cc-133-effort-skill-discovery/group-h-playground.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)