### PR TITLE
fix(hooks): WorktreeCreate emits empty stdout, not the envelope (closes #1990)

### DIFF
--- a/docs/fix--1990-worktreecreate-envelope/playground.html
+++ b/docs/fix--1990-worktreecreate-envelope/playground.html
@@ -1,0 +1,118 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WorktreeCreate envelope fix — #1990 before/after</title>
+<style>
+  :root{--bg:#0b0d0e;--bg2:#131618;--bg3:#1a1f22;--fg:#c8d1d3;--dim:#6b7679;--vdim:#3a4045;
+    --green:#50fa7b;--amber:#f1fa8c;--red:#ff5555;--blue:#8be9fd;--purple:#bd93f9;--orange:#ffb86c;--border:#2a3035;
+    --mono:"JetBrains Mono",ui-monospace,Menlo,Consolas,monospace}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.5 ui-sans-serif,system-ui,-apple-system,sans-serif}
+  header{padding:12px 20px;border-bottom:1px solid var(--border);background:linear-gradient(180deg,#15191c,#0e1113);display:flex;justify-content:space-between;flex-wrap:wrap;gap:6px}
+  header h1{margin:0;font-size:14px} header .meta{color:var(--dim);font-size:11px} header .meta a{color:var(--blue);text-decoration:none}
+  main{max-width:1060px;margin:0 auto;padding:20px 20px 70px}
+  .lead{color:var(--dim);max-width:780px;margin:0 0 18px} .lead code{color:var(--blue);font-family:var(--mono)}
+  .controls{display:flex;gap:20px;flex-wrap:wrap;margin:0 0 20px}
+  .seg-wrap{display:flex;flex-direction:column;gap:4px}
+  .seg-lbl{font-size:10px;text-transform:uppercase;letter-spacing:.06em;color:var(--dim)}
+  .seg{display:inline-flex;border:1px solid var(--border);border-radius:8px;overflow:hidden}
+  .seg button{background:var(--bg2);color:var(--dim);border:0;padding:7px 13px;font-size:12px;cursor:pointer;font-family:var(--mono)}
+  .seg button.on{background:var(--purple);color:#0d0716;font-weight:700}
+  .seg button.on.fix{background:var(--green);color:#00210c}
+  .cols{display:grid;grid-template-columns:1fr 400px;gap:18px}
+  @media(max-width:880px){.cols{grid-template-columns:1fr}}
+  .pipe{background:var(--bg2);border:1px solid var(--border);border-radius:10px;padding:16px 18px}
+  .pipe h2,.diff h2{font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--dim);margin:0 0 14px}
+  .step{border:1px solid var(--border);border-radius:8px;padding:9px 12px;margin-bottom:8px;background:#0d1014;transition:.2s}
+  .step.pass{border-color:var(--green)} .step.fail{border-color:var(--red)} .step.skip{opacity:.4}
+  .step .t{font-family:var(--mono);font-size:12.5px} .step .d{font-size:11px;color:var(--dim);margin-top:2px}
+  .arrow{text-align:center;color:var(--vdim);font-size:12px;margin:-2px 0}
+  .out{margin-top:12px;border-radius:9px;padding:14px 16px;border:1px solid var(--border);font-size:13px}
+  .out.bad{border-color:var(--red);background:rgba(255,85,85,.09)} .out.bad .h{color:var(--red)}
+  .out.good{border-color:var(--green);background:rgba(80,250,123,.08)} .out.good .h{color:var(--green)}
+  .out .h{font-family:var(--mono);font-weight:700} .out p{margin:6px 0 0;font-size:12.5px}
+  .diff{background:#07090a;border:1px solid var(--border);border-radius:10px;padding:14px 16px;font-family:var(--mono);font-size:12px;overflow:auto}
+  .diff .file{color:var(--purple);margin:8px 0 4px} .add{color:var(--green)} .del{color:var(--red)} .ctx{color:var(--dim)}
+  footer{color:var(--vdim);font-size:11px;margin-top:24px;text-align:center} footer a{color:var(--blue)}
+</style>
+</head>
+<body>
+<header>
+  <h1>WorktreeCreate envelope fix — #1990 before / after</h1>
+  <div class="meta">orchestkit · <code>run-hook.mjs</code> · <a href="https://github.com/yonatangross/orchestkit/issues/1990">#1990</a></div>
+</header>
+<main>
+  <p class="lead">Spawn a worktree-isolated agent. CC reads a command-type <code>WorktreeCreate</code> hook's
+    <strong>stdout as the worktree directory path</strong>. OrchestKit's logger is observability-only — it has no path
+    to give. Toggle <b>before/fix</b> and the hook's <b>output</b> to see the envelope get misread as a path (before)
+    vs empty stdout letting CC use its default (fix).</p>
+
+  <div class="controls">
+    <div class="seg-wrap"><span class="seg-lbl">version</span>
+      <div class="seg" id="ver"><button data-v="fix" class="on">fix (#1990)</button><button data-v="before">before</button></div></div>
+    <div class="seg-wrap"><span class="seg-lbl">hook output</span>
+      <div class="seg" id="hk"><button data-h="logger" class="on">observability logger (command)</button><button data-h="http">http (sets worktreePath)</button></div></div>
+  </div>
+
+  <div class="cols">
+    <div class="pipe"><h2>Agent(isolation:"worktree") spawn</h2>
+      <div id="steps"></div>
+      <div class="out" id="out"></div>
+    </div>
+    <div class="diff"><h2>the fix — diff</h2>
+      <div class="file">src/hooks/bin/run-hook.mjs</div>
+<span class="ctx"> // early exits (event not parsed yet → key on hook NAME)</span>
+<span class="add">+ const IS_WORKTREE_PATH_HOOK = hookName.startsWith('worktree/');</span>
+<span class="add">+ function silentExit(){ if(!IS_WORKTREE_PATH_HOOK) console.log(SILENT_OK); process.exit(0); }</span>
+<span class="del">- if(!hookFn){ console.log(SILENT_OK); process.exit(0); }</span>
+<span class="add">+ if(!hookFn){ silentExit(); }</span>
+
+<span class="ctx"> // run path (event known → key on hook_event)</span>
+<span class="add">+ function emitHookResult(result, ev){</span>
+<span class="add">+   if(WORKTREE_PATH_EVENTS.has(ev) && !result?.hookSpecificOutput?.worktreePath) return;</span>
+<span class="add">+   console.log(JSON.stringify(sanitizeOutput(result, ev)));</span>
+<span class="add">+ }</span>
+<span class="del">- console.log(JSON.stringify(sanitizeOutput(result, firingEvent)));</span>
+<span class="add">+ emitHookResult(result, firingEvent);</span>
+    </div>
+  </div>
+  <footer>Self-contained — no network. Mirrors the real dispatcher fix. Recurrence of #1794/#1797 (envelope family #1250/#1826/#1985).</footer>
+</main>
+<script>
+const $=id=>document.getElementById(id);
+let ver="fix", hk="logger";
+function seg(id,key,set){ $(id).querySelectorAll("button").forEach(b=>b.onclick=()=>{
+  $(id).querySelectorAll("button").forEach(x=>x.classList.remove("on","fix"));
+  b.classList.add("on"); if(b.dataset[key]==="fix")b.classList.add("fix"); set(b.dataset[key]); render();
+});}
+seg("ver","v",v=>ver=v); seg("hk","h",v=>hk=v);
+$("ver").querySelector('[data-v="fix"]').classList.add("fix");
+function run(){
+  const steps=[]; const add=(t,d,s)=>steps.push({t,d,s});
+  add("①  CC fires WorktreeCreate","run-hook.mjs worktree/worktree-lifecycle-logger","pass");
+  if(hk==="http"){
+    add("②  hook returns worktreePath","hookSpecificOutput.worktreePath = .worktrees/feat","pass");
+    add("③  CC reads the path","valid directory path ✓","pass");
+    return {steps, out:{cls:"good",h:"✓ WORKTREE CREATED (custom path)",p:"http-type hooks legitimately provide a path — emitted in both before & after. Unaffected by the fix."}};
+  }
+  // observability logger (command)
+  if(ver==="before"){
+    add("②  run-hook prints SILENT_OK",'stdout = {"continue":true,"suppressOutput":true}',"fail");
+    add("③  CC reads stdout AS THE PATH",'path = {"continue":true,…} → not a directory',"fail");
+    return {steps, out:{cls:"bad",h:"💥 SPAWN ABORTED",p:'"WorktreeCreate hook returned a path that is not a directory." The observability hook had no path to give, but the dispatcher printed the envelope anyway → CC misread it. Every worktree-isolated agent dies here.'}};
+  }
+  add("②  run-hook emits EMPTY stdout","worktree/* hook + no worktreePath → print nothing","pass");
+  add("③  CC uses its default path","provisions .worktrees/<slug> itself ✓","pass");
+  return {steps, out:{cls:"good",h:"✓ WORKTREE CREATED (default path)",p:"The observability hook contributes no path; CC provisions the worktree at its own default. The logger's side-effects (advisory file) still run. Agent spawns again."}};
+}
+function render(){
+  const r=run();
+  $("steps").innerHTML=r.steps.map((s,i)=>`<div class="step ${s.s}"><div class="t">${s.t}</div><div class="d">${s.d}</div></div>`+(i<r.steps.length-1?'<div class="arrow">▼</div>':'')).join("");
+  const o=$("out"); o.className="out "+r.out.cls; o.innerHTML=`<span class="h">${r.out.h}</span><p>${r.out.p}</p>`;
+}
+render();
+</script>
+</body>
+</html>

--- a/docs/site/lib/generated/changelog-data.ts
+++ b/docs/site/lib/generated/changelog-data.ts
@@ -17,6 +17,64 @@ export interface ChangelogEntry {
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    "version": "8.6.4",
+    "date": "2026-05-24",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**cc-watch:** give parse_failed an escape hatch (closes [#1985](https://github.com/yonatangross/orchestkit/issues/1985)) ([#1988](https://github.com/yonatangross/orchestkit/issues/1988)) ([bbd3c28](https://github.com/yonatangross/orchestkit/commit/bbd3c2856f6ab0ddfe80fbf6f2aacb6e8b2ab53f))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "8.6.3",
+    "date": "2026-05-24",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**hooks:** SessionStart output missing hookEventName (closes [#1983](https://github.com/yonatangross/orchestkit/issues/1983)) ([#1984](https://github.com/yonatangross/orchestkit/issues/1984)) ([b4eeeab](https://github.com/yonatangross/orchestkit/commit/b4eeeabe4ea8e9a3bc4f5bf792015c77d30fa9a1))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "8.6.2",
+    "date": "2026-05-24",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "changed",
+        "items": [
+          "**skills:** adopt CC 2.1.140-2.1.148 long/bg-session features ([#1981](https://github.com/yonatangross/orchestkit/issues/1981)) ([7d94722](https://github.com/yonatangross/orchestkit/commit/7d947225989d7b6a715b6a8aaf8bea7eaa506d4b))"
+        ]
+      }
+    ]
+  },
+  {
+    "version": "8.6.1",
+    "date": "2026-05-24",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "fixed",
+        "items": [
+          "**hooks:** sweep project root for envelope corruption (closes [#1978](https://github.com/yonatangross/orchestkit/issues/1978)) ([#1979](https://github.com/yonatangross/orchestkit/issues/1979)) ([a7335f1](https://github.com/yonatangross/orchestkit/commit/a7335f13141add3a4b897b4e4f59f27beab4cd03))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "bump CC floor to 2.1.148 (closes [#1945](https://github.com/yonatangross/orchestkit/issues/1945)) ([#1977](https://github.com/yonatangross/orchestkit/issues/1977)) ([8c0c493](https://github.com/yonatangross/orchestkit/commit/8c0c4939529d839b0e8fb7404f3fea296bc386b1))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "8.6.0",
     "date": "2026-05-23",
     "compareUrl": "",

--- a/plugins/ork/hooks/bin/run-hook.mjs
+++ b/plugins/ork/hooks/bin/run-hook.mjs
@@ -222,6 +222,21 @@ if (!hookName) {
   process.exit(0);
 }
 
+// #1990: CC reads a command-type WorktreeCreate/WorktreeRemove hook's STDOUT as
+// the worktree directory path. `worktree/*` hooks fire on those events, so they
+// must NOT print the {"continue":true,...} envelope — CC misreads the JSON as a
+// path ("returned a path that is not a directory") and aborts every
+// Agent(isolation:"worktree") spawn. The early-exit paths below (bundle
+// missing, hook not in registry, etc.) run BEFORE stdin is parsed, so they
+// can't see hook_event — key off the hook NAME instead. silentExit() emits
+// EMPTY for worktree hooks (CC then provisions at its default path) and the
+// normal envelope for every other hook.
+const IS_WORKTREE_PATH_HOOK = hookName.startsWith('worktree/');
+function silentExit() {
+  if (!IS_WORKTREE_PATH_HOOK) console.log(SILENT_OK);
+  process.exit(0);
+}
+
 // Early security-hook override probe — emits the stderr warning even when
 // the bundle can't load. See SECURITY_HOOKS docstring above.
 try {
@@ -299,16 +314,14 @@ try {
 } catch (err) {
   // Bundle not found - likely not built yet
   // Output silent success to not block Claude Code
-  console.log(SILENT_OK);
-  process.exit(0);
+  silentExit();
 }
 
 /** t1: after bundle import */
 const t1 = process.hrtime.bigint();
 
 if (!hooks) {
-  console.log(SILENT_OK);
-  process.exit(0);
+  silentExit();
 }
 
 // Get the hook function from the registry
@@ -316,8 +329,7 @@ const hookFn = hooks.hooks?.[hookName];
 
 // If hook not found (not migrated yet), output silent success
 if (!hookFn) {
-  console.log(SILENT_OK);
-  process.exit(0);
+  silentExit();
 }
 
 // Read stdin with timeout to prevent hanging
@@ -514,6 +526,34 @@ function validateInput(input, hookName) {
 }
 
 /**
+ * Events whose hook STDOUT is read by CC as the worktree directory path
+ * (not the standard continue/suppressOutput envelope). A `command`-type hook
+ * on these events must echo a bare directory path — or nothing at all, in
+ * which case CC provisions the worktree at its own default location.
+ *
+ * #1990: OrchestKit's WorktreeCreate hooks are observability-only (logging +
+ * a deferred sparse-paths advisory) — they do NOT provision worktrees, so they
+ * have no path to contribute. Printing the `{"continue":true,...}` envelope
+ * here makes CC misread the JSON as the path ("returned a path that is not a
+ * directory") and aborts every Agent(isolation:"worktree") spawn. Emitting
+ * EMPTY stdout lets CC fall back to its default worktree creation. HTTP-type
+ * hooks that legitimately set `hookSpecificOutput.worktreePath` still emit it.
+ * Recurrence of #1794/#1797 (the original "WorktreeCreate output shape" fix).
+ */
+const WORKTREE_PATH_EVENTS = new Set(['WorktreeCreate', 'WorktreeRemove']);
+
+/**
+ * Write a hook result to stdout, honoring the WorktreeCreate/WorktreeRemove
+ * path-channel contract. For those events with no `worktreePath`, emit nothing.
+ */
+function emitHookResult(result, firingEvent) {
+  if (WORKTREE_PATH_EVENTS.has(firingEvent) && !result?.hookSpecificOutput?.worktreePath) {
+    return; // empty stdout — CC uses its default worktree path
+  }
+  console.log(JSON.stringify(sanitizeOutput(result, firingEvent)));
+}
+
+/**
  * Execute the hook and output result
  */
 async function runHook(parsedInput) {
@@ -553,7 +593,7 @@ async function runHook(parsedInput) {
     /** t3: after hook function executed */
     t3 = process.hrtime.bigint();
     const firingEvent = parsedInput.hook_event || '';
-    console.log(JSON.stringify(sanitizeOutput(result, firingEvent)));
+    emitHookResult(result, firingEvent);
   } catch (err) {
     /** t3: captured even on error so timing is always recorded */
     t3 = process.hrtime.bigint();
@@ -563,10 +603,10 @@ async function runHook(parsedInput) {
     // sanitizeOutput is a no-op here — but we call it consistently so that
     // any future mutation of the error shape is also guarded.
     const firingEvent = parsedInput?.hook_event || '';
-    console.log(JSON.stringify(sanitizeOutput({
+    emitHookResult({
       continue: true,
       systemMessage: `Hook error (${hookName}): ${err.message}`,
-    }, firingEvent)));
+    }, firingEvent);
   } finally {
     // Track hook execution (Issue #245)
     const durationMs = Date.now() - startTime;

--- a/src/hooks/bin/run-hook.mjs
+++ b/src/hooks/bin/run-hook.mjs
@@ -222,6 +222,21 @@ if (!hookName) {
   process.exit(0);
 }
 
+// #1990: CC reads a command-type WorktreeCreate/WorktreeRemove hook's STDOUT as
+// the worktree directory path. `worktree/*` hooks fire on those events, so they
+// must NOT print the {"continue":true,...} envelope — CC misreads the JSON as a
+// path ("returned a path that is not a directory") and aborts every
+// Agent(isolation:"worktree") spawn. The early-exit paths below (bundle
+// missing, hook not in registry, etc.) run BEFORE stdin is parsed, so they
+// can't see hook_event — key off the hook NAME instead. silentExit() emits
+// EMPTY for worktree hooks (CC then provisions at its default path) and the
+// normal envelope for every other hook.
+const IS_WORKTREE_PATH_HOOK = hookName.startsWith('worktree/');
+function silentExit() {
+  if (!IS_WORKTREE_PATH_HOOK) console.log(SILENT_OK);
+  process.exit(0);
+}
+
 // Early security-hook override probe — emits the stderr warning even when
 // the bundle can't load. See SECURITY_HOOKS docstring above.
 try {
@@ -299,16 +314,14 @@ try {
 } catch (err) {
   // Bundle not found - likely not built yet
   // Output silent success to not block Claude Code
-  console.log(SILENT_OK);
-  process.exit(0);
+  silentExit();
 }
 
 /** t1: after bundle import */
 const t1 = process.hrtime.bigint();
 
 if (!hooks) {
-  console.log(SILENT_OK);
-  process.exit(0);
+  silentExit();
 }
 
 // Get the hook function from the registry
@@ -316,8 +329,7 @@ const hookFn = hooks.hooks?.[hookName];
 
 // If hook not found (not migrated yet), output silent success
 if (!hookFn) {
-  console.log(SILENT_OK);
-  process.exit(0);
+  silentExit();
 }
 
 // Read stdin with timeout to prevent hanging
@@ -514,6 +526,34 @@ function validateInput(input, hookName) {
 }
 
 /**
+ * Events whose hook STDOUT is read by CC as the worktree directory path
+ * (not the standard continue/suppressOutput envelope). A `command`-type hook
+ * on these events must echo a bare directory path — or nothing at all, in
+ * which case CC provisions the worktree at its own default location.
+ *
+ * #1990: OrchestKit's WorktreeCreate hooks are observability-only (logging +
+ * a deferred sparse-paths advisory) — they do NOT provision worktrees, so they
+ * have no path to contribute. Printing the `{"continue":true,...}` envelope
+ * here makes CC misread the JSON as the path ("returned a path that is not a
+ * directory") and aborts every Agent(isolation:"worktree") spawn. Emitting
+ * EMPTY stdout lets CC fall back to its default worktree creation. HTTP-type
+ * hooks that legitimately set `hookSpecificOutput.worktreePath` still emit it.
+ * Recurrence of #1794/#1797 (the original "WorktreeCreate output shape" fix).
+ */
+const WORKTREE_PATH_EVENTS = new Set(['WorktreeCreate', 'WorktreeRemove']);
+
+/**
+ * Write a hook result to stdout, honoring the WorktreeCreate/WorktreeRemove
+ * path-channel contract. For those events with no `worktreePath`, emit nothing.
+ */
+function emitHookResult(result, firingEvent) {
+  if (WORKTREE_PATH_EVENTS.has(firingEvent) && !result?.hookSpecificOutput?.worktreePath) {
+    return; // empty stdout — CC uses its default worktree path
+  }
+  console.log(JSON.stringify(sanitizeOutput(result, firingEvent)));
+}
+
+/**
  * Execute the hook and output result
  */
 async function runHook(parsedInput) {
@@ -553,7 +593,7 @@ async function runHook(parsedInput) {
     /** t3: after hook function executed */
     t3 = process.hrtime.bigint();
     const firingEvent = parsedInput.hook_event || '';
-    console.log(JSON.stringify(sanitizeOutput(result, firingEvent)));
+    emitHookResult(result, firingEvent);
   } catch (err) {
     /** t3: captured even on error so timing is always recorded */
     t3 = process.hrtime.bigint();
@@ -563,10 +603,10 @@ async function runHook(parsedInput) {
     // sanitizeOutput is a no-op here — but we call it consistently so that
     // any future mutation of the error shape is also guarded.
     const firingEvent = parsedInput?.hook_event || '';
-    console.log(JSON.stringify(sanitizeOutput({
+    emitHookResult({
       continue: true,
       systemMessage: `Hook error (${hookName}): ${err.message}`,
-    }, firingEvent)));
+    }, firingEvent);
   } finally {
     // Track hook execution (Issue #245)
     const durationMs = Date.now() - startTime;

--- a/tests/hooks/test-run-hook-dispatcher.sh
+++ b/tests/hooks/test-run-hook-dispatcher.sh
@@ -327,6 +327,57 @@ else
 fi
 
 # =============================================================================
+echo ""
+echo "7. WorktreeCreate path-channel (#1990)"
+echo "--------------------------------------"
+
+# CC reads a command-type WorktreeCreate/WorktreeRemove hook's STDOUT as the
+# worktree directory path. An observability hook that emits the
+# {"continue":true,"suppressOutput":true} envelope makes CC misread the JSON as
+# a path ("returned a path that is not a directory") and abort every
+# Agent(isolation:"worktree") spawn. run-hook.mjs must emit EMPTY stdout here.
+
+# 7a. command-type WorktreeCreate → empty stdout (CC uses its default path).
+run_hook "worktree/worktree-lifecycle-logger" \
+  "{\"hook_event\":\"WorktreeCreate\",\"name\":\"feature-test\",\"type\":\"command\",\"project_dir\":\"$PROJECT_ROOT\"}" \
+  "CLAUDE_PROJECT_DIR=$PROJECT_ROOT"
+if [[ -z "$LAST_STDOUT" ]]; then
+  pass "WorktreeCreate (command): empty stdout — envelope not misread as a path"
+else
+  fail "WorktreeCreate command stdout not empty: '$LAST_STDOUT'"
+fi
+
+# 7b. WorktreeRemove → also empty stdout.
+run_hook "worktree/worktree-lifecycle-logger" \
+  "{\"hook_event\":\"WorktreeRemove\",\"worktree_path\":\"/tmp/wt-test\",\"project_dir\":\"$PROJECT_ROOT\"}" \
+  "CLAUDE_PROJECT_DIR=$PROJECT_ROOT"
+if [[ -z "$LAST_STDOUT" ]]; then
+  pass "WorktreeRemove: empty stdout"
+else
+  fail "WorktreeRemove stdout not empty: '$LAST_STDOUT'"
+fi
+
+# 7c. http-type WorktreeCreate → a legit worktreePath IS still emitted.
+run_hook "worktree/worktree-lifecycle-logger" \
+  "{\"hook_event\":\"WorktreeCreate\",\"name\":\"feature-http\",\"type\":\"http\",\"project_dir\":\"$PROJECT_ROOT\"}" \
+  "CLAUDE_PROJECT_DIR=$PROJECT_ROOT"
+if echo "$LAST_STDOUT" | grep -q "worktreePath"; then
+  pass "WorktreeCreate (http): worktreePath preserved (path-providing hooks unaffected)"
+else
+  fail "WorktreeCreate http dropped worktreePath: '$LAST_STDOUT'"
+fi
+
+# 7d. Regression guard — a normal event still emits the continue envelope.
+run_hook "pretool/bash/dangerous-command-blocker" \
+  "{\"tool_input\":{\"command\":\"echo hi\"},\"hook_event\":\"PreToolUse\",\"project_dir\":\"$PROJECT_ROOT\"}" \
+  "CLAUDE_PROJECT_DIR=$PROJECT_ROOT"
+if echo "$LAST_STDOUT" | grep -q '"continue"'; then
+  pass "PreToolUse still emits envelope (suppression scoped to worktree events)"
+else
+  fail "PreToolUse envelope over-suppressed: '$LAST_STDOUT'"
+fi
+
+# =============================================================================
 # Summary
 echo ""
 echo "================================="


### PR DESCRIPTION
## Summary

Closes #1990. **P0** — every `Agent(isolation: "worktree")` spawn aborted with:

```
Error: WorktreeCreate hook returned a path that is not a directory:
{"continue":true,"suppressOutput":true}.
```

## Root cause

CC reads a **command-type `WorktreeCreate`/`WorktreeRemove` hook's STDOUT as the worktree directory path** (events added 2.1.50 for custom VCS setup; http-type returns it via `hookSpecificOutput.worktreePath` per 2.1.84). OrchestKit's worktree hooks are **observability-only** (logging + a deferred sparse-paths advisory) — they have no path to contribute, but `run-hook.mjs` blindly printed its `SILENT_OK` envelope, which CC then misread as the path → "not a directory" → abort.

Recurrence of #1794/#1797 ("WorktreeCreate output shape"); same envelope family as #1250/#1826/#1985.

## Fix (`src/hooks/bin/run-hook.mjs`)

The envelope leaks from **two kinds of exit**, handled separately because the early ones run before stdin is parsed:

| Path | Knows `hook_event`? | Fix |
|------|--------------------|-----|
| early exits (bundle/registry miss) | no | `silentExit()` keys off the hook **name** (`worktree/*` → emit empty) |
| the run path | yes | `emitHookResult()` emits empty for `WorktreeCreate`/`WorktreeRemove` unless the hook set `hookSpecificOutput.worktreePath` |

- Empty stdout → CC provisions the worktree at its **default** path; the logger's side-effects (advisory file) still run.
- http-type hooks that legitimately set `worktreePath` still emit it.
- All non-worktree events unchanged (regression-guarded).

## Tests

+4 cases in `tests/hooks/test-run-hook-dispatcher.sh`:
- command-type WorktreeCreate → empty stdout
- WorktreeRemove → empty stdout
- http-type WorktreeCreate → `worktreePath` preserved
- PreToolUse → envelope intact (suppression scoped)

```
Results: 24 passed, 0 failed
```

## Impact once merged

Unblocks **all worktree-isolated agent spawns** across every repo that has the ork plugin installed (orchestkit, portfolio, hq, …) — `ork:frontend-ui-developer` and friends work again.

## Playground

`docs/fix--1990-worktreecreate-envelope/playground.html` — before/after spawn sim: toggle version + hook output to watch the envelope get misread as a path (before) vs empty stdout → CC default (fix).

## Caveat

`run-hook.mjs` is a bin script (not bundled); the only built artifact is its `plugins/` copy. The "empty stdout → CC default provisioning" behavior is validated by the dispatcher tests; full end-to-end validation needs a live `Agent(isolation:"worktree")` once this lands (which the bug itself currently blocks).

Generated with Claude Code
