### PR TITLE
refactor(tests): drop fragile counts from cc-version-matrix

### DIFF
--- a/docs/refactor--cc-version-matrix-test-counts/playground.html
+++ b/docs/refactor--cc-version-matrix-test-counts/playground.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Refactor: cc-version-matrix test counts (playground)</title>
+<style>
+body{font:14px ui-monospace,monospace;background:#0b0b0b;color:#e8e8e8;padding:32px;max-width:820px;margin:auto}
+h1{color:#7aa2f7;border-bottom:1px solid #333;padding-bottom:6px}
+h2{color:#bb9af7;margin-top:28px}
+table{width:100%;border-collapse:collapse;margin:12px 0}
+th,td{text-align:left;padding:6px 10px;border-bottom:1px solid #2a2a2a;vertical-align:top}
+th{color:#bb9af7}
+.muted{color:#888}
+.ok{color:#9ece6a}
+.warn{color:#e0af68}
+.bad{color:#f7768e}
+pre{background:#161616;padding:14px;border-radius:6px;overflow-x:auto;line-height:1.4}
+code{background:#161616;padding:1px 5px;border-radius:3px}
+</style>
+</head>
+<body>
+<h1>Refactor: cc-version-matrix test counts</h1>
+<p class="muted">Removes the per-version <code>missing.length</code> assertions (and their hand-tallied math comments) from <code>cc-version-matrix.test.ts</code>. Adoption PRs no longer need to bump 9 hardcoded numbers — only the single <code>CC_FEATURE_MATRIX.length</code> canary.</p>
+
+<h2>Why this matters</h2>
+<p>Each CC adoption PR (M131/M132/M134/M135 and every future one) had to:</p>
+<ul>
+<li>Add N entries to <code>cc-version-matrix.ts</code></li>
+<li>Bump <code>CC_FEATURE_MATRIX.length</code> by N</li>
+<li>Bump 9 separate <code>expect(missing.length).toBe(K)</code> assertions by N each</li>
+<li>Re-write the inline <code>// 10 (2.1.128) + 9 (2.1.129) + ...</code> math comments</li>
+</ul>
+<p>The per-version counts were tautological once <code>is sorted by version ascending</code> covers the sort invariant. The real test value was always in the <code>.some(f =&gt; f.feature === 'X')</code> semantic assertions.</p>
+
+<h2>Before / after</h2>
+<table>
+<tr><th>Aspect</th><th>Before</th><th>After</th></tr>
+<tr><td>Hardcoded counts</td><td><span class="bad">10</span> (1 canary + 9 per-version)</td><td><span class="ok">1</span> (canary only)</td></tr>
+<tr><td>Math comments to update</td><td><span class="bad">9</span> inline sum expressions</td><td><span class="ok">0</span></td></tr>
+<tr><td>Bumps per adoption PR</td><td><span class="bad">10 numbers</span> + 9 comments</td><td><span class="ok">1 number</span></td></tr>
+<tr><td>Tests still passing</td><td>64/64 → 68/68</td><td><span class="ok">68/68 PASS</span> (zero behavior change)</td></tr>
+<tr><td>Lines changed</td><td>—</td><td>+32 / -34 net</td></tr>
+</table>
+
+<h2>What the new tests look like</h2>
+<pre>test('2.1.119 misses 2.1.128 + 2.1.129 + 2.1.132 + 2.1.133 + 2.1.136 features', () =&gt; {
+  const missing = getMissingFeatures('2.1.119');
+  // Semantic assertions: these break if getMissingFeatures regresses or an entry is dropped
+  expect(missing.some(f =&gt; f.feature === 'enter_worktree_branch_from_head')).toBe(true);
+  expect(missing.some(f =&gt; f.feature === 'plugin_dir_zip_archives')).toBe(true);
+  expect(missing.some(f =&gt; f.feature === 'experimental_themes_monitors')).toBe(true);
+  expect(missing.some(f =&gt; f.feature === 'claude_code_session_id_env')).toBe(true);
+  expect(missing.some(f =&gt; f.feature === 'auto_mode_hard_deny')).toBe(true);
+  // Universal boundary: nothing missing should be &lt;= 2.1.119
+  expect(missing.every(f =&gt; compareCCVersions(f.minVersion, '2.1.119') &gt; 0)).toBe(true);
+});</pre>
+
+<h2>What's still caught</h2>
+<ul>
+<li><strong>Dropped matrix entry</strong> — fails <code>CC_FEATURE_MATRIX.length</code> canary AND the relevant <code>.some(...)</code> assertion</li>
+<li><strong>getMissingFeatures regression</strong> — fails the <code>.some(...)</code> + <code>.every(...)</code> boundary checks</li>
+<li><strong>Matrix sort broken</strong> — fails <code>is sorted by version ascending</code> (already a separate test)</li>
+<li><strong>Wrong minVersion on an entry</strong> — fails the corresponding <code>hasFeature(...)</code> boundary test</li>
+</ul>
+
+<h2>What's lost</h2>
+<p>Cross-check that <code>available.length + missing.length === total</code>. In practice this was never failing — the impl is <code>filter(f =&gt; cmp(v, f.minVersion) &gt;= 0)</code> vs <code>filter(f =&gt; cmp(v, f.minVersion) &lt; 0)</code> — the two filters partition exhaustively by construction. Not worth the maintenance cost.</p>
+
+<h2>Verification</h2>
+<pre class="ok">vitest cc-version-matrix.test.ts   68/68 PASS
+npm run build                      OK
+npm run test:skills                OK
+npm run test:manifests             OK
+npm run test:security              14/14 PASS
+npm run typecheck                  clean</pre>
+
+<h2>Why "playground" lives in this HTML</h2>
+<p class="muted">OrchestKit CI requires non-bot PRs to include <code>docs/&lt;branch-slug&gt;/*.html</code> + the word "playground" in the PR body. This file satisfies both gates. Content is a static summary; no JS, no API calls.</p>
+</body>
+</html>

--- a/src/hooks/src/__tests__/lib/cc-version-matrix.test.ts
+++ b/src/hooks/src/__tests__/lib/cc-version-matrix.test.ts
@@ -27,8 +27,9 @@ describe('cc-version-matrix', () => {
   });
 
   describe('CC_FEATURE_MATRIX', () => {
+    // Single canary: bump this number when adding entries.
+    // Drop check belongs here too — if anyone removes an entry the count regresses.
     test('contains expected number of features', () => {
-      // 253 (through 2.1.101) + 10 (2.1.105) + 1 (2.1.107) + 13 (2.1.108) + 1 (2.1.109) + 16 (2.1.110) + 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 407
       expect(CC_FEATURE_MATRIX.length).toBe(407);
     });
 
@@ -103,99 +104,96 @@ describe('cc-version-matrix', () => {
   });
 
   describe('getMissingFeatures', () => {
-    test('no missing features at 2.1.138', () => {
-      // Matrix now includes 2.1.133 + 2.1.136 entries (M132 + M135 Group I). Floor is
-      // 2.1.138, so at the floor there are still no missing features.
-      const missing = getMissingFeatures('2.1.138');
+    // Per-version `missing.length` assertions used to live here with hand-maintained counts
+    // (and a sum-the-buckets comment that had to be re-tallied on every adoption PR).
+    // The numbers were tautological once the matrix is correctly sorted (covered by the
+    // `is sorted by version ascending` test) — every adoption PR had to bump 9 places by
+    // hand. Replaced with feature-name semantic assertions: a regression to
+    // `getMissingFeatures` will fail those, and a dropped matrix entry will fail
+    // `CC_FEATURE_MATRIX.length` (the single remaining count canary).
+
+    test('no missing features at floor', () => {
+      const missing = getMissingFeatures(MIN_CC_VERSION);
       expect(missing.length).toBe(0);
     });
 
-    test('2.1.119 is missing 2.1.128 + 2.1.129 + 2.1.132 + 2.1.133 + 2.1.136 features', () => {
+    test('2.1.119 misses 2.1.128 + 2.1.129 + 2.1.132 + 2.1.133 + 2.1.136 features', () => {
       const missing = getMissingFeatures('2.1.119');
-      // 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 42
-      expect(missing.length).toBe(42);
       expect(missing.some(f => f.feature === 'enter_worktree_branch_from_head')).toBe(true);
       expect(missing.some(f => f.feature === 'plugin_dir_zip_archives')).toBe(true);
       expect(missing.some(f => f.feature === 'experimental_themes_monitors')).toBe(true);
       expect(missing.some(f => f.feature === 'claude_code_session_id_env')).toBe(true);
       expect(missing.some(f => f.feature === 'auto_mode_hard_deny')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.119') > 0)).toBe(true);
     });
 
-    test('2.1.118 is missing 2.1.119 through 2.1.136 features', () => {
+    test('2.1.118 misses 2.1.119+ features', () => {
       const missing = getMissingFeatures('2.1.118');
-      // 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 54
-      expect(missing.length).toBe(54);
       expect(missing.some(f => f.feature === 'posttool_duration_ms')).toBe(true);
       expect(missing.some(f => f.feature === 'from_pr_multi_host')).toBe(true);
       expect(missing.some(f => f.feature === 'channels_console_auth')).toBe(true);
       expect(missing.some(f => f.feature === 'skill_overrides_setting')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.118') > 0)).toBe(true);
     });
 
-    test('2.1.117 is missing 2.1.118 through 2.1.136 features', () => {
+    test('2.1.117 misses 2.1.118+ features', () => {
       const missing = getMissingFeatures('2.1.117');
-      // 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 60
-      expect(missing.length).toBe(60);
       expect(missing.some(f => f.feature === 'mcp_tool_hook_type')).toBe(true);
       expect(missing.some(f => f.feature === 'claude_plugin_tag')).toBe(true);
       expect(missing.some(f => f.feature === 'posttool_duration_ms')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.117') > 0)).toBe(true);
     });
 
-    test('2.1.116 is missing 2.1.117 through 2.1.136 features', () => {
+    test('2.1.116 misses 2.1.117+ features', () => {
       const missing = getMissingFeatures('2.1.116');
-      // 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 74
-      expect(missing.length).toBe(74);
       expect(missing.some(f => f.feature === 'agent_mcp_servers_main_thread')).toBe(true);
       expect(missing.some(f => f.feature === 'opus_46_sonnet_46_default_high')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.116') > 0)).toBe(true);
     });
 
-    test('2.1.114 is missing 2.1.116 through 2.1.136 features', () => {
+    test('2.1.114 misses 2.1.116+ features', () => {
       const missing = getMissingFeatures('2.1.114');
-      // 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 84
-      expect(missing.length).toBe(84);
       expect(missing.some(f => f.feature === 'agent_hooks_main_thread')).toBe(true);
       expect(missing.some(f => f.feature === 'sandbox_rm_dangerous_path_fix')).toBe(true);
       expect(missing.some(f => f.feature === 'agent_mcp_servers_main_thread')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.114') > 0)).toBe(true);
     });
 
-    test('2.1.110 is missing 2.1.111 through 2.1.136 features', () => {
+    test('2.1.110 misses 2.1.111+ features', () => {
       const missing = getMissingFeatures('2.1.110');
-      // 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 113
-      expect(missing.length).toBe(113);
       expect(missing.some(f => f.feature === 'opus_4_7_xhigh')).toBe(true);
       expect(missing.some(f => f.feature === 'ultrareview_command')).toBe(true);
       expect(missing.some(f => f.feature === 'sandbox_denied_domains')).toBe(true);
       expect(missing.some(f => f.feature === 'native_binary_spawn')).toBe(true);
       expect(missing.some(f => f.feature === 'agent_hooks_main_thread')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.110') > 0)).toBe(true);
     });
 
-    test('2.1.101 is missing 2.1.105 through 2.1.136 features', () => {
+    test('2.1.101 misses 2.1.105+ features', () => {
       const missing = getMissingFeatures('2.1.101');
-      // 10 (2.1.105) + 1 (2.1.107) + 13 (2.1.108) + 1 (2.1.109) + 16 (2.1.110) + 17 (2.1.111) + 1 (2.1.112) + 10 (2.1.113) + 1 (2.1.114) + 10 (2.1.116) + 14 (2.1.117) + 6 (2.1.118) + 12 (2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 154
-      expect(missing.length).toBe(154);
       expect(missing.some(f => f.feature === 'plugin_monitors_manifest')).toBe(true);
       expect(missing.some(f => f.feature === 'skill_builtin_discovery')).toBe(true);
       expect(missing.some(f => f.feature === 'prompt_caching_1h_env')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.101') > 0)).toBe(true);
     });
 
-    test('2.1.98 is missing 2.1.101 through 2.1.136 features', () => {
+    test('2.1.98 misses 2.1.101+ features', () => {
       const missing = getMissingFeatures('2.1.98');
-      // 18 (2.1.101) + 94 (2.1.105-2.1.117) + 18 (2.1.118-2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 172
-      expect(missing.length).toBe(172);
       expect(missing.some(f => f.feature === 'deny_overrides_ask')).toBe(true);
       expect(missing.some(f => f.feature === 'skill_context_fork_fix')).toBe(true);
       expect(missing.some(f => f.feature === 'recap_command')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.98') > 0)).toBe(true);
     });
 
-    test('2.1.92 is missing 2.1.94 through 2.1.136 features', () => {
+    test('2.1.92 misses 2.1.94+ features', () => {
       const missing = getMissingFeatures('2.1.92');
-      // 74 (through 2.1.101) + 94 (2.1.105-2.1.117) + 18 (2.1.118-2.1.119) + 10 (2.1.128) + 9 (2.1.129) + 8 (2.1.132) + 11 (2.1.133) + 4 (2.1.136) = 228
-      expect(missing.length).toBe(228);
       expect(missing.some(f => f.feature === 'skill_frontmatter_hooks_fix')).toBe(true);
       expect(missing.some(f => f.feature === 'monitor_tool')).toBe(true);
       expect(missing.some(f => f.feature === 'thinking_progress_rotation')).toBe(true);
+      expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.92') > 0)).toBe(true);
     });
 
-    test('2.1.47 missing 2.1.49+ features', () => {
+    test('2.1.47 misses 2.1.49+ features', () => {
       const missing = getMissingFeatures('2.1.47');
       expect(missing.length).toBeGreaterThan(0);
       expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.47') > 0)).toBe(true);
@@ -206,7 +204,7 @@ describe('cc-version-matrix', () => {
       expect(missing.length).toBe(CC_FEATURE_MATRIX.length);
     });
 
-    test('2.1.45 missing 2.1.47+ features', () => {
+    test('2.1.45 misses 2.1.47+ features', () => {
       const missing = getMissingFeatures('2.1.45');
       expect(missing.every(f => compareCCVersions(f.minVersion, '2.1.45') > 0)).toBe(true);
       expect(missing.some(f => f.minVersion === '2.1.47')).toBe(true);


### PR DESCRIPTION
## Summary

Removes the per-version `missing.length` hardcoded count assertions (and their inline `// 10 (2.1.128) + 9 (2.1.129) + ... = N` math comments) from `cc-version-matrix.test.ts`. Adoption PRs no longer need to bump 10 numbers and rewrite 9 sum expressions — only the single `CC_FEATURE_MATRIX.length` canary stays hardcoded.

Surfaced by `/ork:assess` after M135 Group I (#1760) as the biggest weakness inherited by this codebase.

## What changed

| Before | After |
|--------|-------|
| 10 hardcoded counts (1 canary + 9 per-version) | 1 canary only |
| 9 inline sum-of-buckets math comments | 0 |
| Adoption PR bumps: 10 numbers + 9 comments | 1 number |
| 68/68 PASS | 68/68 PASS (zero behavior change) |
| — | +32 / -34 net lines |

## What's still caught

| Regression | Caught by |
|-----------|-----------|
| Matrix entry dropped | `CC_FEATURE_MATRIX.length` canary + `.some(...)` assertions |
| `getMissingFeatures` regression | `.some(...)` + `.every(... > V)` boundary check |
| Matrix sort broken | `is sorted by version ascending` (separate test) |
| Wrong minVersion on entry | `hasFeature()` boundary tests |

## What's lost

Cross-check that `available.length + missing.length === total`. The two filters partition exhaustively by construction (one is `cmp >= 0`, other is `cmp < 0`). In ~400 entries this has never been a real failure mode; not worth the maintenance cost.

## Test plan

- [x] vitest cc-version-matrix.test.ts: 68/68 PASS
- [x] npm run build: OK (no plugins/ drift — only a test file changed)
- [x] npm run typecheck: clean

## Playground

`docs/refactor--cc-version-matrix-test-counts/playground.html` — static digest of the before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)