### PR TITLE
fix(ci-sentinel): file-backed apiKeyHelper + safer smoke test

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -95,18 +95,54 @@ jobs:
             exit 1
           fi
           mkdir -p ~/.claude
-          printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > ~/.claude/api-key-helper.sh
+          # Write the key to a 600-mode file. The helper script reads from
+          # this file rather than from $ANTHROPIC_API_KEY because CC spawns
+          # the helper with a stripped environment — env vars from the
+          # parent step are NOT inherited (verified locally 2026-05-18:
+          # "apiKeyHelper failed: did not return a value"). The runner is
+          # ephemeral; file is gone at job end.
+          umask 077
+          printf '%s' "$ANTHROPIC_API_KEY" > ~/.claude/.api-key
+          chmod 600 ~/.claude/.api-key
+          printf '#!/bin/sh\ncat %s/.claude/.api-key\n' "$HOME" > ~/.claude/api-key-helper.sh
           chmod +x ~/.claude/api-key-helper.sh
           printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$HOME" > ~/.claude/settings.json
+          echo "settings.json contents (helper path):"
+          cat ~/.claude/settings.json
+          echo "helper script:"
+          cat ~/.claude/api-key-helper.sh
+          echo "key file: $(wc -c < ~/.claude/.api-key) bytes, mode $(stat -c %a ~/.claude/.api-key 2>/dev/null || stat -f %A ~/.claude/.api-key 2>/dev/null)"
+
           # Smoke test: confirm auth actually works before we burn budget
           # on N failed PR analyses. Fails the job loudly if auth is broken.
+          #
+          # IMPORTANT (#1858 → #1859 follow-up): bash `-e` propagates the exit
+          # code of a command substitution. `claude -p` exits 1 on any auth
+          # failure, which under `set -e` silently kills the step BEFORE we
+          # can log the error. Disable -e around the smoke and capture both
+          # stdout and exit explicitly so the failure mode is visible.
+          set +e
           smoke=$(claude -p --max-turns 1 --output-format json --no-session-persistence \
             "respond with the single word OK" 2>&1)
-          if echo "$smoke" | jq -e '.is_error == true' >/dev/null 2>&1; then
-            echo "::error::Auth smoke test failed: $(echo "$smoke" | jq -r '.result // "<no result>"' | head -c 200)"
+          smoke_exit=$?
+          set -e
+
+          echo "claude smoke exit: $smoke_exit"
+          echo "claude smoke output (first 400 chars):"
+          printf '%s\n' "$smoke" | head -c 400
+          echo
+
+          if [ "$smoke_exit" -ne 0 ]; then
+            echo "::error::Auth smoke test exited $smoke_exit — see output above"
             exit 1
           fi
-          echo "Auth smoke test OK ($(echo "$smoke" | jq -r '.usage.total_tokens // 0') tokens)"
+          if printf '%s' "$smoke" | jq -e '.is_error == true' >/dev/null 2>&1; then
+            result=$(printf '%s' "$smoke" | jq -r '.result // "<no result>"' | head -c 200)
+            echo "::error::Auth smoke test reported is_error=true: $result"
+            exit 1
+          fi
+          tokens=$(printf '%s' "$smoke" | jq -r '.usage.total_tokens // 0')
+          echo "Auth smoke test OK (${tokens} tokens)"
 
       - name: Resolve repo + auth context
         id: ctx

--- a/plugins/ork/skills/shared/rules/cc-bare-auth-gotcha.md
+++ b/plugins/ork/skills/shared/rules/cc-bare-auth-gotcha.md
@@ -29,37 +29,65 @@ regardless of whether the API key is supplied via env var, `--settings.apiKey`, 
 ## Do this
 
 ```yaml
-# RIGHT — apiKeyHelper in ~/.claude/settings.json + plain `claude -p`
+# RIGHT — FILE-BACKED apiKeyHelper + plain `claude -p`
+#
+# Critical: the helper script does NOT inherit $ANTHROPIC_API_KEY from
+# the parent step's env. CC strips env before spawning the helper.
+# Verified locally 2026-05-18 (CC 2.1.143): "apiKeyHelper failed: did
+# not return a value". The helper must read from a file the workflow
+# writes.
 - name: Configure Claude apiKeyHelper
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   run: |
     mkdir -p ~/.claude
-    printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > ~/.claude/api-key-helper.sh
+    umask 077
+    printf '%s' "$ANTHROPIC_API_KEY" > ~/.claude/.api-key
+    chmod 600 ~/.claude/.api-key
+    printf '#!/bin/sh\ncat %s/.claude/.api-key\n' "$HOME" \
+      > ~/.claude/api-key-helper.sh
     chmod +x ~/.claude/api-key-helper.sh
     printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$HOME" \
       > ~/.claude/settings.json
 
 - name: Analyze
-  env:
-    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   run: |
     claude -p --max-turns 4 --output-format json --no-session-persistence "..."
 ```
 
-Cost: ~10k tokens/call instead of `--bare`'s advertised ~4k. Worth it — the alternative is a silently failing workflow.
+Cost: ~10k tokens/call instead of `--bare`'s advertised ~4k. Worth it — the alternative is a silently failing workflow. The runner is ephemeral; the `.api-key` file is wiped at job end.
+
+## What does NOT work (don't try these)
+
+| Pattern | Result |
+|---|---|
+| `claude --bare` + `ANTHROPIC_API_KEY` env var | "Not logged in" — `--bare` ignores env despite help text |
+| `claude --bare` + `--settings {"apiKey":"..."}` | "Not logged in" — same |
+| `claude --bare` + `--settings {"apiKeyHelper":"..."}` | "Not logged in" — same |
+| `claude -p` + `--settings {"apiKey":"..."}` | "Not logged in" — `apiKey` in settings is silently ignored |
+| `claude -p` + helper that echoes `$ANTHROPIC_API_KEY` | "apiKeyHelper failed: did not return a value" — env stripped before helper invocation |
+
+The ONLY working combo: plain `claude -p` + `apiKeyHelper` that reads from a file the workflow writes.
 
 ## Verify auth before burning budget
 
-Always include a one-call smoke test after the apiKeyHelper write step:
+Always include a one-call smoke test after the apiKeyHelper write step. Disable `set -e` around the smoke since `claude -p` exits 1 on auth failure and would silently kill the step under errexit:
 
 ```bash
+set +e
 smoke=$(claude -p --max-turns 1 --output-format json --no-session-persistence \
   "respond with OK" 2>&1)
-echo "$smoke" | jq -e '.is_error == true' >/dev/null && {
+smoke_exit=$?
+set -e
+
+echo "claude smoke exit: $smoke_exit"
+printf '%s\n' "$smoke" | head -c 400
+
+if [ "$smoke_exit" -ne 0 ] || \
+   printf '%s' "$smoke" | jq -e '.is_error == true' >/dev/null 2>&1; then
   echo "::error::Auth smoke test failed"
   exit 1
-}
+fi
 ```
 
 The smoke test runs once per workflow invocation and catches auth breaks at the START of the job — not 10 PRs later when you've wasted classifier runs on every failure.

--- a/src/skills/shared/rules/cc-bare-auth-gotcha.md
+++ b/src/skills/shared/rules/cc-bare-auth-gotcha.md
@@ -29,37 +29,65 @@ regardless of whether the API key is supplied via env var, `--settings.apiKey`, 
 ## Do this
 
 ```yaml
-# RIGHT — apiKeyHelper in ~/.claude/settings.json + plain `claude -p`
+# RIGHT — FILE-BACKED apiKeyHelper + plain `claude -p`
+#
+# Critical: the helper script does NOT inherit $ANTHROPIC_API_KEY from
+# the parent step's env. CC strips env before spawning the helper.
+# Verified locally 2026-05-18 (CC 2.1.143): "apiKeyHelper failed: did
+# not return a value". The helper must read from a file the workflow
+# writes.
 - name: Configure Claude apiKeyHelper
   env:
     ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   run: |
     mkdir -p ~/.claude
-    printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > ~/.claude/api-key-helper.sh
+    umask 077
+    printf '%s' "$ANTHROPIC_API_KEY" > ~/.claude/.api-key
+    chmod 600 ~/.claude/.api-key
+    printf '#!/bin/sh\ncat %s/.claude/.api-key\n' "$HOME" \
+      > ~/.claude/api-key-helper.sh
     chmod +x ~/.claude/api-key-helper.sh
     printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$HOME" \
       > ~/.claude/settings.json
 
 - name: Analyze
-  env:
-    ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
   run: |
     claude -p --max-turns 4 --output-format json --no-session-persistence "..."
 ```
 
-Cost: ~10k tokens/call instead of `--bare`'s advertised ~4k. Worth it — the alternative is a silently failing workflow.
+Cost: ~10k tokens/call instead of `--bare`'s advertised ~4k. Worth it — the alternative is a silently failing workflow. The runner is ephemeral; the `.api-key` file is wiped at job end.
+
+## What does NOT work (don't try these)
+
+| Pattern | Result |
+|---|---|
+| `claude --bare` + `ANTHROPIC_API_KEY` env var | "Not logged in" — `--bare` ignores env despite help text |
+| `claude --bare` + `--settings {"apiKey":"..."}` | "Not logged in" — same |
+| `claude --bare` + `--settings {"apiKeyHelper":"..."}` | "Not logged in" — same |
+| `claude -p` + `--settings {"apiKey":"..."}` | "Not logged in" — `apiKey` in settings is silently ignored |
+| `claude -p` + helper that echoes `$ANTHROPIC_API_KEY` | "apiKeyHelper failed: did not return a value" — env stripped before helper invocation |
+
+The ONLY working combo: plain `claude -p` + `apiKeyHelper` that reads from a file the workflow writes.
 
 ## Verify auth before burning budget
 
-Always include a one-call smoke test after the apiKeyHelper write step:
+Always include a one-call smoke test after the apiKeyHelper write step. Disable `set -e` around the smoke since `claude -p` exits 1 on auth failure and would silently kill the step under errexit:
 
 ```bash
+set +e
 smoke=$(claude -p --max-turns 1 --output-format json --no-session-persistence \
   "respond with OK" 2>&1)
-echo "$smoke" | jq -e '.is_error == true' >/dev/null && {
+smoke_exit=$?
+set -e
+
+echo "claude smoke exit: $smoke_exit"
+printf '%s\n' "$smoke" | head -c 400
+
+if [ "$smoke_exit" -ne 0 ] || \
+   printf '%s' "$smoke" | jq -e '.is_error == true' >/dev/null 2>&1; then
   echo "::error::Auth smoke test failed"
   exit 1
-}
+fi
 ```
 
 The smoke test runs once per workflow invocation and catches auth breaks at the START of the job — not 10 PRs later when you've wasted classifier runs on every failure.


### PR DESCRIPTION
## Summary

Postmortem #4 from the 2026-05-18 sentinel activation. After #1858 wired `apiKeyHelper`, the smoke-test step exited 1 silently on the runner. Two real causes uncovered locally:

### Cause 1 — CC strips env when spawning apiKeyHelper

A helper that `echo "$ANTHROPIC_API_KEY"` returns empty because the child process inherits a stripped env:

```
apiKeyHelper failed: did not return a value
```

**Fix**: write the key to `~/.claude/.api-key` (mode 600) and have the helper `cat` that file. Verified end-to-end locally — produces `is_error=false, result="OK confirmed."`.

### Cause 2 — `bash -e` propagates command-substitution failure

`smoke=$(claude -p ...)` exits 1 when claude returns 1 on auth failure. Under `set -e` (GHA default), this kills the step BEFORE the if-branch can log the error.

**Fix**: `set +e` around the smoke, capture exit code explicitly, log output, then re-enable `-e`.

## Changes

* **`.github/workflows/ci-sentinel.yml`** — file-backed apiKeyHelper + 4 visible debug lines (settings.json contents, helper script, key file size+mode, claude smoke exit + output) so future debugging sees what's on disk.

* **`src/skills/shared/rules/cc-bare-auth-gotcha.md`** — updated with the corrected file-backed pattern + a "What does NOT work" table covering all 5 failing combinations I tested. Future workflows reading this rule will know the file-backed pattern is the ONLY working combo.

## Local reproducer

```bash
TMPH=$(mktemp -d)
mkdir -p $TMPH/.claude
KEY="sk-ant-..."

# Pattern A (BROKEN — env stripped)
printf '#!/bin/sh\necho "$ANTHROPIC_API_KEY"\n' > $TMPH/.claude/api-key-helper.sh
chmod +x $TMPH/.claude/api-key-helper.sh
printf '{"apiKeyHelper":"%s/.claude/api-key-helper.sh"}\n' "$TMPH" > $TMPH/.claude/settings.json
HOME=$TMPH ANTHROPIC_API_KEY=$KEY claude -p --max-turns 1 --output-format json "hi"
# → apiKeyHelper failed: did not return a value

# Pattern B (WORKS — file-backed)
printf '%s' "$KEY" > $TMPH/.claude/.api-key
chmod 600 $TMPH/.claude/.api-key
printf '#!/bin/sh\ncat %s/.claude/.api-key\n' "$TMPH" > $TMPH/.claude/api-key-helper.sh
HOME=$TMPH claude -p --max-turns 1 --output-format json "hi"
# → is_error=false, result="Hi there, friend."
```

## Test plan

- [ ] CI green
- [ ] Re-fire `gh workflow run ci-sentinel.yml -f dry_run=true -f max_prs=3`
- [ ] Smoke step shows "Auth smoke test OK (N tokens)" with N > 0
- [ ] At least one PR gets a real verdict in the dry-run job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)