### PR TITLE
docs(milestones): mark M170 as superseded after prior-art assessment

### DIFF
--- a/docs/chore--m170-supersede/playground.html
+++ b/docs/chore--m170-supersede/playground.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>M170 Supersede - Prior-Art Overlap Matrix</title>
+<style>
+  :root { --bg:#0d1117; --fg:#c9d1d9; --grid:#21262d; --accent:#58a6ff; --red:#f85149; --green:#3fb950; --yellow:#d29922; }
+  body { background:var(--bg); color:var(--fg); font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; padding:24px; max-width:1000px; margin:0 auto; }
+  h1 { color:var(--accent); font-size:20px; margin-bottom:4px; }
+  .sub { color:#8b949e; font-size:12px; margin-bottom:24px; }
+  table { width:100%; border-collapse:collapse; margin:20px 0; background:#161b22; border:1px solid var(--grid); border-radius:6px; overflow:hidden; }
+  th, td { padding:10px 12px; text-align:left; border-bottom:1px solid var(--grid); }
+  th { background:#1c2128; color:var(--accent); font-weight:normal; font-size:11px; text-transform:uppercase; letter-spacing:0.5px; }
+  tr:last-child td { border-bottom:none; }
+  .ovr-yes { color:var(--red); font-weight:bold; }
+  .ovr-partial { color:var(--yellow); }
+  .ovr-no { color:var(--green); }
+  code { background:#0d1117; padding:2px 6px; border-radius:3px; color:var(--green); font-size:12px; }
+  .ctl { background:#161b22; border:1px solid var(--grid); padding:12px 16px; border-radius:6px; margin:20px 0; display:flex; gap:12px; align-items:center; }
+  .ctl button { background:#1c2128; color:var(--fg); border:1px solid var(--grid); padding:6px 12px; border-radius:4px; cursor:pointer; font-family:inherit; font-size:12px; }
+  .ctl button.active { background:var(--accent); color:#0d1117; border-color:var(--accent); }
+  .stat { display:grid; grid-template-columns:repeat(4, 1fr); gap:12px; margin:20px 0; }
+  .stat .card { background:#161b22; border:1px solid var(--grid); padding:12px; border-radius:6px; text-align:center; }
+  .stat .v { font-size:24px; color:var(--accent); }
+  .stat .k { font-size:11px; color:#8b949e; text-transform:uppercase; margin-top:4px; }
+  .verdict { background:#1c2128; border-left:4px solid var(--red); padding:16px; border-radius:0 6px 6px 0; margin:20px 0; }
+  .verdict h3 { color:var(--red); margin:0 0 8px; font-size:14px; }
+</style>
+</head>
+<body>
+<h1>🎯 M170 Supersede - Prior-Art Overlap Matrix</h1>
+<div class="sub">Click a column to filter the rows. Each row is one capability M170 proposed; each column is an existing OrchestKit asset.</div>
+
+<div class="ctl">
+  <span style="color:#8b949e;font-size:12px;">Filter:</span>
+  <button class="active" data-filter="all">All (9)</button>
+  <button data-filter="yes">Already exists (7)</button>
+  <button data-filter="partial">Partial overlap (1)</button>
+  <button data-filter="no">Genuinely new (1)</button>
+</div>
+
+<div class="stat">
+  <div class="card"><div class="v">7</div><div class="k">Already exists</div></div>
+  <div class="card"><div class="v">1</div><div class="k">Partial overlap</div></div>
+  <div class="card"><div class="v">1</div><div class="k">Genuinely new</div></div>
+  <div class="card"><div class="v">85%</div><div class="k">Redundancy</div></div>
+</div>
+
+<table id="t">
+  <thead>
+    <tr><th>M170 capability proposed</th><th>Existing asset</th><th>Status</th></tr>
+  </thead>
+  <tbody>
+    <tr data-status="yes"><td>SoT for CC supported floor</td><td><code>shared/cc-support.json</code></td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="yes"><td>Stamp SoT to derived files</td><td><code>scripts/stamp-cc-support.mjs</code></td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="yes"><td>Floor-consistency CI test</td><td><code>tests/manifests/test-cc-version-floor.sh</code> (#1765)</td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="yes"><td>CC CHANGELOG snapshot pipeline</td><td><code>scripts/cc-release-watch.mjs</code> (#1486)</td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="yes"><td>LLM feature extraction per snapshot</td><td><code>scripts/cc-triage.mjs</code> (#1486)</td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="yes"><td>Adoption-issue auto-filer</td><td><code>scripts/cc-file-adoption-issues.sh</code></td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="yes"><td>CI workflow for support window</td><td><code>.github/workflows/cc-support-window-bump.yml</code></td><td class="ovr-yes">already exists</td></tr>
+    <tr data-status="partial"><td>Adoption sweep for 2.1.140-148</td><td><code>docs/docs--cc-adoption-bundle-2.1.140-148/</code></td><td class="ovr-partial">in progress</td></tr>
+    <tr data-status="no"><td>Check SKILL.md compatibility: field</td><td>nothing - real gap</td><td class="ovr-no">genuinely new (filed as #1963)</td></tr>
+  </tbody>
+</table>
+
+<div class="verdict">
+  <h3>Verdict</h3>
+  Of 9 capabilities M170 proposed, 7 already exist and 1 is in progress. The only genuinely new capability is extending one existing bash test to also check skill SKILL.md frontmatter - roughly 30 lines, filed as <a href="https://github.com/yonatangross/orchestkit/issues/1963" style="color:var(--accent);">#1963</a>. A follow-on extension to <code>cc-triage.mjs</code> is filed as <a href="https://github.com/yonatangross/orchestkit/issues/1964" style="color:var(--accent);">#1964</a>. Net result: 2 small issues under GH#152 instead of a 9-issue M170 milestone.
+</div>
+
+<p style="margin-top:24px;color:#8b949e;font-size:12px;">
+  Data source: <code>/ork:assess</code> pass on M170 spec at PR #1961.
+  Lesson saved to <code>~/.claude/.../memory/feedback_grep_prior_art_before_milestone.md</code>.
+</p>
+
+<script>
+const buttons = document.querySelectorAll(".ctl button");
+const rows = document.querySelectorAll("#t tbody tr");
+buttons.forEach(b => b.addEventListener("click", () => {
+  buttons.forEach(x => x.classList.remove("active"));
+  b.classList.add("active");
+  const f = b.dataset.filter;
+  rows.forEach(r => {
+    r.style.display = (f === "all" || r.dataset.status === f) ? "" : "none";
+  });
+}));
+</script>
+</body>
+</html>

--- a/docs/feat--m170-skill-auto-eval-spec/M170-spec.md
+++ b/docs/feat--m170-skill-auto-eval-spec/M170-spec.md
@@ -1,6 +1,62 @@
 # M170 — Skill Auto-Eval Against Latest CC
 
-**Status**: Draft · **Owner**: @yonatangross · **Drafted**: 2026-05-23
+**Status**: ⚠️ **SUPERSEDED** · **Owner**: @yonatangross · **Drafted**: 2026-05-23 · **Superseded**: 2026-05-23
+
+---
+
+## ⚠️ SUPERSEDED — 85% redundant with existing infrastructure
+
+A `/ork:assess` pass after this spec was merged in #1961 surfaced significant
+prior art that was missed during drafting. Filing M170 as proposed would
+duplicate work already shipped under M120 / M130 / M137:
+
+| Prior-art component                                  | What it does                                                          |
+|------------------------------------------------------|-----------------------------------------------------------------------|
+| `shared/cc-support.json`                             | Single source of truth for the CC supported floor                     |
+| `scripts/stamp-cc-support.mjs`                       | Stamps SoT to derived files                                           |
+| `tests/manifests/test-cc-version-floor.sh` (#1765)   | CI test asserting derived files agree with SoT (CLAUDE.md, hooks, doctor) |
+| `scripts/cc-release-watch.mjs` (#1486)               | Pulls CC CHANGELOG, drops snapshots, emits gap report                 |
+| `scripts/cc-triage.mjs` (#1486)                      | LLM-extracts CCFeature[] per snapshot                                 |
+| `scripts/cc-file-adoption-issues.sh`                 | Auto-files adoption issues                                            |
+| `.github/workflows/cc-support-window-bump.yml`       | Automated support window bump                                         |
+| `docs/docs--cc-adoption-bundle-2.1.140-148/`         | In-progress adoption bundle for the exact CC range cited below        |
+
+### The single real gap
+
+`test-cc-version-floor.sh` validates 3 derived sites (`cc-version-matrix.ts`,
+`CLAUDE.md`, `doctor/version-compatibility.md`). It does **not** check the
+111 `src/skills/*/SKILL.md` frontmatter `compatibility:` fields. Closing that
+gap is roughly 30 lines of bash — not a milestone with 9 issues.
+
+### Follow-up issues filed instead
+
+Both filed under **GH#152 "CC 2.1.148 adoption"** (the active CC adoption
+milestone, where the 88-skill sweep belongs by convention):
+
+- **Issue A** — Extend `test-cc-version-floor.sh` to check SKILL.md
+  `compatibility:` fields against the SoT. Size XS.
+- **Issue B** — Extend `scripts/cc-triage.mjs` to flag skills missing
+  newly-introduced CC features as adoption candidates. Size S.
+
+### Why this happened
+
+The spec was drafted without searching for `tests/manifests/test-cc-*` or
+`scripts/cc-*` files. Lesson captured in memory as
+`feedback_grep_prior_art_before_milestone.md`.
+
+### What still has value here
+
+The interactive **playground** (`playground.html`) is genuinely useful for
+visualizing the compat-floor histogram and gut-checking proposed floor
+settings — it can stay as a reference, regardless of the spec being superseded.
+
+---
+
+## 📜 Original spec below (kept for history)
+
+The sections below are the original draft as merged in #1961. They no longer
+reflect the path forward — see the SUPERSEDED block above.
+
 **Source preference**: User feedback recorded in `.claude/rules/recent-decisions.md`:
 > "i want to create a way for us to auto evalulate all of our skills and subagents
 >  whether they are up to stanrd with latest cc stuff"


### PR DESCRIPTION
## Summary

A `/ork:assess` pass after #1961 merged found that M170 is **85% redundant**
with existing infrastructure shipped under M120 / M130 / M137:

- `shared/cc-support.json` — SoT for the CC supported floor
- `tests/manifests/test-cc-version-floor.sh` (#1765, M137) — already checks 3 derived sites
- `scripts/cc-release-watch.mjs` + `scripts/cc-triage.mjs` (#1486, M120/M130)
- `.github/workflows/cc-support-window-bump.yml`
- `docs/docs--cc-adoption-bundle-2.1.140-148/` — adoption work already in progress

## The real gap (filed elsewhere)

`test-cc-version-floor.sh` does **not** check the 111 `src/skills/*/SKILL.md`
`compatibility:` frontmatter fields. That's the genuine gap.

Two follow-up issues filed under **GH#152 "CC 2.1.148 adoption"**:
- ✅ #1963 — extend `test-cc-version-floor.sh` (XS, ~30 lines bash)
- ✅ #1964 — extend `cc-triage.mjs` to flag skills missing new features (S)

## What's in this PR

- `docs/feat--m170-skill-auto-eval-spec/M170-spec.md` — adds ⚠️ SUPERSEDED block
  at top explaining the redundancy, while preserving the original text for history
- `docs/chore--m170-supersede/playground.html` — interactive prior-art overlap
  matrix **playground** showing the 9 capabilities M170 proposed vs existing assets

## Test plan

- [ ] Visual-Style PR Lint passes (PR body uses only vocab emojis: ⚠️ ✅ 🤖)
- [ ] PR Playground gate passes (new playground in `docs/chore--m170-supersede/`)
- [ ] Spec now visibly marked SUPERSEDED — anyone reading it sees the truth
- [ ] Issues #1963 and #1964 link back to this PR for context

## Lesson captured

Memory: `feedback_grep_prior_art_before_milestone.md` — always grep `tests/`,
`scripts/`, `.github/workflows/`, `shared/` before drafting milestone-scale
infrastructure specs. Would have caught this in 2 minutes upfront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)