### PR TITLE
feat(skills): wire --permission-mode + --effort dispatch envelope (M146-6)

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -144,9 +144,16 @@ jobs:
 
             # Run /ci-debug headless. Bare mode (CC 2.1.81+) avoids loading
             # plugins/hooks so the budget is predictable.
+            #
+            # M146-6 (#1849): explicit --permission-mode and --effort lock the
+            # dispatch envelope so cost-per-PR stays predictable regardless
+            # of what the runner inherits. The skill is read-only by design
+            # (no edits), so dontAsk + low effort is the right tradeoff.
             tmpdir="$(mktemp -d)"
             timeout "${ORK_SENTINEL_PER_PR_TIMEOUT_S}s" \
               claude -p --bare \
+                --permission-mode dontAsk \
+                --effort low \
                 --max-turns 4 \
                 --output-format json \
                 "Run /ci-debug on PR ${number} in repo ${{ steps.ctx.outputs.owner }}/${{ steps.ctx.outputs.repo }}. Use only the gh CLI. Output the report markdown only — no preamble." \

--- a/docs/site/content/docs/reference/skills/ci-sentinel.mdx
+++ b/docs/site/content/docs/reference/skills/ci-sentinel.mdx
@@ -74,6 +74,19 @@ The workflow is intentionally configured via in-file env vars (not workflow inpu
 | `max_prs` (workflow_dispatch input) | `10` | Cap on PRs analyzed in one sweep. |
 | `dry_run` (workflow_dispatch input) | `false` | Skip comment posting (for spec validation). |
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+Each headless `claude -p --bare` invocation locks the dispatch envelope so cost-per-PR stays predictable regardless of what the runner inherits:
+
+| Flag | Value | Why |
+|---|---|---|
+| `--permission-mode` | `dontAsk` | `/ci-debug` is read-only by design (proposes, never applies). `dontAsk` silently refuses destructive ops — exactly what we want from an autonomous classifier. **Never** use `bypassPermissions` here. |
+| `--effort` | `low` | Pattern classification doesn't need deep reasoning. Low keeps cost-per-PR in the $0.01–$0.03 range. |
+| `--max-turns` | `4` | Cap on the conversation length. Sweep, classify, report — done. |
+| `--output-format` | `json` | Ledger needs `usage.total_tokens` for the budget circuit-breaker. |
+
+These are hardcoded in the workflow. If you need to override for a fork (e.g. you want `medium` effort), edit `.github/workflows/ci-sentinel.yml` directly — they're intentionally not exposed as `workflow_dispatch` inputs to prevent accidental cost spikes from a one-off manual run.
+
 ## Comment shape
 
 Every verdict comment looks like:

--- a/docs/site/content/docs/reference/skills/fix-issue.mdx
+++ b/docs/site/content/docs/reference/skills/fix-issue.mdx
@@ -343,6 +343,27 @@ if capabilities.memory:
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When spawning the 5 RCA agents (debug-investigator, code-quality-reviewer, test-generator, etc.) — whether in-session via the `Agent` tool or headless via `claude -p --bare` — set explicit per-role flags so behaviour is deterministic across interactive and CI runs:
+
+| Agent role | `--permission-mode` | `--effort` |
+|---|---|---|
+| RCA / investigation (`debug-investigator`, `Explore`) | `dontAsk` | `low` — `medium` |
+| Test reproduction (`test-generator`) | `acceptEdits` | `medium` |
+| Fix authoring (production code) | `default` (keep user in loop) | `medium` — `high` |
+| Verification (`code-quality-reviewer`) | `dontAsk` | `low` |
+
+**Never** use `bypassPermissions` — fix-issue's RCA phase often touches code paths; the audit trail matters. For headless invocations (e.g. from `/ork:ci-sentinel` or a cron-driven bug sweep), pass the flags explicitly:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort medium \
+  --max-turns 12 \
+  "/ork:fix-issue <N>"
+```
+
 ### SendMessage (Evidence Sharing)
 
 When an RCA agent discovers the root cause, share with the fix agent:

--- a/docs/site/content/docs/reference/skills/implement.mdx
+++ b/docs/site/content/docs/reference/skills/implement.mdx
@@ -402,6 +402,27 @@ Full rule (when to fire, body content limits, graceful fallback for users withou
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When dispatching subagents — whether via the in-session `Agent` tool or a headless `claude -p --bare` from a wrapper script — set explicit `--permission-mode` and `--effort` per agent role so behaviour is deterministic across interactive vs CI runs:
+
+| Agent role | `--permission-mode` | `--effort` | Rationale |
+|---|---|---|---|
+| Read-only analysis (`Explore`, `code-quality-reviewer`, `debug-investigator`) | `dontAsk` | `low` | No writes, no risk; minimise cost. |
+| Test generation (`test-generator`) | `acceptEdits` | `medium` | Writes test files; permission prompts would block the parallel sweep. |
+| Production code (`frontend-ui-developer`, `backend-system-architect`) | `default` or `acceptEdits` | `medium` to `high` | Set per-feature complexity. `default` keeps the user in the loop. |
+| **Never** | `bypassPermissions` | — | Skip the audit trail — only acceptable in throwaway sandboxes. |
+
+In-session `Agent` tool calls inherit the parent session's permission mode; the table is the **policy** for what those defaults should be. For genuinely headless invocations (cron, CI), pass the flags explicitly to `claude -p --bare`:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort low \
+  --max-turns 8 \
+  "<prompt>"
+```
+
 ### Context Passing
 
 All spawned agents receive: changed files list, project tier, architectural constraints, and decisions from prior phases (discovery, plan). Pass via the agent prompt, not just "implement X".

--- a/plugins/ork/commands/ci-sentinel.md
+++ b/plugins/ork/commands/ci-sentinel.md
@@ -69,6 +69,19 @@ The workflow is intentionally configured via in-file env vars (not workflow inpu
 | `max_prs` (workflow_dispatch input) | `10` | Cap on PRs analyzed in one sweep. |
 | `dry_run` (workflow_dispatch input) | `false` | Skip comment posting (for spec validation). |
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+Each headless `claude -p --bare` invocation locks the dispatch envelope so cost-per-PR stays predictable regardless of what the runner inherits:
+
+| Flag | Value | Why |
+|---|---|---|
+| `--permission-mode` | `dontAsk` | `/ci-debug` is read-only by design (proposes, never applies). `dontAsk` silently refuses destructive ops — exactly what we want from an autonomous classifier. **Never** use `bypassPermissions` here. |
+| `--effort` | `low` | Pattern classification doesn't need deep reasoning. Low keeps cost-per-PR in the $0.01–$0.03 range. |
+| `--max-turns` | `4` | Cap on the conversation length. Sweep, classify, report — done. |
+| `--output-format` | `json` | Ledger needs `usage.total_tokens` for the budget circuit-breaker. |
+
+These are hardcoded in the workflow. If you need to override for a fork (e.g. you want `medium` effort), edit `.github/workflows/ci-sentinel.yml` directly — they're intentionally not exposed as `workflow_dispatch` inputs to prevent accidental cost spikes from a one-off manual run.
+
 ## Comment shape
 
 Every verdict comment looks like:

--- a/plugins/ork/commands/fix-issue.md
+++ b/plugins/ork/commands/fix-issue.md
@@ -338,6 +338,27 @@ if capabilities.memory:
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When spawning the 5 RCA agents (debug-investigator, code-quality-reviewer, test-generator, etc.) — whether in-session via the `Agent` tool or headless via `claude -p --bare` — set explicit per-role flags so behaviour is deterministic across interactive and CI runs:
+
+| Agent role | `--permission-mode` | `--effort` |
+|---|---|---|
+| RCA / investigation (`debug-investigator`, `Explore`) | `dontAsk` | `low` — `medium` |
+| Test reproduction (`test-generator`) | `acceptEdits` | `medium` |
+| Fix authoring (production code) | `default` (keep user in loop) | `medium` — `high` |
+| Verification (`code-quality-reviewer`) | `dontAsk` | `low` |
+
+**Never** use `bypassPermissions` — fix-issue's RCA phase often touches code paths; the audit trail matters. For headless invocations (e.g. from `/ork:ci-sentinel` or a cron-driven bug sweep), pass the flags explicitly:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort medium \
+  --max-turns 12 \
+  "/ork:fix-issue <N>"
+```
+
 ### SendMessage (Evidence Sharing)
 
 When an RCA agent discovers the root cause, share with the fix agent:

--- a/plugins/ork/commands/implement.md
+++ b/plugins/ork/commands/implement.md
@@ -389,6 +389,27 @@ Full rule (when to fire, body content limits, graceful fallback for users withou
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When dispatching subagents — whether via the in-session `Agent` tool or a headless `claude -p --bare` from a wrapper script — set explicit `--permission-mode` and `--effort` per agent role so behaviour is deterministic across interactive vs CI runs:
+
+| Agent role | `--permission-mode` | `--effort` | Rationale |
+|---|---|---|---|
+| Read-only analysis (`Explore`, `code-quality-reviewer`, `debug-investigator`) | `dontAsk` | `low` | No writes, no risk; minimise cost. |
+| Test generation (`test-generator`) | `acceptEdits` | `medium` | Writes test files; permission prompts would block the parallel sweep. |
+| Production code (`frontend-ui-developer`, `backend-system-architect`) | `default` or `acceptEdits` | `medium` to `high` | Set per-feature complexity. `default` keeps the user in the loop. |
+| **Never** | `bypassPermissions` | — | Skip the audit trail — only acceptable in throwaway sandboxes. |
+
+In-session `Agent` tool calls inherit the parent session's permission mode; the table is the **policy** for what those defaults should be. For genuinely headless invocations (cron, CI), pass the flags explicitly to `claude -p --bare`:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort low \
+  --max-turns 8 \
+  "<prompt>"
+```
+
 ### Context Passing
 
 All spawned agents receive: changed files list, project tier, architectural constraints, and decisions from prior phases (discovery, plan). Pass via the agent prompt, not just "implement X".

--- a/plugins/ork/skills/ci-sentinel/SKILL.md
+++ b/plugins/ork/skills/ci-sentinel/SKILL.md
@@ -91,6 +91,19 @@ The workflow is intentionally configured via in-file env vars (not workflow inpu
 | `max_prs` (workflow_dispatch input) | `10` | Cap on PRs analyzed in one sweep. |
 | `dry_run` (workflow_dispatch input) | `false` | Skip comment posting (for spec validation). |
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+Each headless `claude -p --bare` invocation locks the dispatch envelope so cost-per-PR stays predictable regardless of what the runner inherits:
+
+| Flag | Value | Why |
+|---|---|---|
+| `--permission-mode` | `dontAsk` | `/ci-debug` is read-only by design (proposes, never applies). `dontAsk` silently refuses destructive ops — exactly what we want from an autonomous classifier. **Never** use `bypassPermissions` here. |
+| `--effort` | `low` | Pattern classification doesn't need deep reasoning. Low keeps cost-per-PR in the $0.01–$0.03 range. |
+| `--max-turns` | `4` | Cap on the conversation length. Sweep, classify, report — done. |
+| `--output-format` | `json` | Ledger needs `usage.total_tokens` for the budget circuit-breaker. |
+
+These are hardcoded in the workflow. If you need to override for a fork (e.g. you want `medium` effort), edit `.github/workflows/ci-sentinel.yml` directly — they're intentionally not exposed as `workflow_dispatch` inputs to prevent accidental cost spikes from a one-off manual run.
+
 ## Comment shape
 
 Every verdict comment looks like:

--- a/plugins/ork/skills/fix-issue/SKILL.md
+++ b/plugins/ork/skills/fix-issue/SKILL.md
@@ -363,6 +363,27 @@ if capabilities.memory:
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When spawning the 5 RCA agents (debug-investigator, code-quality-reviewer, test-generator, etc.) — whether in-session via the `Agent` tool or headless via `claude -p --bare` — set explicit per-role flags so behaviour is deterministic across interactive and CI runs:
+
+| Agent role | `--permission-mode` | `--effort` |
+|---|---|---|
+| RCA / investigation (`debug-investigator`, `Explore`) | `dontAsk` | `low` — `medium` |
+| Test reproduction (`test-generator`) | `acceptEdits` | `medium` |
+| Fix authoring (production code) | `default` (keep user in loop) | `medium` — `high` |
+| Verification (`code-quality-reviewer`) | `dontAsk` | `low` |
+
+**Never** use `bypassPermissions` — fix-issue's RCA phase often touches code paths; the audit trail matters. For headless invocations (e.g. from `/ork:ci-sentinel` or a cron-driven bug sweep), pass the flags explicitly:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort medium \
+  --max-turns 12 \
+  "/ork:fix-issue <N>"
+```
+
 ### SendMessage (Evidence Sharing)
 
 When an RCA agent discovers the root cause, share with the fix agent:

--- a/plugins/ork/skills/implement/SKILL.md
+++ b/plugins/ork/skills/implement/SKILL.md
@@ -433,6 +433,27 @@ Full rule (when to fire, body content limits, graceful fallback for users withou
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When dispatching subagents — whether via the in-session `Agent` tool or a headless `claude -p --bare` from a wrapper script — set explicit `--permission-mode` and `--effort` per agent role so behaviour is deterministic across interactive vs CI runs:
+
+| Agent role | `--permission-mode` | `--effort` | Rationale |
+|---|---|---|---|
+| Read-only analysis (`Explore`, `code-quality-reviewer`, `debug-investigator`) | `dontAsk` | `low` | No writes, no risk; minimise cost. |
+| Test generation (`test-generator`) | `acceptEdits` | `medium` | Writes test files; permission prompts would block the parallel sweep. |
+| Production code (`frontend-ui-developer`, `backend-system-architect`) | `default` or `acceptEdits` | `medium` to `high` | Set per-feature complexity. `default` keeps the user in the loop. |
+| **Never** | `bypassPermissions` | — | Skip the audit trail — only acceptable in throwaway sandboxes. |
+
+In-session `Agent` tool calls inherit the parent session's permission mode; the table is the **policy** for what those defaults should be. For genuinely headless invocations (cron, CI), pass the flags explicitly to `claude -p --bare`:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort low \
+  --max-turns 8 \
+  "<prompt>"
+```
+
 ### Context Passing
 
 All spawned agents receive: changed files list, project tier, architectural constraints, and decisions from prior phases (discovery, plan). Pass via the agent prompt, not just "implement X".

--- a/src/skills/ci-sentinel/SKILL.md
+++ b/src/skills/ci-sentinel/SKILL.md
@@ -91,6 +91,19 @@ The workflow is intentionally configured via in-file env vars (not workflow inpu
 | `max_prs` (workflow_dispatch input) | `10` | Cap on PRs analyzed in one sweep. |
 | `dry_run` (workflow_dispatch input) | `false` | Skip comment posting (for spec validation). |
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+Each headless `claude -p --bare` invocation locks the dispatch envelope so cost-per-PR stays predictable regardless of what the runner inherits:
+
+| Flag | Value | Why |
+|---|---|---|
+| `--permission-mode` | `dontAsk` | `/ci-debug` is read-only by design (proposes, never applies). `dontAsk` silently refuses destructive ops — exactly what we want from an autonomous classifier. **Never** use `bypassPermissions` here. |
+| `--effort` | `low` | Pattern classification doesn't need deep reasoning. Low keeps cost-per-PR in the $0.01–$0.03 range. |
+| `--max-turns` | `4` | Cap on the conversation length. Sweep, classify, report — done. |
+| `--output-format` | `json` | Ledger needs `usage.total_tokens` for the budget circuit-breaker. |
+
+These are hardcoded in the workflow. If you need to override for a fork (e.g. you want `medium` effort), edit `.github/workflows/ci-sentinel.yml` directly — they're intentionally not exposed as `workflow_dispatch` inputs to prevent accidental cost spikes from a one-off manual run.
+
 ## Comment shape
 
 Every verdict comment looks like:

--- a/src/skills/fix-issue/SKILL.md
+++ b/src/skills/fix-issue/SKILL.md
@@ -363,6 +363,27 @@ if capabilities.memory:
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When spawning the 5 RCA agents (debug-investigator, code-quality-reviewer, test-generator, etc.) — whether in-session via the `Agent` tool or headless via `claude -p --bare` — set explicit per-role flags so behaviour is deterministic across interactive and CI runs:
+
+| Agent role | `--permission-mode` | `--effort` |
+|---|---|---|
+| RCA / investigation (`debug-investigator`, `Explore`) | `dontAsk` | `low` — `medium` |
+| Test reproduction (`test-generator`) | `acceptEdits` | `medium` |
+| Fix authoring (production code) | `default` (keep user in loop) | `medium` — `high` |
+| Verification (`code-quality-reviewer`) | `dontAsk` | `low` |
+
+**Never** use `bypassPermissions` — fix-issue's RCA phase often touches code paths; the audit trail matters. For headless invocations (e.g. from `/ork:ci-sentinel` or a cron-driven bug sweep), pass the flags explicitly:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort medium \
+  --max-turns 12 \
+  "/ork:fix-issue <N>"
+```
+
 ### SendMessage (Evidence Sharing)
 
 When an RCA agent discovers the root cause, share with the fix agent:

--- a/src/skills/implement/SKILL.md
+++ b/src/skills/implement/SKILL.md
@@ -433,6 +433,27 @@ Full rule (when to fire, body content limits, graceful fallback for users withou
 
 ## Agent Coordination
 
+### Dispatch envelope (CC 2.1.142+ flags — M146-6 / #1849)
+
+When dispatching subagents — whether via the in-session `Agent` tool or a headless `claude -p --bare` from a wrapper script — set explicit `--permission-mode` and `--effort` per agent role so behaviour is deterministic across interactive vs CI runs:
+
+| Agent role | `--permission-mode` | `--effort` | Rationale |
+|---|---|---|---|
+| Read-only analysis (`Explore`, `code-quality-reviewer`, `debug-investigator`) | `dontAsk` | `low` | No writes, no risk; minimise cost. |
+| Test generation (`test-generator`) | `acceptEdits` | `medium` | Writes test files; permission prompts would block the parallel sweep. |
+| Production code (`frontend-ui-developer`, `backend-system-architect`) | `default` or `acceptEdits` | `medium` to `high` | Set per-feature complexity. `default` keeps the user in the loop. |
+| **Never** | `bypassPermissions` | — | Skip the audit trail — only acceptable in throwaway sandboxes. |
+
+In-session `Agent` tool calls inherit the parent session's permission mode; the table is the **policy** for what those defaults should be. For genuinely headless invocations (cron, CI), pass the flags explicitly to `claude -p --bare`:
+
+```bash
+claude -p --bare \
+  --permission-mode dontAsk \
+  --effort low \
+  --max-turns 8 \
+  "<prompt>"
+```
+
 ### Context Passing
 
 All spawned agents receive: changed files list, project tier, architectural constraints, and decisions from prior phases (discovery, plan). Pass via the agent prompt, not just "implement X".


### PR DESCRIPTION
## Summary

Closes #1849 (M146-6). Adopts CC 2.1.142's `--permission-mode` and `--effort` flags so dispatched subagents have deterministic behaviour across interactive vs CI runs. P1 from yesterday's M146 issue triage.

## What ships

| File | Change |
|---|---|
| `.github/workflows/ci-sentinel.yml` | Adds `--permission-mode dontAsk --effort low` to the `claude -p --bare` invocation. `/ci-debug` is read-only by design — `dontAsk` silently refuses destructive ops, `low` keeps cost-per-PR in the $0.01–$0.03 range. |
| `src/skills/ci-sentinel/SKILL.md` | New "Dispatch envelope" subsection in Configuration with the full 4-flag policy table (`--permission-mode`, `--effort`, `--max-turns`, `--output-format`). |
| `src/skills/implement/SKILL.md` | Per-role dispatch policy added to Agent Coordination: read-only analysis → `dontAsk`/`low`; test gen → `acceptEdits`/`medium`; production code → `default`/`medium`-`high`. |
| `src/skills/fix-issue/SKILL.md` | Same shape, tuned for RCA flow: investigation → low effort; verification → low; fix authoring → medium-high with `default` mode so user stays in the loop. |

## Hard rule preserved

**Never** `--permission-mode bypassPermissions` for autonomous flows. The propose-don't-apply guarantee from `/ork:ci-sentinel` and the audit trail in `/ork:fix-issue` both depend on the model NOT silently writing. Documented in both skills.

## Why this matters

- `/ork:ci-sentinel` runs `claude -p --bare` from a GitHub Actions runner with no human present. Without explicit flags, it would inherit whatever the runner's default is — which can vary between CC versions or `~/.claude` configs. Locking the envelope makes cost-per-PR predictable.
- `/ork:implement` and `/ork:fix-issue` spawn 5+ parallel subagents. Without per-role flag policy, a `frontend-ui-developer` spawned in the same session as an `Explore` agent inherits the same permission mode — usually wrong. The table gives the spawn site a clear default.

## Validation

- `npm run build` — 112 skills, plugins/ regenerated
- `bin/validate-counts.sh` — all counts + versions match
- `npm run test:skills` — 0 failed (10 + 3 across two test files)
- pre-commit: frontmatter, lint, GHA workflow lint — all OK

## Test plan

- [ ] CI green (manifest, security, hook unit, type, lint, PR Playground gate, actionlint on ci-sentinel.yml)
- [ ] Manual: trigger `ci-sentinel.yml` with `workflow_dispatch + dry_run: true` against an open PR; confirm the `claude -p --bare` invocation includes both new flags
- [ ] Manual: spawn a subagent from `/ork:implement` and verify the documented per-role default applies (sanity check, no API)

## Next from M146

- #1847 P1 — Migrate notification hooks to `terminalSequence` (kills `osascript`/`notify-send` deps)
- #1845 P1 — Declare plugin `dependencies:` in manifests/ork.json (unlocks `claude plugin disable` enforcement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)