### PR TITLE
docs(claude): claim D2 — drop static counts, point at plugin details

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ No sugarcoat. Failed = failed; blocked = blocked. Rule: `shared/rules/anti-sycop
 
 ## Project Overview
 
-**OrchestKit** — Claude Code plugin: **<!--ork:skills-->108<!--/ork--> skills**, **<!--ork:agents-->37<!--/ork--> agents**, **<!--ork:hooks-->188<!--/ork--> hooks** (<!--ork:hooks-global-->120<!--/ork--> global + <!--ork:hooks-agent-->46<!--/ork--> agent-scoped + <!--ork:hooks-skill-->22<!--/ork--> skill-scoped).
+**OrchestKit** — Claude Code plugin for AI-assisted development with built-in best practices, security patterns, and quality gates.
 
-**Purpose**: AI-assisted development with built-in best practices, security patterns, and quality gates.
+For live component counts (skills / agents / hooks / per-session token cost) run `claude plugin details ork` — requires CC ≥ 2.1.139.
 
 ## Directory Structure
 
@@ -79,7 +79,7 @@ Commit after each logical unit of work — never batch all commits to end of ses
 
 ## Plugin Architecture
 
-Single plugin `ork`: <!--ork:skills-->108<!--/ork--> skills, <!--ork:agents-->37<!--/ork--> agents, <!--ork:hooks-->188<!--/ork--> hooks (<!--ork:hooks-global-->120<!--/ork--> global + <!--ork:hooks-agent-->46<!--/ork--> agent-scoped + <!--ork:hooks-skill-->22<!--/ork--> skill-scoped). <!--ork:invocable-->28<!--/ork--> user-invocable via `/ork:skillname`.
+Single plugin `ork`. User-invocable skills surface as `/ork:<skillname>`. Counts + per-session token cost: `claude plugin details ork`.
 
 ## Monitors
 


### PR DESCRIPTION
## Summary

Closes deferred-from-M137 item **D2** (counter cleanup). Replaces the static \`<!--ork:skills-->108<!--/ork-->\` style tags in CLAUDE.md with a pointer at \`claude plugin details ork\` — the CC 2.1.139 command that returns live counts and per-session token cost.

## Why now

CLAUDE.md was sitting at **4726 / 4800 bytes (98% of budget)** — one skill addition from breaching the perf test gate. The static counts also drift; the new command becomes the single source of truth.

## Numbers

| Metric                      | Before  | After   | Delta    |
|-----------------------------|---------|---------|----------|
| CLAUDE.md bytes             | 4726    | 4354    | −372     |
| Session tokens              | 5230    | 5137    | −93      |
| CLAUDE.md budget headroom   | 1.5%    | 9.3%    | +7.8 pp  |

## Verification

- ✅ \`bin/validate-counts.sh\` — counts still match plugin.json (validator never read CLAUDE.md tags)
- ✅ \`tests/performance/test-token-overhead.sh\` — 7/7 budget tests green
- ✅ Nothing in scripts/, bin/, .github/ greps for \`ork:skills\` / \`ork:agents\` / \`ork:hooks\` tags — they were informational only

🤖 Generated with [Claude Code](https://claude.com/claude-code)