### PR TITLE
fix(ci-sentinel): install Claude Code on the runner

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -59,6 +59,19 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install Claude Code
+        run: |
+          # First dry-run on 2026-05-18 failed with
+          # "claude: No such file or directory" — ubuntu-latest ships
+          # without CC. Install once per run; ~5s cold from npm.
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+
       - name: Resolve repo + auth context
         id: ctx
         run: |


### PR DESCRIPTION
## Summary

First real dry-run dispatch (run [26020540716](https://github.com/yonatangross/orchestkit/actions/runs/26020540716)) on 2026-05-18 hit:

```
timeout: failed to run command 'claude': No such file or directory
```

`ubuntu-latest` runners don't ship Claude Code. The workflow needs an explicit install step before invoking `claude -p --bare`.

## What ships

Two steps inserted before the analyze loop:

```yaml
- uses: actions/setup-node@v4
  with: { node-version: "22" }

- name: Install Claude Code
  run: |
    npm install -g @anthropic-ai/claude-code
    claude --version
```

Cold install is ~5s; not worth caching for an hourly cron.

## Validation plan

- [ ] Merge this PR
- [ ] Re-fire `gh workflow run ci-sentinel.yml -f dry_run=true -f max_prs=3`
- [ ] Confirm `claude --version` step prints a version
- [ ] Confirm at least one PR gets a verdict in the job summary (no comment posted, per dry_run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)