### PR TITLE
fix(ci-sentinel): wire apiKeyHelper + shared --bare gotcha rule

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -76,6 +76,38 @@ jobs:
           npm install -g @anthropic-ai/claude-code
           claude --version
 
+      - name: Configure Claude apiKeyHelper
+        # Critical (#1857 postmortem): `claude -p` does NOT authenticate
+        # via ANTHROPIC_API_KEY env var alone in a fresh-HOME environment.
+        # Verified locally on 2026-05-18 (CC 2.1.143) — empty HOME + env
+        # var returns "Not logged in" even though --help says it should
+        # work. The only documented path that DOES work in headless mode
+        # is `apiKeyHelper` in `~/.claude/settings.json` — a shell command
+        # whose stdout is the API key. Putting the actual key in a tiny
+        # helper script keeps it out of settings.json (which CC may log).
+        # See shared/rules/cc-bare-auth-gotcha.md and feedback memory
+        # entry for the full reproducer.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ANTHROPIC_API_KEY secret is not set — add it under Settings → Secrets and variables → Actions"
+            exit 1
+          fi
+          mkdir -p ~/.claude
+          printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > ~/.claude/api-key-helper.sh
+          chmod +x ~/.claude/api-key-helper.sh
+          printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$HOME" > ~/.claude/settings.json
+          # Smoke test: confirm auth actually works before we burn budget
+          # on N failed PR analyses. Fails the job loudly if auth is broken.
+          smoke=$(claude -p --max-turns 1 --output-format json --no-session-persistence \
+            "respond with the single word OK" 2>&1)
+          if echo "$smoke" | jq -e '.is_error == true' >/dev/null 2>&1; then
+            echo "::error::Auth smoke test failed: $(echo "$smoke" | jq -r '.result // "<no result>"' | head -c 200)"
+            exit 1
+          fi
+          echo "Auth smoke test OK ($(echo "$smoke" | jq -r '.usage.total_tokens // 0') tokens)"
+
       - name: Resolve repo + auth context
         id: ctx
         run: |

--- a/plugins/ork/skills/shared/rules/cc-bare-auth-gotcha.md
+++ b/plugins/ork/skills/shared/rules/cc-bare-auth-gotcha.md
@@ -1,0 +1,102 @@
+# Rule: `claude --bare` auth is broken — never use it in CI
+
+**Status**: confirmed CC 2.1.81–2.1.143 · upstream bug filed [anthropics/claude-code#60155](https://github.com/anthropics/claude-code/issues/60155) · prior incident [orchestkit#1629](https://github.com/yonatangross/orchestkit/issues/1629)
+
+## The trap
+
+The `--bare` flag's `--help` text promises:
+
+> Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read).
+
+**All three documented paths fail.** Every invocation in `--bare` mode returns:
+
+```
+{"is_error":true, "result":"Not logged in · Please run /login"}
+```
+
+regardless of whether the API key is supplied via env var, `--settings.apiKey`, or `--settings.apiKeyHelper`.
+
+## Don't do this
+
+```yaml
+# WRONG — will silently fail every claude invocation
+- env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    claude -p --bare --max-turns 4 --output-format json "..."
+```
+
+## Do this
+
+```yaml
+# RIGHT — apiKeyHelper in ~/.claude/settings.json + plain `claude -p`
+- name: Configure Claude apiKeyHelper
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    mkdir -p ~/.claude
+    printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > ~/.claude/api-key-helper.sh
+    chmod +x ~/.claude/api-key-helper.sh
+    printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$HOME" \
+      > ~/.claude/settings.json
+
+- name: Analyze
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    claude -p --max-turns 4 --output-format json --no-session-persistence "..."
+```
+
+Cost: ~10k tokens/call instead of `--bare`'s advertised ~4k. Worth it — the alternative is a silently failing workflow.
+
+## Verify auth before burning budget
+
+Always include a one-call smoke test after the apiKeyHelper write step:
+
+```bash
+smoke=$(claude -p --max-turns 1 --output-format json --no-session-persistence \
+  "respond with OK" 2>&1)
+echo "$smoke" | jq -e '.is_error == true' >/dev/null && {
+  echo "::error::Auth smoke test failed"
+  exit 1
+}
+```
+
+The smoke test runs once per workflow invocation and catches auth breaks at the START of the job — not 10 PRs later when you've wasted classifier runs on every failure.
+
+## When upstream fixes it
+
+The fix would let `--bare` honor `ANTHROPIC_API_KEY` per the help text. When that lands, revert this rule's "do this" block to use `--bare` (saves ~60% of token cost per invocation). Anchor the revert PR on the upstream issue closure.
+
+## Reproducer
+
+All three fail. All from the same fresh-HOME state to rule out cached OAuth state:
+
+```bash
+TMPH=$(mktemp -d)
+KEY="sk-ant-..."
+
+# Path 1: ANTHROPIC_API_KEY env var
+HOME=$TMPH ANTHROPIC_API_KEY=$KEY claude -p --bare \
+  --max-turns 1 --output-format json "hi"
+
+# Path 2: apiKey via --settings
+echo "{\"apiKey\":\"$KEY\"}" > $TMPH/s.json
+HOME=$TMPH claude -p --bare --settings $TMPH/s.json \
+  --max-turns 1 --output-format json "hi"
+
+# Path 3: apiKeyHelper via --settings
+echo "{\"apiKeyHelper\":\"echo $KEY\"}" > $TMPH/s.json
+HOME=$TMPH claude -p --bare --settings $TMPH/s.json \
+  --max-turns 1 --output-format json "hi"
+```
+
+All three: `{"is_error":true,"result":"Not logged in · Please run /login"}`.
+
+Same env var **without** `--bare` (and with apiKeyHelper written to `~/.claude/settings.json`) works:
+
+```bash
+HOME=$TMPH ANTHROPIC_API_KEY=$KEY claude -p \
+  --max-turns 1 --output-format json "hi"
+# → {"is_error":false, "result":"Hi there, friend."}
+```

--- a/src/skills/shared/rules/cc-bare-auth-gotcha.md
+++ b/src/skills/shared/rules/cc-bare-auth-gotcha.md
@@ -1,0 +1,102 @@
+# Rule: `claude --bare` auth is broken — never use it in CI
+
+**Status**: confirmed CC 2.1.81–2.1.143 · upstream bug filed [anthropics/claude-code#60155](https://github.com/anthropics/claude-code/issues/60155) · prior incident [orchestkit#1629](https://github.com/yonatangross/orchestkit/issues/1629)
+
+## The trap
+
+The `--bare` flag's `--help` text promises:
+
+> Anthropic auth is strictly ANTHROPIC_API_KEY or apiKeyHelper via --settings (OAuth and keychain are never read).
+
+**All three documented paths fail.** Every invocation in `--bare` mode returns:
+
+```
+{"is_error":true, "result":"Not logged in · Please run /login"}
+```
+
+regardless of whether the API key is supplied via env var, `--settings.apiKey`, or `--settings.apiKeyHelper`.
+
+## Don't do this
+
+```yaml
+# WRONG — will silently fail every claude invocation
+- env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    claude -p --bare --max-turns 4 --output-format json "..."
+```
+
+## Do this
+
+```yaml
+# RIGHT — apiKeyHelper in ~/.claude/settings.json + plain `claude -p`
+- name: Configure Claude apiKeyHelper
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    mkdir -p ~/.claude
+    printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > ~/.claude/api-key-helper.sh
+    chmod +x ~/.claude/api-key-helper.sh
+    printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$HOME" \
+      > ~/.claude/settings.json
+
+- name: Analyze
+  env:
+    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+  run: |
+    claude -p --max-turns 4 --output-format json --no-session-persistence "..."
+```
+
+Cost: ~10k tokens/call instead of `--bare`'s advertised ~4k. Worth it — the alternative is a silently failing workflow.
+
+## Verify auth before burning budget
+
+Always include a one-call smoke test after the apiKeyHelper write step:
+
+```bash
+smoke=$(claude -p --max-turns 1 --output-format json --no-session-persistence \
+  "respond with OK" 2>&1)
+echo "$smoke" | jq -e '.is_error == true' >/dev/null && {
+  echo "::error::Auth smoke test failed"
+  exit 1
+}
+```
+
+The smoke test runs once per workflow invocation and catches auth breaks at the START of the job — not 10 PRs later when you've wasted classifier runs on every failure.
+
+## When upstream fixes it
+
+The fix would let `--bare` honor `ANTHROPIC_API_KEY` per the help text. When that lands, revert this rule's "do this" block to use `--bare` (saves ~60% of token cost per invocation). Anchor the revert PR on the upstream issue closure.
+
+## Reproducer
+
+All three fail. All from the same fresh-HOME state to rule out cached OAuth state:
+
+```bash
+TMPH=$(mktemp -d)
+KEY="sk-ant-..."
+
+# Path 1: ANTHROPIC_API_KEY env var
+HOME=$TMPH ANTHROPIC_API_KEY=$KEY claude -p --bare \
+  --max-turns 1 --output-format json "hi"
+
+# Path 2: apiKey via --settings
+echo "{\"apiKey\":\"$KEY\"}" > $TMPH/s.json
+HOME=$TMPH claude -p --bare --settings $TMPH/s.json \
+  --max-turns 1 --output-format json "hi"
+
+# Path 3: apiKeyHelper via --settings
+echo "{\"apiKeyHelper\":\"echo $KEY\"}" > $TMPH/s.json
+HOME=$TMPH claude -p --bare --settings $TMPH/s.json \
+  --max-turns 1 --output-format json "hi"
+```
+
+All three: `{"is_error":true,"result":"Not logged in · Please run /login"}`.
+
+Same env var **without** `--bare` (and with apiKeyHelper written to `~/.claude/settings.json`) works:
+
+```bash
+HOME=$TMPH ANTHROPIC_API_KEY=$KEY claude -p \
+  --max-turns 1 --output-format json "hi"
+# → {"is_error":false, "result":"Hi there, friend."}
+```


### PR DESCRIPTION
## Summary

Postmortem #3 from the 2026-05-18 ci-sentinel activation. After dropping `--bare` in #1857, plain `claude -p` STILL failed with "Not logged in" on the runner. Reproduced locally: in a fresh-HOME environment, the `ANTHROPIC_API_KEY` env var alone isn't enough — CC requires `apiKeyHelper` in `~/.claude/settings.json`.

## Changes

* **`.github/workflows/ci-sentinel.yml`** — new "Configure Claude apiKeyHelper" step writes a tiny helper script that echoes `$ANTHROPIC_API_KEY`, then writes `settings.json` pointing at it. Keeps the key in env (not embedded in settings.json). Includes a smoke-test `claude -p` call that fails the job loudly if auth is broken — so we never burn budget on N silent failures.

* **`src/skills/shared/rules/cc-bare-auth-gotcha.md`** — NEW shared rule. Future CI-adjacent skills should reference this so they don't re-walk the trap. Includes the apiKeyHelper recipe, the failing reproducer for all 3 documented auth paths, and the revert plan for when upstream fixes `--bare`.

## Upstream

Filed **anthropics/claude-code#60155** with the full reproducer. When it's fixed, this rule's "do this" block can revert to `--bare` (saves ~60% per-call token cost).

## Test plan

- [ ] CI green
- [ ] Re-fire `gh workflow run ci-sentinel.yml -f dry_run=true -f max_prs=3`
- [ ] Auth smoke test step shows "Auth smoke test OK (N tokens)"
- [ ] At least one PR gets a real verdict in the job summary

## Related

- Prior incident: orchestkit#1629 (cc-triage workflow ~6 mo ago hit the same --bare auth bug)
- Memory entry: `feedback_cc_bare_auth_broken.md` in user-level memory store (locks the lesson across sessions)
- Upstream: anthropics/claude-code#60155

🤖 Generated with [Claude Code](https://claude.com/claude-code)