### PR TITLE
feat(docs-site): serve docs from orchestkit.yonyon.ai (canonical)

### DIFF
--- a/docs/feat--docs-orchestkit-yonyon-domain/domain-cutover-playground.html
+++ b/docs/feat--docs-orchestkit-yonyon-domain/domain-cutover-playground.html
@@ -1,0 +1,242 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OrchestKit → yonyon.ai · Domain Cutover Playground</title>
+    <style>
+      :root {
+        --bg: #0b0e14;
+        --panel: #121722;
+        --panel-2: #0f1420;
+        --ink: #e6edf3;
+        --muted: #8b98a9;
+        --line: #232b3a;
+        --accent: #7c9cff;
+        --accent-2: #59d9a4;
+        --warn: #f0a35e;
+        --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+        --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        background: radial-gradient(1200px 600px at 80% -10%, #16203a 0%, var(--bg) 55%);
+        color: var(--ink);
+        font-family: var(--sans);
+        line-height: 1.5;
+        padding: 32px 20px 80px;
+      }
+      .wrap { max-width: 980px; margin: 0 auto; }
+      header h1 { font-size: 1.6rem; margin: 0 0 4px; letter-spacing: -0.02em; }
+      header p { color: var(--muted); margin: 0 0 24px; }
+      .pill { display: inline-block; font-family: var(--mono); font-size: 0.72rem; padding: 2px 8px; border: 1px solid var(--line); border-radius: 999px; color: var(--muted); }
+      .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+      @media (max-width: 760px) { .grid { grid-template-columns: 1fr; } }
+      .card { background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 18px 18px 16px; }
+      .card h2 { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); margin: 0 0 12px; }
+      .opt { display: flex; gap: 10px; align-items: flex-start; padding: 9px 11px; border: 1px solid var(--line); border-radius: 10px; margin-bottom: 8px; cursor: pointer; transition: border-color .15s, background .15s; }
+      .opt:hover { border-color: #33405a; }
+      .opt.sel { border-color: var(--accent); background: #141d33; }
+      .opt input { margin-top: 3px; accent-color: var(--accent); }
+      .opt .t { font-weight: 600; font-size: 0.92rem; }
+      .opt .d { color: var(--muted); font-size: 0.8rem; }
+      .opt .rec { color: var(--accent-2); font-size: 0.72rem; font-family: var(--mono); }
+      .flow { font-family: var(--mono); font-size: 0.82rem; background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; padding: 16px; white-space: pre-wrap; color: var(--ink); }
+      .flow .h { color: var(--accent); }
+      .flow .g { color: var(--accent-2); }
+      .flow .w { color: var(--warn); }
+      .flow .m { color: var(--muted); }
+      pre { font-family: var(--mono); font-size: 0.78rem; background: var(--panel-2); border: 1px solid var(--line); border-radius: 12px; padding: 14px; overflow-x: auto; margin: 0; }
+      pre .c { color: var(--muted); }
+      pre .k { color: var(--accent); }
+      pre .s { color: var(--accent-2); }
+      .tabs { display: flex; gap: 6px; margin-bottom: 10px; }
+      .tab { font-family: var(--mono); font-size: 0.76rem; padding: 5px 10px; border: 1px solid var(--line); border-radius: 8px; color: var(--muted); cursor: pointer; background: transparent; }
+      .tab.sel { color: var(--ink); border-color: var(--accent); background: #141d33; }
+      .full { grid-column: 1 / -1; }
+      .note { font-size: 0.78rem; color: var(--muted); margin-top: 10px; }
+      .note b { color: var(--warn); }
+      .seq { counter-reset: step; list-style: none; padding: 0; margin: 0; font-size: 0.85rem; }
+      .seq li { counter-increment: step; padding: 8px 0 8px 34px; position: relative; border-bottom: 1px dashed var(--line); }
+      .seq li:last-child { border-bottom: 0; }
+      .seq li::before { content: counter(step); position: absolute; left: 0; top: 7px; width: 22px; height: 22px; border-radius: 50%; background: #141d33; border: 1px solid var(--accent); color: var(--accent); font-family: var(--mono); font-size: 0.75rem; display: grid; place-items: center; }
+      code { font-family: var(--mono); background: #141d33; padding: 1px 5px; border-radius: 5px; font-size: 0.85em; }
+      footer { color: var(--muted); font-size: 0.75rem; margin-top: 28px; text-align: center; }
+      a { color: var(--accent); }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header>
+        <span class="pill">orchestkit · docs-site domain cutover</span>
+        <h1>OrchestKit&nbsp;→&nbsp;yonyon.ai</h1>
+        <p>Interactive playground for the docs-site domain migration. Flip the three decisions and watch the DNS flow, Terraform, and Next.js config update live. Defaults reflect the chosen path: <b>A1&nbsp;B1&nbsp;C1</b>.</p>
+      </header>
+
+      <div class="grid">
+        <div class="card">
+          <h2>A · Domain shape</h2>
+          <label class="opt sel" data-group="shape" data-val="orchestkit">
+            <input type="radio" name="shape" checked />
+            <div><div class="t">orchestkit.yonyon.ai <span class="rec">★ chosen</span></div><div class="d">Matches the Vercel project name + the <code>&lt;service&gt;.yonyon.ai</code> convention.</div></div>
+          </label>
+          <label class="opt" data-group="shape" data-val="docs">
+            <input type="radio" name="shape" />
+            <div><div class="t">docs.yonyon.ai</div><div class="d">Generic — better if other product docs share one roof later.</div></div>
+          </label>
+          <label class="opt" data-group="shape" data-val="ork">
+            <input type="radio" name="shape" />
+            <div><div class="t">ork.yonyon.ai</div><div class="d">Short / brand-y, matches the <code>/ork:</code> plugin namespace.</div></div>
+          </label>
+        </div>
+
+        <div class="card">
+          <h2>B · Cloudflare proxy</h2>
+          <label class="opt sel" data-group="proxy" data-val="dns">
+            <input type="radio" name="proxy" checked />
+            <div><div class="t">DNS-only <span class="rec">★ chosen</span></div><div class="d">Grey-cloud. Vercel edge serves SSL + CDN. The shai.yonyon.ai pattern for public sites.</div></div>
+          </label>
+          <label class="opt" data-group="proxy" data-val="proxied">
+            <input type="radio" name="proxy" />
+            <div><div class="t">Proxied (orange-cloud)</div><div class="d">CF caching / WAF / analytics in front — inherits the cert-issuance two-step.</div></div>
+          </label>
+          <h2 style="margin-top:16px">C · Old *.vercel.app</h2>
+          <label class="opt sel" data-group="redir" data-val="301">
+            <input type="radio" name="redir" checked />
+            <div><div class="t">301 → canonical <span class="rec">★ chosen</span></div><div class="d">One canonical URL for SEO. Redirect in <code>next.config.mjs</code>.</div></div>
+          </label>
+          <label class="opt" data-group="redir" data-val="both">
+            <input type="radio" name="redir" />
+            <div><div class="t">Keep both live</div><div class="d">Vercel keeps the alias regardless — simplest, but splits SEO signal.</div></div>
+          </label>
+        </div>
+
+        <div class="card full">
+          <h2>Request flow</h2>
+          <div class="flow" id="flow"></div>
+          <div class="note" id="flow-note"></div>
+        </div>
+
+        <div class="card full">
+          <h2>Generated config</h2>
+          <div class="tabs">
+            <button class="tab sel" data-tab="tf">platform · orchestkit.tf</button>
+            <button class="tab" data-tab="next">orchestkit · next.config.mjs</button>
+            <button class="tab" data-tab="verify">verify</button>
+          </div>
+          <pre id="code"></pre>
+        </div>
+
+        <div class="card full">
+          <h2>Cutover sequence</h2>
+          <ol class="seq">
+            <li><b>platform PR → dev:</b> add <code>vercel_project_domain.orchestkit</code> + <code>cloudflare_dns_record.orchestkit</code> to <code>infra/terraform/orchestkit.tf</code>; <code>terraform validate</code> passes.</li>
+            <li><b>operator apply (Touch ID):</b> <code>op run --env-file=.env.tpl -- terraform apply</code> — needs a Cloudflare <code>Zone:DNS:Edit</code> token (default HQ token is list-scope only, per the m133 playbook).</li>
+            <li><b>wait for "Valid Configuration"</b> + cert (~2&nbsp;min): <code>dig +short orchestkit.yonyon.ai @1.1.1.1</code>.</li>
+            <li><b>orchestkit PR → main:</b> flip canonical (<code>lib/constants.ts</code>, <code>next.config.mjs</code> ACAO + 301) — ships on the next <code>main</code> deploy (Git-integrated).</li>
+            <li><b>verify:</b> <code>curl -sI https://orchestkit.vercel.app</code> → <code>301</code> → <code>orchestkit.yonyon.ai</code>.</li>
+          </ol>
+        </div>
+      </div>
+
+      <footer>
+        Self-contained playground · no external requests · part of PR <code>feat/docs-orchestkit-yonyon-domain</code>
+      </footer>
+    </div>
+
+    <script>
+      const state = { shape: "orchestkit", proxy: "dns", redir: "301" };
+      const sub = { orchestkit: "orchestkit", docs: "docs", ork: "ork" };
+
+      function host() { return sub[state.shape] + ".yonyon.ai"; }
+
+      function renderFlow() {
+        const h = host();
+        const proxied = state.proxy === "proxied";
+        const cloud = proxied ? '<span class="w">CF proxy (orange-cloud, WAF/cache)</span>' : '<span class="g">CF DNS-only (grey-cloud)</span>';
+        const redir = state.redir === "301"
+          ? '<span class="m">orchestkit.vercel.app/*  ──301──▶  https://' + h + '/*</span>'
+          : '<span class="m">orchestkit.vercel.app  (kept live, no redirect)</span>';
+        document.getElementById("flow").innerHTML =
+          'Browser  ──▶  <span class="h">' + h + '</span>\n' +
+          '            └─ CNAME → cname.vercel-dns.com  (' + cloud + ')\n' +
+          '                 └─▶  Vercel edge  ──▶  docs/site  (Next.js / fumadocs)\n\n' +
+          redir;
+        document.getElementById("flow-note").innerHTML = proxied
+          ? '<b>Proxied:</b> set yonyon.ai SSL mode to Full (strict); expect a brief "Invalid Configuration" window during cert issuance — flip proxy off until Vercel reports Valid, then back on.'
+          : 'DNS-only: cert issues cleanly on first apply; nothing to babysit.';
+      }
+
+      const tpl = {
+        tf: () => {
+          const proxied = state.proxy === "proxied" ? "true " : "false";
+          const name = sub[state.shape];
+          return '<span class="c"># infra/terraform/orchestkit.tf</span>\n' +
+            '<span class="k">resource</span> <span class="s">"vercel_project_domain" "orchestkit"</span> {\n' +
+            '  project_id = module.orchestkit.project_id\n' +
+            '  domain     = <span class="s">"' + host() + '"</span>\n' +
+            '}\n\n' +
+            '<span class="k">resource</span> <span class="s">"cloudflare_dns_record" "orchestkit"</span> {\n' +
+            '  count   = length(var.cloudflare_api_token) > 0 ? 1 : 0\n' +
+            '  zone_id = local.cloudflare_yonyon_zone_id\n' +
+            '  name    = <span class="s">"' + name + '"</span>\n' +
+            '  type    = <span class="s">"CNAME"</span>\n' +
+            '  content = <span class="s">"cname.vercel-dns.com"</span>\n' +
+            '  ttl     = 1\n' +
+            '  proxied = ' + proxied + (state.proxy === "proxied" ? '<span class="c"> # CF in front</span>' : '<span class="c"> # Vercel edge direct</span>') + '\n' +
+            '}';
+        },
+        next: () => {
+          if (state.redir === "both")
+            return '<span class="c">// next.config.mjs — "keep both" → no host redirect added.</span>\n' +
+              '<span class="c">// Only the canonical constant + ACAO change:</span>\n' +
+              'domain: <span class="s">"https://' + host() + '"</span>  <span class="c">// lib/constants.ts</span>';
+          return '<span class="c">// docs/site/next.config.mjs — redirects()</span>\n' +
+            '{\n' +
+            '  source: <span class="s">"/:path*"</span>,\n' +
+            '  has: [{ type: <span class="s">"host"</span>, value: <span class="s">"orchestkit.vercel.app"</span> }],\n' +
+            '  destination: <span class="s">"https://' + host() + '/:path*"</span>,\n' +
+            '  statusCode: <span class="k">301</span>,\n' +
+            '}\n\n' +
+            '<span class="c">// lib/constants.ts</span>\n' +
+            'domain: <span class="s">"https://' + host() + '"</span>';
+        },
+        verify: () => '<span class="c"># DNS resolves to Vercel</span>\n' +
+          'dig +short ' + host() + ' @1.1.1.1\n' +
+          '<span class="c"># → cname.vercel-dns.com + Vercel IPs</span>\n\n' +
+          '<span class="c"># cert + canonical redirect</span>\n' +
+          'curl -sI https://orchestkit.vercel.app\n' +
+          (state.redir === "301"
+            ? '<span class="c"># → HTTP/2 301 · location: https://' + host() + '/</span>'
+            : '<span class="c"># → HTTP/2 200 (alias kept live)</span>') + '\n\n' +
+          'curl -sI https://' + host() + '\n' +
+          '<span class="c"># → HTTP/2 200</span>'
+      };
+
+      let tab = "tf";
+      function renderCode() { document.getElementById("code").innerHTML = tpl[tab](); }
+
+      document.querySelectorAll(".opt").forEach((el) => {
+        el.addEventListener("click", () => {
+          const g = el.dataset.group;
+          document.querySelectorAll('.opt[data-group="' + g + '"]').forEach((o) => o.classList.remove("sel"));
+          el.classList.add("sel");
+          el.querySelector("input").checked = true;
+          state[g] = el.dataset.val;
+          renderFlow(); renderCode();
+        });
+      });
+      document.querySelectorAll(".tab").forEach((el) => {
+        el.addEventListener("click", () => {
+          document.querySelectorAll(".tab").forEach((t) => t.classList.remove("sel"));
+          el.classList.add("sel");
+          tab = el.dataset.tab;
+          renderCode();
+        });
+      });
+
+      renderFlow(); renderCode();
+    </script>
+  </body>
+</html>

--- a/docs/site/__tests__/landing-page.test.tsx
+++ b/docs/site/__tests__/landing-page.test.tsx
@@ -25,7 +25,7 @@ vi.mock("..//lib/constants", () => ({
   SITE: {
     name: "OrchestKit",
     version: "6.3.0",
-    domain: "https://orchestkit.vercel.app",
+    domain: "https://orchestkit.yonyon.ai",
     github: "https://github.com/yonatangross/orchestkit",
     installCommand: "claude install orchestkit/ork",
   },

--- a/docs/site/lib/constants.ts
+++ b/docs/site/lib/constants.ts
@@ -8,7 +8,7 @@ import { TOTALS, MIN_CC_VERSION } from "./generated/shared-data";
 export const SITE = {
   name: "OrchestKit",
   version: orkManifest.version,
-  domain: "https://orchestkit.vercel.app",
+  domain: "https://orchestkit.yonyon.ai",
   github: "https://github.com/yonatangross/orchestkit",
   installCommand: "claude install orchestkit/ork",
   ccVersion: `${MIN_CC_VERSION}+`,

--- a/docs/site/next.config.mjs
+++ b/docs/site/next.config.mjs
@@ -16,12 +16,21 @@ const config = {
       destination: "/docs/foundations/overview",
       permanent: false,
     },
+    {
+      // 301 the bare Vercel host onto the canonical brand domain (orchestkit.yonyon.ai).
+      // Preview deployments (orchestkit-<hash>.vercel.app) don't match this exact host,
+      // so they stay reachable; only the production alias is redirected.
+      source: "/:path*",
+      has: [{ type: "host", value: "orchestkit.vercel.app" }],
+      destination: "https://orchestkit.yonyon.ai/:path*",
+      statusCode: 301,
+    },
   ],
   headers: async () => [
     {
       source: "/(.*)",
       headers: [
-        { key: "Access-Control-Allow-Origin", value: "https://orchestkit.vercel.app" },
+        { key: "Access-Control-Allow-Origin", value: "https://orchestkit.yonyon.ai" },
         { key: "X-Frame-Options", value: "DENY" },
         { key: "X-Content-Type-Options", value: "nosniff" },
         { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },


### PR DESCRIPTION
## What

Switch the docs site's canonical domain from `orchestkit.vercel.app` to **`orchestkit.yonyon.ai`** and 301 the old host onto it. Companion to the DNS / Vercel-domain PR in `Yonatan-HQ/platform` (`infra/terraform/orchestkit.tf`).

## Decisions (chosen by owner)

- **A1** domain shape -> `orchestkit.yonyon.ai`
- **B1** Cloudflare proxy -> DNS-only (Vercel edge serves SSL + CDN)
- **C1** old host -> `301` -> canonical

## Changes (`docs/site/`)

- `lib/constants.ts` - `SITE.domain` -> `https://orchestkit.yonyon.ai` (single source of truth; drives `metadataBase` / OG / canonical in `app/layout.tsx`)
- `next.config.mjs` - CORS `Access-Control-Allow-Origin` -> `https://orchestkit.yonyon.ai`; add a `301` redirect from the `orchestkit.vercel.app` host. Preview `*.vercel.app` URLs keep working (exact-host match, so only the prod alias redirects).
- `__tests__/landing-page.test.tsx` - mock `SITE.domain` updated to match.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/docs-orchestkit-yonyon-domain/docs/feat--docs-orchestkit-yonyon-domain/domain-cutover-playground.html)** - flip the three decisions (domain shape / proxy mode / redirect) and watch the DNS flow, Terraform, and `next.config` update live. Defaults reflect the chosen path A1 B1 C1.

## Sequencing (hold this PR)

Drafted on purpose: do not merge until the platform DNS PR is applied and Vercel reports **Valid Configuration** for `orchestkit.yonyon.ai`. Merging before DNS is live would 301 visitors to a non-resolving host. Once DNS is live, this ships on the next `main` deploy (the project is Git-integrated).

## Verification (post-merge)

```bash
curl -sI https://orchestkit.vercel.app    # -> 301 -> https://orchestkit.yonyon.ai/
curl -sI https://orchestkit.yonyon.ai     # -> 200
```

Companion PR: Yonatan-HQ/platform#4110 (DNS + Vercel domain).
