### PR TITLE
fix(skills): residual library-currency sweep (16 skills)

### DIFF
--- a/docs/fix--lib-currency-residual/residual-sweep.html
+++ b/docs/fix--lib-currency-residual/residual-sweep.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Residual Deprecation Sweep — closing the audit</title>
+<style>
+  :root{--bg:#0a0d12;--panel:#12171f;--panel2:#1a212c;--border:#2a323d;--fg:#e6edf3;--muted:#8b98a9;--green:#3fb950;--high:#ff8c42;--accent:#bc8cff;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font:14.5px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}
+  header{padding:26px 26px 16px;border-bottom:1px solid var(--border);background:linear-gradient(180deg,#0e131a,var(--bg))}
+  h1{margin:0 0 6px;font-size:22px}.sub{color:var(--muted);font-size:13.5px;max-width:920px}
+  main{max-width:1040px;margin:0 auto;padding:24px 26px 70px}section{margin-bottom:30px}
+  h2{font-size:15px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);border-left:3px solid var(--accent);padding-left:10px;margin:0 0 14px}
+  table{width:100%;border-collapse:collapse;font-size:12.5px}th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--border);vertical-align:top}
+  th{color:var(--muted);font-size:11px;text-transform:uppercase}code{font-family:var(--mono);font-size:11.5px;background:var(--panel2);padding:1px 5px;border-radius:4px}
+  .g{color:var(--green)}.h{color:var(--high)}
+  .note{background:rgba(63,185,80,.06);border:1px solid rgba(63,185,80,.3);border-radius:9px;padding:13px 15px;color:#bfe9cf;font-size:13px}
+  .leave{background:rgba(255,140,66,.06);border:1px solid rgba(255,140,66,.3);border-radius:9px;padding:13px 15px;color:#f0d9c9;font-size:13px}
+  footer{color:var(--muted);font-size:11.5px;border-top:1px solid var(--border);padding:18px 26px;text-align:center}
+</style>
+</head>
+<body>
+<header>
+  <h1>Residual Deprecation Sweep — closing the 2026-05-31 audit 🧹</h1>
+  <div class="sub">The deferred proliferation from Lanes 1–3: the same deprecated patterns in <b>non-audited skills</b>. 16 default sub-agents, one per skill, <b>judgment-aware</b> (no blind replace) + an aggregate gap-sweep. Off fresh <code>main</code> (both lanes merged).</div>
+</header>
+<main>
+  <section>
+    <h2>What changed</h2>
+    <div class="note">68 files across 16 skills. Mechanical fixes applied everywhere they were real code; model-id modernization applied only to plain "use this model" defaults; everything specialized or deliberate was <b>left and logged</b>.</div>
+    <table><thead><tr><th>pattern</th><th>fix</th><th>result</th></tr></thead><tbody>
+      <tr><td><code>gpt-5.2</code> (plain default)</td><td>→ <code>gpt-5.5</code></td><td class="g">0 plain remaining</td></tr>
+      <tr><td><code>gpt-4o</code> (plain default)</td><td>→ <code>gpt-5.5</code></td><td class="g">0 remaining</td></tr>
+      <tr><td><code>gpt-5.2-mini</code> / <code>gpt-4o-mini</code></td><td>→ <code>gpt-5-mini</code></td><td class="g">cheap-tier preserved</td></tr>
+      <tr><td><code>z.string().email()/.uuid()/.url()/.datetime()</code></td><td>→ <code>z.email()</code> / <code>z.uuid()</code> / <code>z.url()</code> / <code>z.iso.datetime()</code></td><td class="g">0 (3 left are migration-doc comments)</td></tr>
+      <tr><td><code>asyncio.get_event_loop()</code></td><td>→ <code>get_running_loop()</code> / <code>time.monotonic()</code></td><td class="g">0 remaining</td></tr>
+      <tr><td>Pydantic <code>class Config:</code></td><td>→ <code>model_config = SettingsConfigDict / ConfigDict</code> (per base class)</td><td class="g">0 remaining</td></tr>
+      <tr><td><code>datetime.utcnow()</code></td><td>→ <code>datetime.now(UTC)</code></td><td class="g">0 remaining</td></tr>
+    </tbody></table>
+  </section>
+  <section>
+    <h2>Left intentionally (judgment, not laziness)</h2>
+    <div class="leave">
+      <ul style="margin:0;padding-left:18px">
+        <li><code>gpt-5.2-codex</code> ×20 (dedicated <code>gpt-5-2-codex.md</code> + its sibling rows) — specialized model; deferred to a separate codex-lineup pass rather than create an incoherent "gpt-5.5 standard beside gpt-5.2-codex" doc.</li>
+        <li><code>gpt-5.2-realtime</code> / <code>gpt-4o-transcribe</code> ×2 — current specialized voice/transcription models; mapping them to <code>gpt-5.5</code> would strip the capability.</li>
+        <li><code>gpt-3.5-turbo</code> ×1 — a deliberate cheap/legacy fallback-tier cost illustration in a token-budget script.</li>
+        <li>3× <code>z.string().email</code> in <code>zod-v4-api.md</code> — these are <em>comments</em> documenting what the new form replaced (the code is already <code>z.email()</code>).</li>
+      </ul>
+    </div>
+  </section>
+  <section>
+    <h2>Heaviest skills</h2>
+    <table><thead><tr><th>skill</th><th>residual fixed</th></tr></thead><tbody>
+      <tr><td>agent-orchestration</td><td>38× gpt-5.2→5.5, 2× *-mini→gpt-5-mini (codex file left)</td></tr>
+      <tr><td>rag-retrieval</td><td>gpt ids + gpt-5.2-mini→gpt-5-mini + class Config</td></tr>
+      <tr><td>security-patterns</td><td>Zod 4 across 6 files (SKILL/validation rules/examples/script)</td></tr>
+      <tr><td>distributed-systems / architecture-patterns</td><td>get_event_loop→get_running_loop, utcnow→now(UTC), gpt ids</td></tr>
+      <tr><td>api-design / monitoring-observability</td><td>class Config→ConfigDict, gpt ids</td></tr>
+    </tbody></table>
+  </section>
+  <section>
+    <h2>Audit status after this</h2>
+    <div class="note">Lane 1 (#2142) + Lane 2/3 (#2143) + this residual sweep = the entire 2026-05-31 library-currency audit remediated. Only the explicitly-deferred <b>codex/realtime model-lineup verification</b> remains (its own small pass).</div>
+  </section>
+</main>
+<footer>OrchestKit · fix/lib-currency-residual (off main) · 16 default sub-agents + aggregate gap-sweep · judgment-aware, leave-logged · closes the audit (modulo codex pass)</footer>
+</body>
+</html>

--- a/plugins/ork/skills/accessibility/examples/wcag-examples.md
+++ b/plugins/ork/skills/accessibility/examples/wcag-examples.md
@@ -13,7 +13,7 @@ import { useState } from 'react';
 import { z } from 'zod';
 
 const FormSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+  email: z.email('Please enter a valid email address'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
   agreeToTerms: z.boolean().refine((val) => val === true, {
     message: 'You must agree to the terms',

--- a/plugins/ork/skills/accessibility/scripts/accessible-form-template.tsx
+++ b/plugins/ork/skills/accessibility/scripts/accessible-form-template.tsx
@@ -29,7 +29,7 @@ const FormSchema = z.object({
   fullName: z.string().min(1, 'Name is required'),
 
   // Email input
-  email: z.string().email('Please enter a valid email address'),
+  email: z.email('Please enter a valid email address'),
 
   // Phone input with custom validation
   phone: z

--- a/plugins/ork/skills/agent-orchestration/references/crewai-patterns.md
+++ b/plugins/ork/skills/agent-orchestration/references/crewai-patterns.md
@@ -288,7 +288,7 @@ crew = Crew(
     agents=[manager, researcher, writer],
     tasks=[research_task, write_task, review_task],
     process=Process.hierarchical,
-    manager_llm="gpt-4o",  # Required for hierarchical
+    manager_llm="gpt-5.5",  # Required for hierarchical
     memory=True,
     verbose=True
 )
@@ -308,8 +308,8 @@ agent = Agent(
     backstory="Expert with 10 years experience",
 
     # LLM configuration
-    llm="gpt-4o",
-    function_calling_llm="gpt-4o-mini",  # Cheaper model for tools
+    llm="gpt-5.5",
+    function_calling_llm="gpt-5-mini",  # Cheaper model for tools
     use_system_prompt=True,
 
     # Execution control
@@ -709,7 +709,7 @@ class ReviewFlow(Flow):
     @human_feedback(
         message="Do you approve this content?",
         emit=["approved", "rejected"],
-        llm="gpt-4o-mini"
+        llm="gpt-5-mini"
     )
     def generate_content(self):
         return "Content for human review..."

--- a/plugins/ork/skills/agent-orchestration/references/framework-comparison.md
+++ b/plugins/ork/skills/agent-orchestration/references/framework-comparison.md
@@ -76,7 +76,7 @@ agent = AssistantAgent(name="assistant", llm_config=config)
 # MS Agent Framework (new)
 from autogen_agentchat.agents import AssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-model_client = OpenAIChatCompletionClient(model="gpt-5.2")
+model_client = OpenAIChatCompletionClient(model="gpt-5.5")
 agent = AssistantAgent(name="assistant", model_client=model_client)
 ```
 

--- a/plugins/ork/skills/agent-orchestration/references/microsoft-agent-framework.md
+++ b/plugins/ork/skills/agent-orchestration/references/microsoft-agent-framework.md
@@ -10,7 +10,7 @@ from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 # Create model client
 model_client = OpenAIChatCompletionClient(
-    model="gpt-5.2",
+    model="gpt-5.5",
     api_key=os.environ["OPENAI_API_KEY"]
 )
 

--- a/plugins/ork/skills/agent-orchestration/references/openai-agents-sdk.md
+++ b/plugins/ork/skills/agent-orchestration/references/openai-agents-sdk.md
@@ -20,7 +20,7 @@ from agents import Agent, Runner
 agent = Agent(
     name="assistant",
     instructions="You are a helpful assistant that answers questions.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 # Synchronous run
@@ -44,7 +44,7 @@ session = SQLiteSession(db_path="conversations.db")
 agent = Agent(
     name="assistant",
     instructions="You are a helpful assistant.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 runner = Runner()
@@ -98,7 +98,7 @@ billing_agent = Agent(
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You handle billing inquiries. Check account status and payment issues.
 Hand back to triage when billing issue is resolved.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 support_agent = Agent(
@@ -106,7 +106,7 @@ support_agent = Agent(
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You handle technical support. Troubleshoot issues and provide solutions.
 Hand back to triage when support issue is resolved.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 # Triage agent with handoffs
@@ -117,7 +117,7 @@ You are the first point of contact. Determine the nature of inquiries.
 - Billing questions: hand off to billing
 - Technical issues: hand off to support
 - General questions: answer directly""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     handoffs=[
         handoff(agent=billing_agent),
         handoff(agent=support_agent)
@@ -205,7 +205,7 @@ async with MCPServerManager() as manager:
     agent = Agent(
         name="mcp_agent",
         instructions="Use available tools to help the user.",
-        model="gpt-5.2",
+        model="gpt-5.5",
         mcp_servers=[filesystem_server, api_server]
     )
 
@@ -228,7 +228,7 @@ async with MCPServerStdio(
     agent = Agent(
         name="file_agent",
         instructions="Help with file operations.",
-        model="gpt-5.2",
+        model="gpt-5.5",
         mcp_servers=[server]
     )
     result = await runner.run(agent, "What files are available?")
@@ -256,7 +256,7 @@ def create_ticket(title: str, description: str, priority: str) -> str:
 support_agent = Agent(
     name="support",
     instructions="Help users with technical issues. Search knowledge base first.",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[search_knowledge_base, create_ticket]
 )
 ```
@@ -285,7 +285,7 @@ class ResponseValidator(OutputGuardrail):
 agent = Agent(
     name="safe_assistant",
     instructions="You are a helpful assistant.",
-    model="gpt-5.2",
+    model="gpt-5.5",
     input_guardrails=[ContentFilter()],
     output_guardrails=[ResponseValidator()]
 )
@@ -346,7 +346,7 @@ from agents import Agent, Runner
 agent = Agent(
     name="streamer",
     instructions="Provide detailed explanations.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 runner = Runner()
@@ -428,7 +428,7 @@ config = RunConfig(
 agent = Agent(
     name="assistant",
     instructions="You are helpful.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 result = await runner.run(agent, "Complex task", run_config=config)

--- a/plugins/ork/skills/agent-orchestration/rules/frameworks-autogen.md
+++ b/plugins/ork/skills/agent-orchestration/rules/frameworks-autogen.md
@@ -19,7 +19,7 @@ from autogen_agentchat.conditions import TextMentionTermination
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 # Create model client
-model_client = OpenAIChatCompletionClient(model="gpt-5.2")
+model_client = OpenAIChatCompletionClient(model="gpt-5.5")
 
 # Define agents
 planner = AssistantAgent(
@@ -156,21 +156,21 @@ researcher_agent = Agent(
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You are a research specialist. Gather information and facts.
 When research is complete, hand off to the writer.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 writer_agent = Agent(
     name="writer",
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You are a content writer. Create compelling content from research.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 orchestrator = Agent(
     name="orchestrator",
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You coordinate research and writing tasks.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     handoffs=[handoff(agent=researcher_agent), handoff(agent=writer_agent)]
 )
 

--- a/plugins/ork/skills/agent-orchestration/rules/frameworks-comparison.md
+++ b/plugins/ork/skills/agent-orchestration/rules/frameworks-comparison.md
@@ -118,7 +118,7 @@ agent = AssistantAgent(name="assistant", llm_config=config)
 # MS Agent Framework (new)
 from autogen_agentchat.agents import AssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-model_client = OpenAIChatCompletionClient(model="gpt-5.2")
+model_client = OpenAIChatCompletionClient(model="gpt-5.5")
 agent = AssistantAgent(name="assistant", model_client=model_client)
 ```
 
@@ -184,6 +184,6 @@ result = await app.ainvoke({"text": "..."})
 ```python
 # Simple task = single agent
 from langchain_openai import ChatOpenAI
-llm = ChatOpenAI(model="gpt-5.2")
+llm = ChatOpenAI(model="gpt-5.5")
 result = await llm.ainvoke("Summarize this text: ...")
 ```

--- a/plugins/ork/skills/agent-orchestration/rules/frameworks-crewai.md
+++ b/plugins/ork/skills/agent-orchestration/rules/frameworks-crewai.md
@@ -55,7 +55,7 @@ crew = Crew(
     agents=[manager, researcher, writer],
     tasks=[project_task],
     process=Process.hierarchical,
-    manager_llm="gpt-5.2",
+    manager_llm="gpt-5.5",
     memory=True,
     verbose=True
 )
@@ -224,6 +224,6 @@ crew = Crew(
     agents=[manager, researcher, writer, reviewer],
     tasks=[project_task],
     process=Process.hierarchical,  # Manager delegates dynamically
-    manager_llm="gpt-5.2"
+    manager_llm="gpt-5.5"
 )
 ```

--- a/plugins/ork/skills/agent-orchestration/rules/loops-plan-execute.md
+++ b/plugins/ork/skills/agent-orchestration/rules/loops-plan-execute.md
@@ -84,7 +84,7 @@ When done: Answer: [Final answer]`;
 
   for (let i = 0; i < maxIterations; i++) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2', messages, temperature: 0.1
+      model: 'gpt-5.5', messages, temperature: 0.1
     });
 
     const content = response.choices[0].message.content!;
@@ -135,7 +135,7 @@ export async function functionCallingAgent(task: string): Promise<AgentResult> {
   let iteration = 0;
   while (iteration < 10) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2', messages, tools: openaiTools
+      model: 'gpt-5.5', messages, tools: openaiTools
     });
 
     const message = response.choices[0].message;

--- a/plugins/ork/skills/agent-orchestration/rules/multi-synthesis.md
+++ b/plugins/ork/skills/agent-orchestration/rules/multi-synthesis.md
@@ -50,7 +50,7 @@ export async function multiAgentCollaboration(
 
   // 1. Coordinator plans the task
   const planResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       {
         role: 'system',
@@ -70,7 +70,7 @@ Provide a numbered plan with agent assignments.`
   const agentResults = await Promise.all(
     agents.map(async (agent) => {
       const response = await openai.chat.completions.create({
-        model: 'gpt-5.2',
+        model: 'gpt-5.5',
         messages: [
           { role: 'system', content: agent.systemPrompt },
           { role: 'user', content: `Task: ${task}\n\nPlan:\n${plan}\n\nComplete your part.` }
@@ -82,7 +82,7 @@ Provide a numbered plan with agent assignments.`
 
   // 3. Synthesize results
   const synthesisResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       { role: 'system', content: 'Synthesize agent results into a coherent final answer.' },
       { role: 'user', content: `Task: ${task}\n\nAgent Results:\n${JSON.stringify(agentResults, null, 2)}` }

--- a/plugins/ork/skills/agent-orchestration/scripts/agent-workflow-template.ts
+++ b/plugins/ork/skills/agent-orchestration/scripts/agent-workflow-template.ts
@@ -160,7 +160,7 @@ IMPORTANT:
 
   for (let i = 0; i < maxIterations; i++) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       messages,
       temperature: 0.1
     })
@@ -237,7 +237,7 @@ export async function functionCallingAgent(task: string): Promise<AgentResult> {
   let iteration = 0
   while (iteration < 10) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       messages,
       tools: openaiTools
     })
@@ -305,7 +305,7 @@ export async function multiAgentCollaboration(
 
   // 1. Coordinator plans the task
   const planResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       {
         role: 'system',
@@ -333,7 +333,7 @@ Provide a numbered plan with agent assignments.`
   const agentResults = await Promise.all(
     agents.map(async (agent) => {
       const response = await openai.chat.completions.create({
-        model: 'gpt-5.2',
+        model: 'gpt-5.5',
         messages: [
           { role: 'system', content: agent.systemPrompt },
           { role: 'user', content: `Task: ${task}\n\nPlan:\n${plan}\n\nComplete your part.` }
@@ -351,7 +351,7 @@ Provide a numbered plan with agent assignments.`
 
   // 3. Synthesize results
   const synthesisResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       {
         role: 'system',

--- a/plugins/ork/skills/agent-orchestration/scripts/crewai-crew.py
+++ b/plugins/ork/skills/agent-orchestration/scripts/crewai-crew.py
@@ -11,13 +11,12 @@ Features:
 """
 
 import json
-import os
 from typing import Any
 
 import structlog
 from crewai import Agent, Crew, Process, Task
 from crewai.tools import tool
-from langfuse import observe, get_client
+from langfuse import get_client, observe
 
 logger = structlog.get_logger()
 
@@ -25,6 +24,7 @@ logger = structlog.get_logger()
 # ============================================================================
 # CUSTOM TOOLS
 # ============================================================================
+
 
 @tool("Search Database")
 def search_database(query: str) -> str:
@@ -52,11 +52,9 @@ def analyze_data(data: str, analysis_type: str) -> str:
     """
     logger.info("Analyzing data", analysis_type=analysis_type)
     # Replace with actual analysis logic
-    return json.dumps({
-        "analysis_type": analysis_type,
-        "findings": ["Finding 1", "Finding 2"],
-        "confidence": 0.85
-    })
+    return json.dumps(
+        {"analysis_type": analysis_type, "findings": ["Finding 1", "Finding 2"], "confidence": 0.85}
+    )
 
 
 @tool("Generate Report")
@@ -79,6 +77,7 @@ def generate_report(title: str, sections: str) -> str:
 # AGENT DEFINITIONS
 # ============================================================================
 
+
 def create_manager_agent() -> Agent:
     """Create the project manager agent that coordinates the team."""
     return Agent(
@@ -92,7 +91,7 @@ def create_manager_agent() -> Agent:
         memory=True,
         verbose=True,
         max_iter=15,  # Maximum iterations for task completion
-        max_retry_limit=2  # Retries on failure
+        max_retry_limit=2,  # Retries on failure
     )
 
 
@@ -108,7 +107,7 @@ def create_researcher_agent() -> Agent:
         memory=True,
         verbose=True,
         tools=[search_database],
-        max_iter=10
+        max_iter=10,
     )
 
 
@@ -124,7 +123,7 @@ def create_analyst_agent() -> Agent:
         memory=True,
         verbose=True,
         tools=[analyze_data],
-        max_iter=10
+        max_iter=10,
     )
 
 
@@ -140,13 +139,14 @@ def create_writer_agent() -> Agent:
         memory=True,
         verbose=True,
         tools=[generate_report],
-        max_iter=10
+        max_iter=10,
     )
 
 
 # ============================================================================
 # TASK DEFINITIONS
 # ============================================================================
+
 
 def create_research_task(researcher: Agent, topic: str) -> Task:
     """Create the research gathering task."""
@@ -166,7 +166,7 @@ def create_research_task(researcher: Agent, topic: str) -> Task:
         - Key findings organized by theme
         - Supporting data and sources
         - Initial observations""",
-        agent=researcher
+        agent=researcher,
     )
 
 
@@ -188,7 +188,7 @@ def create_analysis_task(analyst: Agent, research_task: Task) -> Task:
         - Top 3-5 recommendations
         - Confidence scores for findings""",
         agent=analyst,
-        context=[research_task]  # Receives research output
+        context=[research_task],  # Receives research output
     )
 
 
@@ -210,13 +210,14 @@ def create_report_task(writer: Agent, analysis_task: Task, topic: str) -> Task:
         - Recommendations with priorities
         - Appendix with supporting data""",
         agent=writer,
-        context=[analysis_task]  # Receives analysis output
+        context=[analysis_task],  # Receives analysis output
     )
 
 
 # ============================================================================
 # CREW ASSEMBLY
 # ============================================================================
+
 
 @observe()
 def create_research_crew(topic: str) -> tuple[Crew, list[Task]]:
@@ -240,11 +241,11 @@ def create_research_crew(topic: str) -> tuple[Crew, list[Task]]:
         agents=[manager, researcher, analyst, writer],
         tasks=tasks,
         process=Process.hierarchical,
-        manager_llm="gpt-5.2",  # Manager uses GPT-5.2 for coordination
+        manager_llm="gpt-5.5",  # Manager uses GPT-5.5 for coordination
         memory=True,  # Enable shared memory
         verbose=True,
         max_rpm=20,  # Rate limit API calls
-        share_crew=False  # Don't share crew state between runs
+        share_crew=False,  # Don't share crew state between runs
     )
 
     return crew, tasks
@@ -253,6 +254,7 @@ def create_research_crew(topic: str) -> tuple[Crew, list[Task]]:
 # ============================================================================
 # EXECUTION
 # ============================================================================
+
 
 @observe()
 def run_research_crew(topic: str) -> dict[str, Any]:
@@ -264,10 +266,7 @@ def run_research_crew(topic: str) -> dict[str, Any]:
     Returns:
         Dictionary with crew results and metadata
     """
-    get_client().update_current_trace(
-        name="crewai_research",
-        metadata={"topic": topic}
-    )
+    get_client().update_current_trace(name="crewai_research", metadata={"topic": topic})
 
     logger.info("Starting research crew", topic=topic)
 
@@ -282,43 +281,34 @@ def run_research_crew(topic: str) -> dict[str, Any]:
         for task in tasks:
             task_outputs[task.agent.role] = task.output.raw if task.output else None
 
-        logger.info(
-            "Research crew completed",
-            topic=topic,
-            tasks_completed=len(tasks)
-        )
+        logger.info("Research crew completed", topic=topic, tasks_completed=len(tasks))
 
         get_client().update_current_observation(
-            output={"status": "success", "tasks_completed": len(tasks)},
-            metadata={"topic": topic}
+            output={"status": "success", "tasks_completed": len(tasks)}, metadata={"topic": topic}
         )
 
         return {
             "status": "success",
             "topic": topic,
-            "final_report": result.raw if hasattr(result, 'raw') else str(result),
+            "final_report": result.raw if hasattr(result, "raw") else str(result),
             "task_outputs": task_outputs,
-            "tokens_used": result.token_usage if hasattr(result, 'token_usage') else None
+            "tokens_used": result.token_usage if hasattr(result, "token_usage") else None,
         }
 
     except Exception as e:
         logger.error("Research crew failed", topic=topic, error=str(e))
 
         get_client().update_current_observation(
-            output={"status": "error", "error": str(e)},
-            level="error"
+            output={"status": "error", "error": str(e)}, level="error"
         )
 
-        return {
-            "status": "error",
-            "topic": topic,
-            "error": str(e)
-        }
+        return {"status": "error", "topic": topic, "error": str(e)}
 
 
 # ============================================================================
 # ASYNC EXECUTION (Alternative)
 # ============================================================================
+
 
 @observe()
 async def run_research_crew_async(topic: str) -> dict[str, Any]:
@@ -341,16 +331,12 @@ async def run_research_crew_async(topic: str) -> dict[str, Any]:
         return {
             "status": "success",
             "topic": topic,
-            "final_report": result.raw if hasattr(result, 'raw') else str(result)
+            "final_report": result.raw if hasattr(result, "raw") else str(result),
         }
 
     except Exception as e:
         logger.error("Async research crew failed", error=str(e))
-        return {
-            "status": "error",
-            "topic": topic,
-            "error": str(e)
-        }
+        return {"status": "error", "topic": topic, "error": str(e)}
 
 
 # ============================================================================

--- a/plugins/ork/skills/agent-orchestration/scripts/openai-multi-agent.py
+++ b/plugins/ork/skills/agent-orchestration/scripts/openai-multi-agent.py
@@ -163,7 +163,7 @@ When the technical issue is resolved or requires escalation,
 hand back to the triage agent with a summary.
 
 Always be patient and clear in your explanations.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[search_knowledge_base, create_support_ticket]
 )
 
@@ -184,7 +184,7 @@ When the billing issue is resolved or requires escalation,
 hand back to the triage agent with a summary.
 
 Be empathetic and transparent about billing matters.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[check_account_status, process_refund]
 )
 
@@ -205,7 +205,7 @@ When the account matter is resolved, hand back to the
 triage agent with a summary.
 
 Be helpful and proactive in suggesting improvements.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[check_account_status]
 )
 
@@ -233,7 +233,7 @@ When specialists hand back to you:
 3. Route to another specialist if needed
 
 Always be friendly, professional, and efficient.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     handoffs=[
         handoff(agent=technical_agent),
         handoff(agent=billing_agent),

--- a/plugins/ork/skills/api-design/examples/fastapi-problem-details.md
+++ b/plugins/ork/skills/api-design/examples/fastapi-problem-details.md
@@ -6,7 +6,7 @@ Complete example implementing RFC 9457 Problem Details in FastAPI.
 
 ```python
 # app/core/exceptions.py
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 from typing import Any
 
@@ -36,8 +36,8 @@ class ProblemDetail(BaseModel):
     trace_id: str | None = None
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "type": "https://api.orchestkit.dev/problems/validation-error",
                 "title": "Validation Error",
@@ -48,6 +48,7 @@ class ProblemDetail(BaseModel):
                 "timestamp": "2026-01-07T10:30:00Z",
             }
         }
+    )
 
 
 class ValidationProblem(ProblemDetail):

--- a/plugins/ork/skills/api-design/examples/orchestkit-api-design.md
+++ b/plugins/ork/skills/api-design/examples/orchestkit-api-design.md
@@ -318,11 +318,13 @@ GET /api/v1/health
 **Location**: `backend/app/api/schemas/errors.py`
 
 ```python
+from pydantic import BaseModel, ConfigDict
+
 class ErrorResponse(BaseModel):
     error: dict[str, Any]
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "error": {
                     "code": "VALIDATION_ERROR",
@@ -331,6 +333,7 @@ class ErrorResponse(BaseModel):
                 }
             }
         }
+    )
 ```
 
 ### Example Error Responses

--- a/plugins/ork/skills/api-design/references/rest-patterns.md
+++ b/plugins/ork/skills/api-design/references/rest-patterns.md
@@ -412,6 +412,8 @@ GET /api/v1/analyses?fields=id,title,status
 
 ```python
 # app/api/schemas/errors.py
+from pydantic import BaseModel, ConfigDict
+
 class ErrorDetail(BaseModel):
     field: str
     message: str
@@ -420,8 +422,8 @@ class ErrorDetail(BaseModel):
 class ErrorResponse(BaseModel):
     error: dict[str, Any]
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "error": {
                     "code": "VALIDATION_ERROR",
@@ -438,6 +440,7 @@ class ErrorResponse(BaseModel):
                 }
             }
         }
+    )
 ```
 
 ### FastAPI Exception Handlers

--- a/plugins/ork/skills/api-design/rules/streaming-sse.md
+++ b/plugins/ork/skills/api-design/rules/streaming-sse.md
@@ -54,7 +54,7 @@ export async function GET(req: Request) {
 ```typescript
 export async function POST(req: Request) {
   const { messages } = await req.json()
-  const stream = await openai.chat.completions.create({ model: 'gpt-5.2', messages, stream: true })
+  const stream = await openai.chat.completions.create({ model: 'gpt-5.5', messages, stream: true })
   const encoder = new TextEncoder()
 
   return new Response(

--- a/plugins/ork/skills/architecture-patterns/references/backend-layer-separation.md
+++ b/plugins/ork/skills/architecture-patterns/references/backend-layer-separation.md
@@ -195,7 +195,7 @@ async def get_user(user_id: int) -> User:
 
 # For unavoidable sync code, use run_in_executor
 async def process_file(file_path: str) -> bytes:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None,
         lambda: open(file_path, 'rb').read()

--- a/plugins/ork/skills/architecture-patterns/references/layer-rules.md
+++ b/plugins/ork/skills/architecture-patterns/references/layer-rules.md
@@ -184,7 +184,7 @@ async def get_user(user_id: int) -> User:
 
 # For unavoidable sync code, use run_in_executor
 async def process_file(file_path: str) -> bytes:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None,
         lambda: open(file_path, 'rb').read()

--- a/plugins/ork/skills/architecture-patterns/rules/right-sizing-decision.md
+++ b/plugins/ork/skills/architecture-patterns/rules/right-sizing-decision.md
@@ -13,17 +13,17 @@ Context-aware recommendations for ORM, auth, error handling, and testing by proj
 ```python
 # MVP with 0 users, building custom JWT from scratch
 import jwt
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from passlib.context import CryptContext
 
 pwd_context = CryptContext(schemes=["argon2"])
 
 def create_access_token(user_id: str) -> str:
-    expire = datetime.utcnow() + timedelta(minutes=15)
+    expire = datetime.now(UTC) + timedelta(minutes=15)
     return jwt.encode({"sub": user_id, "exp": expire}, SECRET_KEY)
 
 def create_refresh_token(user_id: str) -> str:
-    expire = datetime.utcnow() + timedelta(days=7)
+    expire = datetime.now(UTC) + timedelta(days=7)
     return jwt.encode({"sub": user_id, "exp": expire, "type": "refresh"}, SECRET_KEY)
 
 # +200 LOC for token rotation, revocation, middleware...

--- a/plugins/ork/skills/distributed-systems/checklists/circuit-breaker-setup.md
+++ b/plugins/ork/skills/distributed-systems/checklists/circuit-breaker-setup.md
@@ -281,7 +281,7 @@ Add to your service's README:
 
 | Service | Threshold | Recovery | Fallback |
 |---------|-----------|----------|----------|
-| openai | 3 failures | 60s | Use gpt-5.2-mini |
+| openai | 3 failures | 60s | Use gpt-5-mini |
 | anthropic | 3 failures | 60s | Use cache |
 | youtube | 5 failures | 120s | Return partial data |
 

--- a/plugins/ork/skills/distributed-systems/examples/orchestkit-workflow-resilience.md
+++ b/plugins/ork/skills/distributed-systems/examples/orchestkit-workflow-resilience.md
@@ -337,7 +337,7 @@ analysis_llm_chain = LLMFallbackChain(
         OpenAIProvider(
             LLMConfig(
                 name="fallback",
-                model="gpt-5.2-mini",
+                model="gpt-5-mini",
                 timeout=30.0,
                 max_tokens=4096,
             )

--- a/plugins/ork/skills/distributed-systems/references/llm-resilience.md
+++ b/plugins/ork/skills/distributed-systems/references/llm-resilience.md
@@ -355,8 +355,8 @@ class CostCircuitBreaker:
         """Calculate cost based on model pricing (Dec 2025)."""
         PRICING = {
             "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
-            "gpt-5.2": {"input": 2.5, "output": 10.0},
-            "gpt-5.2-mini": {"input": 0.15, "output": 0.60},
+            "gpt-5.5": {"input": 2.5, "output": 10.0},
+            "gpt-5-mini": {"input": 0.15, "output": 0.60},
             "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0},
         }
 
@@ -433,7 +433,7 @@ llm_chain = FallbackChain(
     fallbacks=[
         LLMConfig(
             name="fallback",
-            model="gpt-5.2-mini",
+            model="gpt-5-mini",
             timeout=20.0,
         ),
     ],

--- a/plugins/ork/skills/distributed-systems/references/redis-locks.md
+++ b/plugins/ork/skills/distributed-systems/references/redis-locks.md
@@ -4,6 +4,7 @@
 
 ```python
 import asyncio
+import time
 from datetime import timedelta
 from uuid import UUID
 
@@ -72,7 +73,7 @@ class RedisLock:
     async def acquire(self, timeout: timedelta | None = None) -> bool:
         """Acquire lock with optional timeout."""
         deadline = (
-            asyncio.get_event_loop().time() + timeout.total_seconds()
+            time.monotonic() + timeout.total_seconds()
             if timeout
             else None
         )
@@ -90,7 +91,7 @@ class RedisLock:
                 self._acquired = True
                 return True
 
-            if deadline and asyncio.get_event_loop().time() >= deadline:
+            if deadline and time.monotonic() >= deadline:
                 return False
 
             # Exponential backoff

--- a/plugins/ork/skills/distributed-systems/references/redlock-algorithm.md
+++ b/plugins/ork/skills/distributed-systems/references/redlock-algorithm.md
@@ -139,7 +139,7 @@ class Redlock:
             # Retry with delay + jitter
             if attempt < self._config.retry_count - 1:
                 delay = self._config.retry_delay.total_seconds()
-                jitter = delay * 0.1 * (0.5 - asyncio.get_event_loop().time() % 1)
+                jitter = delay * 0.1 * (0.5 - time.monotonic() % 1)
                 await asyncio.sleep(delay + jitter)
 
         return RedlockResult(acquired=False, resource=resource)

--- a/plugins/ork/skills/distributed-systems/scripts/distributed-lock-template.py
+++ b/plugins/ork/skills/distributed-systems/scripts/distributed-lock-template.py
@@ -9,13 +9,15 @@ Requirements:
     # Or use uuid4 fallback (less optimal for time-ordering)
 """
 
+import asyncio
+import hashlib
+import time
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import AsyncGenerator, Protocol
+from typing import Protocol
 from uuid import uuid4
-import asyncio
-import hashlib
 
 # UUIDv7 preferred for time-ordered IDs (better for indexes)
 # Falls back to uuid4 if uuid-utils not installed
@@ -119,11 +121,7 @@ class RedisDistributedLock(DistributedLock):
     async def acquire(self, timeout: timedelta | None = None) -> bool:
         """Acquire lock with retry logic."""
         ttl_ms = int(self._config.ttl.total_seconds() * 1000)
-        deadline = (
-            asyncio.get_event_loop().time() + timeout.total_seconds()
-            if timeout
-            else None
-        )
+        deadline = time.monotonic() + timeout.total_seconds() if timeout else None
 
         for attempt in range(self._config.retry_count):
             result = await self._client.eval(
@@ -139,11 +137,11 @@ class RedisDistributedLock(DistributedLock):
                 self._start_auto_extend()
                 return True
 
-            if deadline and asyncio.get_event_loop().time() >= deadline:
+            if deadline and time.monotonic() >= deadline:
                 return False
 
             # Exponential backoff with jitter
-            delay = self._config.retry_delay.total_seconds() * (2 ** attempt)
+            delay = self._config.retry_delay.total_seconds() * (2**attempt)
             jitter = delay * 0.1
             await asyncio.sleep(delay + jitter)
 
@@ -267,9 +265,7 @@ class PostgresAdvisoryLock(DistributedLock):
         else:
             # Blocking with statement timeout
             timeout_ms = int(timeout.total_seconds() * 1000) if timeout else 10000
-            await self._session.execute(
-                text(f"SET LOCAL statement_timeout = {timeout_ms}")
-            )
+            await self._session.execute(text(f"SET LOCAL statement_timeout = {timeout_ms}"))
             try:
                 await self._session.execute(
                     text(f"SELECT {func}(:lock_id)"),
@@ -279,9 +275,7 @@ class PostgresAdvisoryLock(DistributedLock):
             except Exception:
                 self._acquired = False
             finally:
-                await self._session.execute(
-                    text("SET LOCAL statement_timeout = 0")
-                )
+                await self._session.execute(text("SET LOCAL statement_timeout = 0"))
 
         return self._acquired
 
@@ -357,7 +351,7 @@ async def distributed_lock(
     name: str,
     client,  # Redis client or SQLAlchemy session
     config: LockConfig | None = None,
-) -> AsyncGenerator[DistributedLock, None]:
+) -> AsyncGenerator[DistributedLock]:
     """Factory for distributed locks.
 
     Args:

--- a/plugins/ork/skills/distributed-systems/scripts/llm-fallback-chain.py
+++ b/plugins/ork/skills/distributed-systems/scripts/llm-fallback-chain.py
@@ -10,7 +10,7 @@ Multi-model fallback implementation with:
 Usage:
     chain = LLMFallbackChain(
         primary=LLMProvider("claude-sonnet-4-6"),
-        fallbacks=[LLMProvider("gpt-5.2-mini")],
+        fallbacks=[LLMProvider("gpt-5-mini")],
         cache=semantic_cache,
     )
 
@@ -32,6 +32,7 @@ T = TypeVar("T")
 
 class ResponseSource(Enum):
     """Source of the LLM response."""
+
     PRIMARY = "primary"
     FALLBACK = "fallback"
     CACHE = "cache"
@@ -41,6 +42,7 @@ class ResponseSource(Enum):
 @dataclass
 class LLMResponse:
     """Response from LLM with metadata."""
+
     content: str
     source: ResponseSource
     model: str | None = None
@@ -60,6 +62,7 @@ class LLMResponse:
 @dataclass
 class LLMConfig:
     """Configuration for an LLM provider."""
+
     name: str
     model: str
     api_key: str | None = None
@@ -118,6 +121,7 @@ class SemanticCache(ABC):
 @dataclass
 class FallbackChainStats:
     """Statistics for fallback chain."""
+
     total_calls: int = 0
     primary_successes: int = 0
     fallback_successes: int = 0
@@ -309,9 +313,7 @@ class LLMFallbackChain:
                 else 0
             ),
             "cache_hit_rate": (
-                self.stats.cache_hits / self.stats.total_calls
-                if self.stats.total_calls > 0
-                else 0
+                self.stats.cache_hits / self.stats.total_calls if self.stats.total_calls > 0 else 0
             ),
         }
 
@@ -357,7 +359,9 @@ class QualityAwareFallbackChain(LLMFallbackChain):
 
         for attempt in range(self.max_quality_retries + 1):
             # Get response from chain
-            response = await super().complete(prompt, use_cache=use_cache, cache_result=cache_result, **kwargs)
+            response = await super().complete(
+                prompt, use_cache=use_cache, cache_result=cache_result, **kwargs
+            )
 
             # If no quality evaluator, return immediately
             if not self.quality_evaluator:
@@ -397,6 +401,7 @@ class QualityAwareFallbackChain(LLMFallbackChain):
 
 class AllModelsFailedError(Exception):
     """Raised when all LLM models in the chain fail."""
+
     pass
 
 
@@ -438,6 +443,7 @@ class MockLLMProvider(LLMProvider):
 
 # Example usage
 if __name__ == "__main__":
+
     async def main():
         # Create providers
         primary = MockLLMProvider(
@@ -453,7 +459,7 @@ if __name__ == "__main__":
         fallback = MockLLMProvider(
             LLMConfig(
                 name="fallback",
-                model="gpt-5.2-mini",
+                model="gpt-5-mini",
                 cost_per_million_input=0.15,
                 cost_per_million_output=0.60,
             ),
@@ -472,9 +478,11 @@ if __name__ == "__main__":
         print("Testing fallback chain:")
         for i in range(10):
             response = await chain.complete(f"Test prompt {i}")
-            print(f"  {i+1}. Source: {response.source.value}, "
-                  f"Model: {response.model}, "
-                  f"Degraded: {response.is_degraded}")
+            print(
+                f"  {i + 1}. Source: {response.source.value}, "
+                f"Model: {response.model}, "
+                f"Degraded: {response.is_degraded}"
+            )
 
         print(f"\nStats: {chain.get_stats()}")
 

--- a/plugins/ork/skills/distributed-systems/scripts/token-budget.py
+++ b/plugins/ork/skills/distributed-systems/scripts/token-budget.py
@@ -30,15 +30,17 @@ logger = logging.getLogger(__name__)
 
 class TruncationStrategy(Enum):
     """Strategy for truncating content that exceeds budget."""
-    TRUNCATE_END = "truncate_end"      # Cut from the end
+
+    TRUNCATE_END = "truncate_end"  # Cut from the end
     TRUNCATE_START = "truncate_start"  # Cut from the start
-    SUMMARIZE = "summarize"            # Summarize content
+    SUMMARIZE = "summarize"  # Summarize content
     SLIDING_WINDOW = "sliding_window"  # Keep most recent
 
 
 @dataclass
 class BudgetAllocation:
     """Token budget allocation by category."""
+
     system_prompt: int = 2000
     conversation: int = 20000
     retrieved_docs: int = 8000
@@ -48,17 +50,18 @@ class BudgetAllocation:
     @property
     def total_budget(self) -> int:
         return (
-            self.system_prompt +
-            self.conversation +
-            self.retrieved_docs +
-            self.output_reserve +
-            self.safety_margin
+            self.system_prompt
+            + self.conversation
+            + self.retrieved_docs
+            + self.output_reserve
+            + self.safety_margin
         )
 
 
 @dataclass
 class TokenUsage:
     """Track token usage by category."""
+
     system_prompt: int = 0
     conversation: int = 0
     retrieved_docs: int = 0
@@ -69,6 +72,7 @@ class TokenUsage:
 @dataclass
 class BudgetStats:
     """Statistics for token budget usage."""
+
     total_requests: int = 0
     truncations: int = 0
     summarizations: int = 0
@@ -85,8 +89,7 @@ class TokenBudgetError(Exception):
         self.required = required
         self.available = available
         super().__init__(
-            f"Token budget exceeded for {category}: "
-            f"required {required}, available {available}"
+            f"Token budget exceeded for {category}: required {required}, available {available}"
         )
 
 
@@ -100,8 +103,8 @@ class TokenCounter:
     # Model to encoding mapping
     MODEL_ENCODINGS = {
         "gpt-4": "cl100k_base",
-        "gpt-5.2": "o200k_base",
-        "gpt-5.2-mini": "o200k_base",
+        "gpt-5.5": "o200k_base",
+        "gpt-5-mini": "o200k_base",
         "gpt-3.5-turbo": "cl100k_base",
         "text-embedding-3-small": "cl100k_base",
         "text-embedding-3-large": "cl100k_base",
@@ -119,9 +122,7 @@ class TokenCounter:
 
             # Try model-specific encoding
             if self.model in self.MODEL_ENCODINGS:
-                self._encoding = tiktoken.get_encoding(
-                    self.MODEL_ENCODINGS[self.model]
-                )
+                self._encoding = tiktoken.get_encoding(self.MODEL_ENCODINGS[self.model])
             else:
                 # Try to get encoding for model directly
                 try:
@@ -129,9 +130,7 @@ class TokenCounter:
                 except KeyError:
                     # Fall back to cl100k_base for unknown models
                     self._encoding = tiktoken.get_encoding("cl100k_base")
-                    logger.warning(
-                        f"Unknown model '{self.model}', using cl100k_base encoding"
-                    )
+                    logger.warning(f"Unknown model '{self.model}', using cl100k_base encoding")
 
         except ImportError:
             logger.warning("tiktoken not available, using approximation")
@@ -350,8 +349,7 @@ class TokenBudgetGuard:
         self.stats.total_tokens_saved += tokens_saved
 
         logger.info(
-            f"Truncated messages from {current_tokens} to {used} tokens "
-            f"(saved {tokens_saved})"
+            f"Truncated messages from {current_tokens} to {used} tokens (saved {tokens_saved})"
         )
 
         return fitted
@@ -411,16 +409,15 @@ class TokenBudgetGuard:
         PRICING = {
             "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
             "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0},
-            "gpt-5.2": {"input": 2.5, "output": 10.0},
-            "gpt-5.2-mini": {"input": 0.15, "output": 0.60},
+            "gpt-5.5": {"input": 2.5, "output": 10.0},
+            "gpt-5-mini": {"input": 0.15, "output": 0.60},
         }
 
         prices = PRICING.get(self.model, {"input": 1.0, "output": 3.0})
 
-        return (
-            (input_tokens / 1_000_000) * prices["input"] +
-            (output_tokens / 1_000_000) * prices["output"]
-        )
+        return (input_tokens / 1_000_000) * prices["input"] + (output_tokens / 1_000_000) * prices[
+            "output"
+        ]
 
     def get_stats(self) -> dict:
         """Get budget guard statistics."""

--- a/plugins/ork/skills/interaction-patterns/rules/interaction-form-ux.md
+++ b/plugins/ork/skills/interaction-patterns/rules/interaction-form-ux.md
@@ -90,7 +90,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 const schema = z.object({
-  email: z.string().email('Enter a valid email address (e.g. name@company.com)'),
+  email: z.email('Enter a valid email address (e.g. name@company.com)'),
   phone: z.string().regex(/^\+?[\d\s-]{7,}$/, 'Enter a phone number (e.g. +1 555 0100)').optional(),
 })
 

--- a/plugins/ork/skills/json-render-catalog/references/storybook-import.md
+++ b/plugins/ork/skills/json-render-catalog/references/storybook-import.md
@@ -52,7 +52,7 @@ The script applies a deterministic mapping. Anything outside this list is **drop
 | `{ control: 'select', options: [...] }` | `z.enum([...])` | Best case — fully constrained |
 | `{ control: 'radio', options: [...] }` | `z.enum([...])` | Same |
 | `{ control: 'color' }` | `z.string().regex(/^#[0-9a-fA-F]{6}$/)` | Hex only |
-| `{ control: 'date' }` | `z.string().datetime()` | ISO-8601 |
+| `{ control: 'date' }` | `z.iso.datetime()` | ISO-8601 |
 | `{ control: 'object' }` | **DROPPED** | Too open-ended for AI safety; add manually with explicit shape |
 | `{ control: 'array' }` | `z.array(z.string()).max(20)` | Length cap; assumed string elements |
 | TypeScript `ReactNode` | `children: 'allowed'` | Marks the catalog entry as a container |

--- a/plugins/ork/skills/json-render-catalog/rules/prop-constraints.md
+++ b/plugins/ork/skills/json-render-catalog/rules/prop-constraints.md
@@ -65,7 +65,7 @@ GoodComponent: {
 | Numeric | `z.number()` | `z.number().int().min(0).max(100)` |
 | Boolean flags | (no constraint) | `z.boolean().default(false)` |
 | Freeform object | `z.record(z.any())` | `z.object({ specific: z.string() })` |
-| URL/image | `z.string()` | `z.string().url().max(2048)` |
+| URL/image | `z.string()` | `z.url().max(2048)` |
 
 ### Refinements for Complex Validation
 

--- a/plugins/ork/skills/json-render-catalog/scripts/storybook-to-catalog.mjs
+++ b/plugins/ork/skills/json-render-catalog/scripts/storybook-to-catalog.mjs
@@ -83,7 +83,7 @@ function argToZod(argType) {
     case 'color':
       return { zod: 'z.string().regex(/^#[0-9a-fA-F]{6}$/)' }
     case 'date':
-      return { zod: 'z.string().datetime()' }
+      return { zod: 'z.iso.datetime()' }
     case 'array': {
       const max = argType.max ?? 20
       return { zod: `z.array(z.string()).max(${max})` }

--- a/plugins/ork/skills/llm-integration/SKILL.md
+++ b/plugins/ork/skills/llm-integration/SKILL.md
@@ -163,7 +163,7 @@ Design, version, and optimize prompts for production LLM applications.
 | Training epochs | 1-3 (more risks overfitting) |
 | Context compression | Anchored iterative (60-80%) |
 | Compress trigger | 70% utilization, target 50% |
-| Judge model | `claude-haiku-4-5-20251001` (cost tier) or `gpt-5.2` |
+| Judge model | `claude-haiku-4-5-20251001` (cost tier) or `gpt-5.5` |
 | Quality threshold | 0.7 production, 0.6 drafts |
 | Few-shot examples | 3-5 diverse, representative |
 | Prompt versioning | Langfuse with labels |

--- a/plugins/ork/skills/llm-integration/references/dpo-alignment.md
+++ b/plugins/ork/skills/llm-integration/references/dpo-alignment.md
@@ -176,7 +176,7 @@ async def generate_preference_pairs(
     for prompt in prompts:
         # Generate good response
         good = await client.chat.completions.create(
-            model="gpt-5.2",
+            model="gpt-5.5",
             messages=[
                 {"role": "system", "content": "Provide a helpful, accurate response."},
                 {"role": "user", "content": prompt}
@@ -185,7 +185,7 @@ async def generate_preference_pairs(
 
         # Generate bad response
         bad = await client.chat.completions.create(
-            model="gpt-5.2",
+            model="gpt-5.5",
             messages=[
                 {"role": "system", "content": "Provide a response that is vague, "
                  "unhelpful, or slightly incorrect."},

--- a/plugins/ork/skills/llm-integration/references/synthetic-data.md
+++ b/plugins/ork/skills/llm-integration/references/synthetic-data.md
@@ -7,7 +7,7 @@ Synthetic data generation uses large teacher models (GPT-4, Claude) to create tr
 ## Teacher-Student Paradigm
 
 ```
-Teacher Model (GPT-5.2) → Generate Examples → Train Student (Llama-8B)
+Teacher Model (GPT-5.5) → Generate Examples → Train Student (Llama-8B)
                                                     ↓
                                               Deploy Student (cheaper)
 ```
@@ -339,16 +339,16 @@ def estimate_generation_cost(
     num_examples: int,
     avg_input_tokens: int = 100,
     avg_output_tokens: int = 300,
-    model: str = "gpt-5.2",
+    model: str = "gpt-5.5",
 ) -> float:
     """Estimate synthetic data generation cost."""
-    # GPT-5.2 pricing (as of 2026)
+    # GPT-5.5 pricing (as of 2026)
     prices = {
-        "gpt-5.2": {"input": 2.50 / 1_000_000, "output": 10.00 / 1_000_000},
+        "gpt-5.5": {"input": 2.50 / 1_000_000, "output": 10.00 / 1_000_000},
         "claude-haiku-4-5-20251001": {"input": 0.15 / 1_000_000, "output": 0.60 / 1_000_000},
     }
 
-    price = prices.get(model, prices["gpt-5.2"])
+    price = prices.get(model, prices["gpt-5.5"])
 
     input_cost = num_examples * avg_input_tokens * price["input"]
     output_cost = num_examples * avg_output_tokens * price["output"]
@@ -356,7 +356,7 @@ def estimate_generation_cost(
     return input_cost + output_cost
 
 
-# Example: 10,000 examples with GPT-4o
+# Example: 10,000 examples with GPT-5.5
 cost = estimate_generation_cost(10000)
 print(f"Estimated cost: ${cost:.2f}")  # ~$32.50
 ```

--- a/plugins/ork/skills/llm-integration/rules/calling-validation.md
+++ b/plugins/ork/skills/llm-integration/rules/calling-validation.md
@@ -69,7 +69,7 @@ class ToolRegistry:
 async def run_tool_loop(
     registry: ToolRegistry,
     user_message: str,
-    model: str = "gpt-5.2",
+    model: str = "gpt-5.5",
     max_iterations: int = 10
 ) -> str:
     """Run tool execution loop with iteration guard."""

--- a/plugins/ork/skills/llm-integration/rules/evaluation-metrics.md
+++ b/plugins/ork/skills/llm-integration/rules/evaluation-metrics.md
@@ -60,7 +60,7 @@ List any unsupported claims."""
 ```
 
 Key decisions:
-- Judge model: `claude-haiku-4-5-20251001` or `gpt-5.2` (different from evaluated model)
+- Judge model: `claude-haiku-4-5-20251001` or `gpt-5.5` (different from evaluated model)
 - Quality threshold: 0.7 production, 0.6 drafts
 - Dimensions: 3-5 most relevant to use case
 - Sample size: 50+ for reliable metrics

--- a/plugins/ork/skills/llm-integration/rules/local-gpu-optimization.md
+++ b/plugins/ork/skills/llm-integration/rules/local-gpu-optimization.md
@@ -28,7 +28,7 @@ def get_llm_provider(task_type: str = "general"):
     else:
         # Fall back to cloud API
         from langchain_openai import ChatOpenAI
-        return ChatOpenAI(model="gpt-5.2")
+        return ChatOpenAI(model="gpt-5.5")
 
 # Usage
 llm = get_llm_provider(task_type="coding")
@@ -109,7 +109,7 @@ async def prewarm_models() -> None:
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-5.2")  # Always uses cloud, ignores local setup
+llm = ChatOpenAI(model="gpt-5.5")  # Always uses cloud, ignores local setup
 response = await llm.ainvoke("Generate code...")
 ```
 
@@ -122,7 +122,7 @@ from langchain_openai import ChatOpenAI
 def get_llm_provider(task_type: str = "general"):
     if os.getenv("OLLAMA_ENABLED") == "true":
         return ChatOllama(model="qwen2.5-coder:32b", keep_alive="5m")
-    return ChatOpenAI(model="gpt-5.2")
+    return ChatOpenAI(model="gpt-5.5")
 
 llm = get_llm_provider(task_type="coding")
 ```

--- a/plugins/ork/skills/llm-integration/rules/streaming-sse.md
+++ b/plugins/ork/skills/llm-integration/rules/streaming-sse.md
@@ -17,7 +17,7 @@ client = AsyncOpenAI()
 async def async_stream(prompt: str):
     """Async streaming for better concurrency."""
     stream = await client.chat.completions.create(
-        model="gpt-5.2",
+        model="gpt-5.5",
         messages=[{"role": "user", "content": prompt}],
         stream=True
     )

--- a/plugins/ork/skills/llm-integration/rules/streaming-structured.md
+++ b/plugins/ork/skills/llm-integration/rules/streaming-structured.md
@@ -13,7 +13,7 @@ tags: [streaming, tool-calls, partial-json, chunk-accumulation, structured]
 async def stream_with_tools(messages: list, tools: list):
     """Handle streaming responses that include tool calls."""
     stream = await client.chat.completions.create(
-        model="gpt-5.2",
+        model="gpt-5.5",
         messages=messages,
         tools=tools,
         stream=True

--- a/plugins/ork/skills/llm-integration/rules/tuning-dataset-prep.md
+++ b/plugins/ork/skills/llm-integration/rules/tuning-dataset-prep.md
@@ -19,7 +19,7 @@ client = AsyncOpenAI()
 async def generate_training_example(topic: str) -> dict:
     """Generate a single training example using teacher model."""
     response = await client.chat.completions.create(
-        model="gpt-5.2",  # Teacher
+        model="gpt-5.5",  # Teacher
         messages=[{
             "role": "system",
             "content": f"Generate a training example about {topic}. "

--- a/plugins/ork/skills/llm-integration/scripts/function-def.py
+++ b/plugins/ork/skills/llm-integration/scripts/function-def.py
@@ -18,6 +18,7 @@ from openai import AsyncOpenAI
 
 # --- Tool Registry ---
 
+
 class ToolRegistry:
     """Registry for managing tool definitions and execution."""
 
@@ -52,9 +53,9 @@ class ToolRegistry:
                     "type": "object",
                     "properties": properties,
                     "required": list(properties.keys()),
-                    "additionalProperties": False
-                }
-            }
+                    "additionalProperties": False,
+                },
+            },
         }
 
     def _python_to_json_type(self, hint) -> str:
@@ -73,11 +74,9 @@ class ToolRegistry:
 
 # --- Tool Execution Loop ---
 
+
 async def run_tool_loop(
-    registry: ToolRegistry,
-    user_message: str,
-    model: str = "gpt-5.2",
-    max_iterations: int = 10
+    registry: ToolRegistry, user_message: str, model: str = "gpt-5.5", max_iterations: int = 10
 ) -> str:
     """Run tool execution loop until completion."""
     client = AsyncOpenAI()
@@ -88,7 +87,7 @@ async def run_tool_loop(
             model=model,
             messages=messages,
             tools=registry.schemas,
-            parallel_tool_calls=False  # Required for strict mode
+            parallel_tool_calls=False,  # Required for strict mode
         )
 
         message = response.choices[0].message
@@ -100,14 +99,11 @@ async def run_tool_loop(
 
         for tool_call in message.tool_calls:
             result = await registry.execute(
-                tool_call.function.name,
-                json.loads(tool_call.function.arguments)
+                tool_call.function.name, json.loads(tool_call.function.arguments)
             )
-            messages.append({
-                "role": "tool",
-                "tool_call_id": tool_call.id,
-                "content": json.dumps(result)
-            })
+            messages.append(
+                {"role": "tool", "tool_call_id": tool_call.id, "content": json.dumps(result)}
+            )
 
     raise RuntimeError("Max iterations reached")
 

--- a/plugins/ork/skills/llm-integration/test-cases.json
+++ b/plugins/ork/skills/llm-integration/test-cases.json
@@ -117,7 +117,7 @@
       "rule": "tuning-dataset-prep",
       "query": "Generate synthetic training data for fine-tuning",
       "expectedBehavior": [
-        "Uses teacher model (GPT-5.2) to generate examples",
+        "Uses teacher model (GPT-5.5) to generate examples",
         "Validates examples with separate validator model",
         "Deduplicates using embedding similarity to remove semantically redundant training examples",
         "Formats as Alpaca or ChatML template for consistent training data structure"

--- a/plugins/ork/skills/monitoring-observability/checklists/langfuse-setup-checklist.md
+++ b/plugins/ork/skills/monitoring-observability/checklists/langfuse-setup-checklist.md
@@ -141,15 +141,14 @@ Langfuse v3 requires ClickHouse (analytics), Redis (queuing), MinIO (blob storag
 
 **Python (backend/app/core/config.py):**
 ```python
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     LANGFUSE_PUBLIC_KEY: str
     LANGFUSE_SECRET_KEY: str
     LANGFUSE_HOST: str = "https://cloud.langfuse.com"
 
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()
 ```
@@ -311,7 +310,7 @@ async def call_claude(prompt: str, model: str = "claude-sonnet-4-6") -> str:
 
 ```python
 @observe(name="llm_call")
-async def call_openai(prompt: str, model: str = "gpt-5.2") -> str:
+async def call_openai(prompt: str, model: str = "gpt-5.5") -> str:
     """Call OpenAI with cost tracking."""
 
     get_client().update_current_observation(
@@ -324,7 +323,7 @@ async def call_openai(prompt: str, model: str = "gpt-5.2") -> str:
         messages=[{"role": "user", "content": prompt}]
     )
 
-    # OpenAI pricing (gpt-5.2: $2.50/MTok input, $10/MTok output)
+    # OpenAI pricing (gpt-5.5: $2.50/MTok input, $10/MTok output)
     input_tokens = response.usage.prompt_tokens
     output_tokens = response.usage.completion_tokens
     cost_usd = (input_tokens / 1_000_000) * 2.50 + (output_tokens / 1_000_000) * 10.00

--- a/plugins/ork/skills/monitoring-observability/references/agent-observability.md
+++ b/plugins/ork/skills/monitoring-observability/references/agent-observability.md
@@ -249,7 +249,7 @@ async def run_openai_agent(query: str):
     agent = Agent(
         name="analyst",
         instructions="You are a code analyst.",
-        model="gpt-5.2",
+        model="gpt-5.5",
     )
     # OpenAI Agents SDK supports Langfuse via OTEL exporter
     result = await Runner.run(agent, query)

--- a/plugins/ork/skills/monitoring-observability/references/experiments-api.md
+++ b/plugins/ork/skills/monitoring-observability/references/experiments-api.md
@@ -286,7 +286,7 @@ async def ab_test_models(dataset_name: str):
 
     configs = {
         "sonnet": {"model": "claude-sonnet-4-6", "temperature": 0.7},
-        "gpt5": {"model": "gpt-5.2", "temperature": 0.7},
+        "gpt5": {"model": "gpt-5.5", "temperature": 0.7},
     }
 
     for name, config in configs.items():

--- a/plugins/ork/skills/monitoring-observability/references/framework-integrations.md
+++ b/plugins/ork/skills/monitoring-observability/references/framework-integrations.md
@@ -77,7 +77,7 @@ async def run_openai_agents(query: str):
     agent = Agent(
         name="research_agent",
         instructions="You are a research assistant.",
-        model="gpt-5.2",
+        model="gpt-5.5",
         tools=[search_docs],
     )
 
@@ -86,7 +86,7 @@ async def run_openai_agents(query: str):
 
     get_client().update_current_observation(
         output=result.final_output,
-        metadata={"agent": "research_agent", "model": "gpt-5.2"},
+        metadata={"agent": "research_agent", "model": "gpt-5.5"},
     )
     return result.final_output
 ```
@@ -217,7 +217,7 @@ async def run_voice_agent(session_id: str):
     assistant = VoiceAssistant(
         vad=silero.VAD.load(),
         stt=openai.STT(),
-        llm=openai.LLM(model="gpt-5.2"),
+        llm=openai.LLM(model="gpt-5.5"),
         tts=openai.TTS(),
     )
 

--- a/plugins/ork/skills/monitoring-observability/references/online-evaluators.md
+++ b/plugins/ork/skills/monitoring-observability/references/online-evaluators.md
@@ -21,7 +21,7 @@ Online evaluators are LLM-as-judge rules configured in the Langfuse UI that run 
 3. Configure:
    - **Name** — e.g., `response-quality`, `safety-check`, `hallucination-detector`
    - **Evaluator type** — select **LLM-as-judge**
-   - **Model** — e.g., `claude-sonnet-4-6`, `gpt-4o`
+   - **Model** — e.g., `claude-sonnet-4-6`, `gpt-5.5`
    - **Score name** — the key stored on the trace (e.g., `quality`, `safety`)
    - **Filter** — which traces to evaluate (by tag, model, metadata field, etc.)
    - **Sampling rate** — evaluate 100% or a random sample (e.g., 10% for high-volume endpoints)

--- a/plugins/ork/skills/rag-retrieval/examples/chatbot-with-rag-example.ts
+++ b/plugins/ork/skills/rag-retrieval/examples/chatbot-with-rag-example.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
 
   // 4. Generate streaming response
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages,
     stream: true
   })
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
 async function shouldUseRAG(message: string, _history: unknown[]): Promise<boolean> {
   // Use a cheap model to determine if RAG is needed
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2-mini',
+    model: 'gpt-5-mini',
     messages: [
       {
         role: 'system',

--- a/plugins/ork/skills/rag-retrieval/rules/hyde-fallback.md
+++ b/plugins/ork/skills/rag-retrieval/rules/hyde-fallback.md
@@ -28,7 +28,7 @@ async def hyde_with_fallback(
 ```
 
 **Performance Tips:**
-- Use fast model (gpt-5.2-mini, claude-haiku-4-5) for generation
+- Use fast model (gpt-5-mini, claude-haiku-4-5) for generation
 - Cache aggressively (queries often repeat)
 - Set tight timeouts (2-3s) with fallback
 - Keep hypothetical docs concise (100-200 tokens)

--- a/plugins/ork/skills/rag-retrieval/rules/hyde-generation.md
+++ b/plugins/ork/skills/rag-retrieval/rules/hyde-generation.md
@@ -31,7 +31,7 @@ async def generate_hyde(
 ) -> HyDEResult:
     """Generate hypothetical document and embed it."""
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content":
                 "Write a short paragraph that would answer this query. "
@@ -66,7 +66,7 @@ async def generate_hyde(
 ```python
 async def generate_hyde(query: str) -> HyDEResult:
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[{"role": "user", "content": query}],
         max_tokens=150
     )
@@ -79,7 +79,7 @@ async def generate_hyde(query: str) -> HyDEResult:
 ```python
 async def generate_hyde(query: str) -> HyDEResult:
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": "Write a short paragraph that would answer this query."},
             {"role": "user", "content": query}
@@ -96,7 +96,7 @@ async def generate_hyde(query: str) -> HyDEResult:
 
 **Key rules:**
 - Embed the hypothetical document, NOT the original query
-- Use fast/cheap model (gpt-5.2-mini, claude-haiku-4-5) for generation
+- Use fast/cheap model (gpt-5-mini, claude-haiku-4-5) for generation
 - Temperature 0.3 for consistent, factual hypothetical docs
 - Keep hypothetical docs concise: 100-200 tokens
 - Adds ~500ms latency — always implement with timeout fallback

--- a/plugins/ork/skills/rag-retrieval/rules/query-decompose.md
+++ b/plugins/ork/skills/rag-retrieval/rules/query-decompose.md
@@ -19,7 +19,7 @@ class ConceptExtraction(BaseModel):
 
 async def decompose_query(query: str, llm: AsyncOpenAI) -> list[str]:
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content":
                 "Extract 2-4 independent concepts from this query. "
@@ -79,7 +79,7 @@ async def decomposed_search(query: str, top_k: int = 10) -> list[dict]:
 
 **Key rules:**
 - Max 2-4 concepts per query (more increases latency without proportional benefit)
-- Use gpt-5.2-mini for decomposition (fast, cheap, good at concept extraction)
+- Use gpt-5-mini for decomposition (fast, cheap, good at concept extraction)
 - RRF fusion is robust and parameter-free for combining per-concept results
 - Cache decomposition results — same query often asked repeatedly
 - Set timeout with fallback to original query if decomposition fails

--- a/plugins/ork/skills/rag-retrieval/rules/reranking-llm.md
+++ b/plugins/ork/skills/rag-retrieval/rules/reranking-llm.md
@@ -15,7 +15,7 @@ async def llm_rerank(query: str, documents: list[dict], llm: AsyncOpenAI, top_k:
     docs_text = "\n\n".join([f"[Doc {i+1}]\n{doc['content'][:300]}..." for i, doc in enumerate(documents)])
 
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": "Rate each document's relevance to the query (0.0-1.0).\nOutput one score per line."},
             {"role": "user", "content": f"Query: {query}\n\nDocuments:\n{docs_text}"}
@@ -62,7 +62,7 @@ async def llm_rerank(query: str, documents: list[dict]) -> list[dict]:
     scores = []
     for doc in documents:  # Sequential LLM calls!
         response = await llm.chat.completions.create(
-            model="gpt-5.2-mini",
+            model="gpt-5-mini",
             messages=[{"role": "user", "content": f"Rate relevance (0-1):\nQuery: {query}\nDoc: {doc['content']}"}]
         )
         scores.append(float(response.choices[0].message.content))
@@ -79,7 +79,7 @@ async def llm_rerank(query: str, documents: list[dict], top_k: int = 10) -> list
     ])
 
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": "Rate each document's relevance (0.0-1.0). One score per line."},
             {"role": "user", "content": f"Query: {query}\n\nDocuments:\n{docs_text}"}

--- a/plugins/ork/skills/rag-retrieval/scripts/rag-pipeline-template.ts
+++ b/plugins/ork/skills/rag-retrieval/scripts/rag-pipeline-template.ts
@@ -163,7 +163,7 @@ async function generateAnswer(
 
   // Generate answer with LLM
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     temperature: 0.1, // Low temperature for factual responses
     messages: [
       {
@@ -279,7 +279,7 @@ async function condenseQuestion(
   }
 
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2-mini', // Cheaper model for this task
+    model: 'gpt-5-mini', // Cheaper model for this task
     messages: [
       {
         role: 'system',

--- a/plugins/ork/skills/rag-retrieval/scripts/scripts/crag-workflow.py
+++ b/plugins/ork/skills/rag-retrieval/scripts/scripts/crag-workflow.py
@@ -27,12 +27,12 @@ import logging
 import operator
 from dataclasses import dataclass
 from enum import Enum
-from typing import Annotated, Literal, Protocol
+from typing import Annotated, Protocol
 
 from langchain_core.documents import Document
 from langchain_core.runnables import Runnable
 from langgraph.graph import END, START, StateGraph
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +135,7 @@ class CRAGState(BaseModel):
     max_retries: int = 2
     used_web_search: bool = False
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 # =============================================================================
@@ -270,9 +269,7 @@ async def grade_documents(state: CRAGState, config: CRAGConfig) -> dict:
     for i, doc in enumerate(state.documents):
         doc_id = doc.metadata.get("id", f"doc_{i}")
 
-        result = await grader.ainvoke(
-            {"question": state.question, "document": doc.page_content}
-        )
+        result = await grader.ainvoke({"question": state.question, "document": doc.page_content})
 
         grading_results[doc_id] = result
 
@@ -336,7 +333,7 @@ async def rewrite_query(state: CRAGState, config: CRAGConfig) -> dict:
     # Provide context about what was retrieved
     ambiguous_topics = [doc.page_content[:100] for doc in state.ambiguous_docs[:3]]
     context = (
-        f"\n\nPrevious retrieval returned these partially relevant topics:\n"
+        "\n\nPrevious retrieval returned these partially relevant topics:\n"
         + "\n".join(ambiguous_topics)
         if ambiguous_topics
         else ""
@@ -369,9 +366,7 @@ async def web_search(state: CRAGState, config: CRAGConfig) -> dict:
     # Use original question for web search (more natural phrasing)
     query = state.original_question or state.question
 
-    web_docs = await searcher.search(
-        query, max_results=config.web_search_max_results
-    )
+    web_docs = await searcher.search(query, max_results=config.web_search_max_results)
 
     # Add to correct docs (web results assumed relevant)
     combined_correct = state.correct_docs + web_docs
@@ -517,9 +512,7 @@ async def crag_query(
     Returns:
         Dict with generation, sources_used, and metadata
     """
-    config = CRAGConfig(
-        retriever=retriever, llm=llm, tavily_api_key=tavily_api_key
-    )
+    config = CRAGConfig(retriever=retriever, llm=llm, tavily_api_key=tavily_api_key)
 
     graph = build_crag(config)
     result = await graph.ainvoke({"question": question})
@@ -541,11 +534,11 @@ async def crag_query(
 
 async def example_usage():
     """Example of using CRAG workflow."""
-    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
     from langchain_community.vectorstores import FAISS
+    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
     # Setup components
-    llm = ChatOpenAI(model="gpt-5.2-mini", temperature=0)
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
 
     # Create a simple retriever
     embeddings = OpenAIEmbeddings()
@@ -577,10 +570,7 @@ async def example_usage():
     print(f"\nSources: {result['sources_used']}")
     print(f"Retries: {result['retry_count']}")
     print(f"Web search used: {result['used_web_search']}")
-    print(
-        f"Docs: {len(result['correct_docs'])} correct, "
-        f"{len(result['ambiguous_docs'])} ambiguous"
-    )
+    print(f"Docs: {len(result['correct_docs'])} correct, {len(result['ambiguous_docs'])} ambiguous")
 
 
 if __name__ == "__main__":

--- a/plugins/ork/skills/rag-retrieval/scripts/scripts/self-rag-graph.py
+++ b/plugins/ork/skills/rag-retrieval/scripts/scripts/self-rag-graph.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 
 import logging
 import operator
-from dataclasses import dataclass, field
-from typing import Annotated, Any, Literal, Protocol
+from dataclasses import dataclass
+from typing import Annotated, Literal, Protocol
 
 from langchain_core.documents import Document
 from langchain_core.runnables import Runnable
 from langgraph.graph import END, START, StateGraph
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +69,7 @@ class LLM(Protocol):
 class RetrievalDecision(BaseModel):
     """Decision on whether to retrieve documents."""
 
-    needs_retrieval: bool = Field(
-        description="Whether retrieval would help answer this query"
-    )
+    needs_retrieval: bool = Field(description="Whether retrieval would help answer this query")
     confidence: float = Field(
         ge=0.0, le=1.0, description="Confidence in answering without retrieval"
     )
@@ -132,8 +130,7 @@ class SelfRAGState(BaseModel):
     max_retries: int = 2
     skip_retrieval: bool = False
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 # =============================================================================
@@ -260,9 +257,7 @@ async def grade_documents(state: SelfRAGState, config: SelfRAGConfig) -> dict:
     for i, doc in enumerate(state.documents):
         doc_id = doc.metadata.get("id", f"doc_{i}")
 
-        grade = await grader.ainvoke(
-            {"question": state.question, "document": doc.page_content}
-        )
+        grade = await grader.ainvoke({"question": state.question, "document": doc.page_content})
 
         grades[doc_id] = grade
         logger.debug(f"Graded {doc_id}: {grade.is_relevant}")
@@ -327,9 +322,7 @@ async def verify_support(state: SelfRAGState, config: SelfRAGConfig) -> dict:
 
     context = "\n\n".join([doc.page_content for doc in state.documents])
 
-    verification = await verifier.ainvoke(
-        {"generation": state.generation, "context": context}
-    )
+    verification = await verifier.ainvoke({"generation": state.generation, "context": context})
 
     logger.info(f"Support verification: {verification.is_supported}")
 
@@ -347,19 +340,15 @@ async def rewrite_query(state: SelfRAGState, config: SelfRAGConfig) -> dict:
             doc.page_content[:100]
             for i, doc in enumerate(state.documents)
             if state.document_grades.get(doc.metadata.get("id", f"doc_{i}"), None)
-            and state.document_grades[
-                doc.metadata.get("id", f"doc_{i}")
-            ].is_relevant
-            == "no"
+            and state.document_grades[doc.metadata.get("id", f"doc_{i}")].is_relevant == "no"
         ][:3]
         if irrelevant_topics:
-            failed_context = f"\n\nPrevious retrieval returned these irrelevant topics:\n" + "\n".join(
-                irrelevant_topics
+            failed_context = (
+                "\n\nPrevious retrieval returned these irrelevant topics:\n"
+                + "\n".join(irrelevant_topics)
             )
 
-    rewritten = await rewriter.ainvoke(
-        {"question": state.question, "context": failed_context}
-    )
+    rewritten = await rewriter.ainvoke({"question": state.question, "context": failed_context})
 
     logger.info(f"Query rewritten: {rewritten.query[:100]}...")
 
@@ -381,9 +370,7 @@ def route_after_grading(state: SelfRAGState, config: SelfRAGConfig) -> str:
     if state.skip_retrieval:
         return "generate"
 
-    relevant_count = sum(
-        1 for g in state.document_grades.values() if g.is_relevant == "yes"
-    )
+    relevant_count = sum(1 for g in state.document_grades.values() if g.is_relevant == "yes")
 
     if relevant_count >= config.min_relevant_docs:
         return "generate"
@@ -401,9 +388,11 @@ def route_after_verification(state: SelfRAGState, config: SelfRAGConfig) -> str:
 
     support_level = state.support_verification.is_supported
 
-    if support_level == "fully":
-        return END
-    elif support_level == "partially" and config.support_threshold == "partially":
+    if (
+        support_level == "fully"
+        or support_level == "partially"
+        and config.support_threshold == "partially"
+    ):
         return END
     elif state.retry_count < config.max_retries:
         return "rewrite"
@@ -429,24 +418,12 @@ def build_self_rag(config: SelfRAGConfig) -> StateGraph:
     workflow = StateGraph(SelfRAGState)
 
     # Add nodes with config binding
-    workflow.add_node(
-        "decide_retrieval", lambda s: decide_retrieval(s, config)
-    )
-    workflow.add_node(
-        "retrieve", lambda s: retrieve_documents(s, config)
-    )
-    workflow.add_node(
-        "grade", lambda s: grade_documents(s, config)
-    )
-    workflow.add_node(
-        "generate", lambda s: generate_answer(s, config)
-    )
-    workflow.add_node(
-        "verify", lambda s: verify_support(s, config)
-    )
-    workflow.add_node(
-        "rewrite", lambda s: rewrite_query(s, config)
-    )
+    workflow.add_node("decide_retrieval", lambda s: decide_retrieval(s, config))
+    workflow.add_node("retrieve", lambda s: retrieve_documents(s, config))
+    workflow.add_node("grade", lambda s: grade_documents(s, config))
+    workflow.add_node("generate", lambda s: generate_answer(s, config))
+    workflow.add_node("verify", lambda s: verify_support(s, config))
+    workflow.add_node("rewrite", lambda s: rewrite_query(s, config))
 
     # Define edges
     workflow.add_edge(START, "decide_retrieval")
@@ -489,11 +466,11 @@ def build_self_rag(config: SelfRAGConfig) -> StateGraph:
 
 async def example_usage():
     """Example of using Self-RAG workflow."""
-    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
     from langchain_community.vectorstores import FAISS
+    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
     # Setup components (replace with your actual setup)
-    llm = ChatOpenAI(model="gpt-5.2-mini", temperature=0)
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
 
     # Create a simple retriever (replace with your vector store)
     embeddings = OpenAIEmbeddings()

--- a/plugins/ork/skills/rag-retrieval/test-cases.json
+++ b/plugins/ork/skills/rag-retrieval/test-cases.json
@@ -119,7 +119,7 @@
       "expectedBehavior": [
         "Generates a hypothetical answer document that mirrors the expected retrieval target language",
         "Embeds the hypothetical doc, NOT the query",
-        "Uses a fast model like gpt-5.2-mini to generate hypothetical documents with low latency",
+        "Uses a fast model like gpt-5-mini to generate hypothetical documents with low latency",
         "Sets temperature to 0.3 for consistent and focused hypothetical document generation output"
       ]
     },

--- a/plugins/ork/skills/react-server-components-framework/references/tanstack-router-patterns.md
+++ b/plugins/ork/skills/react-server-components-framework/references/tanstack-router-patterns.md
@@ -115,7 +115,7 @@ import { useActionState, use } from 'react'
 import { z } from 'zod'
 
 const UrlSchema = z.object({
-  url: z.string().url('Please enter a valid URL'),
+  url: z.url('Please enter a valid URL'),
 })
 
 async function submitUrl(

--- a/plugins/ork/skills/security-patterns/SKILL.md
+++ b/plugins/ork/skills/security-patterns/SKILL.md
@@ -74,7 +74,7 @@ token = jwt.encode(payload, SECRET_KEY, algorithm='HS256')
 // Zod v4 schema validation
 import { z } from 'zod';
 const UserSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   name: z.string().min(2).max(100),
   role: z.enum(['user', 'admin']).default('user'),
 });

--- a/plugins/ork/skills/security-patterns/examples/validation-patterns.md
+++ b/plugins/ork/skills/security-patterns/examples/validation-patterns.md
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 // Request body schema
 const CreateUserSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8).max(100),
   name: z.string().min(2).max(100).transform(s => s.trim()),
   role: z.enum(['user', 'admin']).default('user'),
@@ -74,7 +74,7 @@ app.get('/api/users', validateQuery(PaginationSchema), (req, res) => {
 const NotificationSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('email'),
-    email: z.string().email(),
+    email: z.email(),
     subject: z.string().min(1),
     body: z.string().min(1),
   }),
@@ -152,8 +152,7 @@ function validateFileContent(buffer: Buffer, mimeType: string): boolean {
 ```typescript
 const ALLOWED_DOMAINS = ['api.example.com', 'cdn.example.com'] as const;
 
-const UrlSchema = z.string()
-  .url()
+const UrlSchema = z.url()
   .refine(
     (url) => {
       const { hostname, protocol } = new URL(url);
@@ -237,7 +236,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 const SignupSchema = z.object({
-  email: z.string().email('Invalid email'),
+  email: z.email('Invalid email'),
   password: z.string()
     .min(8, 'Password must be at least 8 characters')
     .regex(/[A-Z]/, 'Must contain uppercase')

--- a/plugins/ork/skills/security-patterns/rules/guardrails-nemo.md
+++ b/plugins/ork/skills/security-patterns/rules/guardrails-nemo.md
@@ -21,7 +21,7 @@ return response  # Raw, unvalidated output!
 models:
   - type: main
     engine: openai
-    model: gpt-5.2
+    model: gpt-5.5
 
 rails:
   config:
@@ -81,7 +81,7 @@ if not input_result.validation_passed:
     return "Invalid input"
 
 llm_output = llm.generate(input_result.validated_output)
-output_result = guard(llm_api=openai.chat.completions.create, model="gpt-5.2",
+output_result = guard(llm_api=openai.chat.completions.create, model="gpt-5.5",
                       messages=[{"role": "user", "content": user_input}])
 
 if output_result.validation_passed:

--- a/plugins/ork/skills/security-patterns/rules/validation-input.md
+++ b/plugins/ork/skills/security-patterns/rules/validation-input.md
@@ -21,7 +21,7 @@ tags: input-validation, zod, pydantic, schema-validation, allowlist
 import { z } from 'zod';
 
 const UserSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   name: z.string().min(2).max(100),
   age: z.coerce.number().int().min(0).max(150),
   role: z.enum(['user', 'admin']).default('user'),
@@ -135,7 +135,7 @@ if (email.includes('@')) {
 **Correct — Server-side schema validation with Zod ensures all input is validated:**
 ```typescript
 app.post('/api/users', validateBody(z.object({
-  email: z.string().email(),
+  email: z.email(),
 })), async (req, res) => {
   // req.body.email is validated regardless of client
 });

--- a/plugins/ork/skills/security-patterns/rules/validation-schemas.md
+++ b/plugins/ork/skills/security-patterns/rules/validation-schemas.md
@@ -14,7 +14,7 @@ tags: file-validation, discriminated-unions, magic-bytes, upload-security
 const NotificationSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('email'),
-    email: z.string().email(),
+    email: z.email(),
     subject: z.string().min(1),
     body: z.string().min(1),
   }),
@@ -63,8 +63,7 @@ function validateFileContent(buffer: Buffer, mimeType: string): boolean {
 ```typescript
 const ALLOWED_DOMAINS = ['api.example.com', 'cdn.example.com'] as const;
 
-const SafeUrlSchema = z.string()
-  .url()
+const SafeUrlSchema = z.url()
   .refine(
     (url) => {
       const { hostname, protocol } = new URL(url);
@@ -82,7 +81,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 const SignupSchema = z.object({
-  email: z.string().email('Invalid email'),
+  email: z.email('Invalid email'),
   password: z.string()
     .min(8, 'Password must be at least 8 characters')
     .regex(/[A-Z]/, 'Must contain uppercase')

--- a/plugins/ork/skills/security-patterns/scripts/validation-schemas.ts
+++ b/plugins/ork/skills/security-patterns/scripts/validation-schemas.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 // Common Field Schemas
 // =============================================================================
 
-export const email = z.string().email();
+export const email = z.email();
 
 export const password = z.string()
   .min(8, 'Password must be at least 8 characters')
@@ -19,7 +19,7 @@ export const password = z.string()
   .regex(/[a-z]/, 'Must contain lowercase letter')
   .regex(/[0-9]/, 'Must contain number');
 
-export const uuid = z.string().uuid();
+export const uuid = z.uuid();
 
 export const slug = z.string()
   .min(1)
@@ -29,7 +29,7 @@ export const slug = z.string()
 export const phone = z.string()
   .regex(/^\+[1-9]\d{1,14}$/, 'Invalid phone number (E.164 format)');
 
-export const url = z.string().url();
+export const url = z.url();
 
 export const isoDate = z.coerce.date();
 
@@ -135,8 +135,7 @@ export type FileUpload = z.infer<typeof FileUploadSchema>;
 
 const ALLOWED_DOMAINS = ['api.example.com', 'cdn.example.com'] as const;
 
-export const SafeUrlSchema = z.string()
-  .url()
+export const SafeUrlSchema = z.url()
   .refine(
     (urlString) => {
       try {
@@ -156,8 +155,7 @@ export const SafeUrlSchema = z.string()
 // =============================================================================
 
 // For async validations like uniqueness checks
-export const UniqueEmailSchema = z.string()
-  .email()
+export const UniqueEmailSchema = z.email()
   .refine(
     async (email) => {
       // Replace with actual database check

--- a/plugins/ork/skills/testing-e2e/rules/validation-end-to-end.md
+++ b/plugins/ork/skills/testing-e2e/rules/validation-end-to-end.md
@@ -36,7 +36,7 @@ export const appRouter = t.router({
     }),
 
   createUser: t.procedure
-    .input(z.object({ email: z.string().email(), name: z.string() }))
+    .input(z.object({ email: z.email(), name: z.string() }))
     .mutation(async ({ input }) => {
       return await db.user.create({ data: input })
     })

--- a/plugins/ork/skills/testing-integration/rules/validation-zod-schema.md
+++ b/plugins/ork/skills/testing-integration/rules/validation-zod-schema.md
@@ -24,8 +24,8 @@ const data: any = await fetch('/api').then(r => r.json())
 import { z } from 'zod'
 
 const UserSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
+  id: z.uuid(),
+  email: z.email(),
   age: z.number().int().positive().max(120),
   role: z.enum(['admin', 'user', 'guest']),
   createdAt: z.date().default(() => new Date())
@@ -43,8 +43,8 @@ const user: User = result.data
 
 **Correct -- branded types to prevent ID confusion:**
 ```typescript
-const UserId = z.string().uuid().brand<'UserId'>()
-const AnalysisId = z.string().uuid().brand<'AnalysisId'>()
+const UserId = z.uuid().brand<'UserId'>()
+const AnalysisId = z.uuid().brand<'AnalysisId'>()
 
 type UserId = z.infer<typeof UserId>
 type AnalysisId = z.infer<typeof AnalysisId>

--- a/plugins/ork/skills/ui-components/rules/forms-react-hook-form.md
+++ b/plugins/ork/skills/ui-components/rules/forms-react-hook-form.md
@@ -32,7 +32,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
 const userSchema = z.object({
-  email: z.string().email('Please enter a valid email'),
+  email: z.email('Please enter a valid email'),
   password: z.string().min(8, 'Minimum 8 characters'),
   confirmPassword: z.string(),
 }).refine((data) => data.password === data.confirmPassword, {

--- a/src/skills/accessibility/examples/wcag-examples.md
+++ b/src/skills/accessibility/examples/wcag-examples.md
@@ -13,7 +13,7 @@ import { useState } from 'react';
 import { z } from 'zod';
 
 const FormSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+  email: z.email('Please enter a valid email address'),
   password: z.string().min(8, 'Password must be at least 8 characters'),
   agreeToTerms: z.boolean().refine((val) => val === true, {
     message: 'You must agree to the terms',

--- a/src/skills/accessibility/scripts/accessible-form-template.tsx
+++ b/src/skills/accessibility/scripts/accessible-form-template.tsx
@@ -29,7 +29,7 @@ const FormSchema = z.object({
   fullName: z.string().min(1, 'Name is required'),
 
   // Email input
-  email: z.string().email('Please enter a valid email address'),
+  email: z.email('Please enter a valid email address'),
 
   // Phone input with custom validation
   phone: z

--- a/src/skills/agent-orchestration/references/crewai-patterns.md
+++ b/src/skills/agent-orchestration/references/crewai-patterns.md
@@ -288,7 +288,7 @@ crew = Crew(
     agents=[manager, researcher, writer],
     tasks=[research_task, write_task, review_task],
     process=Process.hierarchical,
-    manager_llm="gpt-4o",  # Required for hierarchical
+    manager_llm="gpt-5.5",  # Required for hierarchical
     memory=True,
     verbose=True
 )
@@ -308,8 +308,8 @@ agent = Agent(
     backstory="Expert with 10 years experience",
 
     # LLM configuration
-    llm="gpt-4o",
-    function_calling_llm="gpt-4o-mini",  # Cheaper model for tools
+    llm="gpt-5.5",
+    function_calling_llm="gpt-5-mini",  # Cheaper model for tools
     use_system_prompt=True,
 
     # Execution control
@@ -709,7 +709,7 @@ class ReviewFlow(Flow):
     @human_feedback(
         message="Do you approve this content?",
         emit=["approved", "rejected"],
-        llm="gpt-4o-mini"
+        llm="gpt-5-mini"
     )
     def generate_content(self):
         return "Content for human review..."

--- a/src/skills/agent-orchestration/references/framework-comparison.md
+++ b/src/skills/agent-orchestration/references/framework-comparison.md
@@ -76,7 +76,7 @@ agent = AssistantAgent(name="assistant", llm_config=config)
 # MS Agent Framework (new)
 from autogen_agentchat.agents import AssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-model_client = OpenAIChatCompletionClient(model="gpt-5.2")
+model_client = OpenAIChatCompletionClient(model="gpt-5.5")
 agent = AssistantAgent(name="assistant", model_client=model_client)
 ```
 

--- a/src/skills/agent-orchestration/references/microsoft-agent-framework.md
+++ b/src/skills/agent-orchestration/references/microsoft-agent-framework.md
@@ -10,7 +10,7 @@ from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 # Create model client
 model_client = OpenAIChatCompletionClient(
-    model="gpt-5.2",
+    model="gpt-5.5",
     api_key=os.environ["OPENAI_API_KEY"]
 )
 

--- a/src/skills/agent-orchestration/references/openai-agents-sdk.md
+++ b/src/skills/agent-orchestration/references/openai-agents-sdk.md
@@ -20,7 +20,7 @@ from agents import Agent, Runner
 agent = Agent(
     name="assistant",
     instructions="You are a helpful assistant that answers questions.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 # Synchronous run
@@ -44,7 +44,7 @@ session = SQLiteSession(db_path="conversations.db")
 agent = Agent(
     name="assistant",
     instructions="You are a helpful assistant.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 runner = Runner()
@@ -98,7 +98,7 @@ billing_agent = Agent(
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You handle billing inquiries. Check account status and payment issues.
 Hand back to triage when billing issue is resolved.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 support_agent = Agent(
@@ -106,7 +106,7 @@ support_agent = Agent(
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You handle technical support. Troubleshoot issues and provide solutions.
 Hand back to triage when support issue is resolved.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 # Triage agent with handoffs
@@ -117,7 +117,7 @@ You are the first point of contact. Determine the nature of inquiries.
 - Billing questions: hand off to billing
 - Technical issues: hand off to support
 - General questions: answer directly""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     handoffs=[
         handoff(agent=billing_agent),
         handoff(agent=support_agent)
@@ -205,7 +205,7 @@ async with MCPServerManager() as manager:
     agent = Agent(
         name="mcp_agent",
         instructions="Use available tools to help the user.",
-        model="gpt-5.2",
+        model="gpt-5.5",
         mcp_servers=[filesystem_server, api_server]
     )
 
@@ -228,7 +228,7 @@ async with MCPServerStdio(
     agent = Agent(
         name="file_agent",
         instructions="Help with file operations.",
-        model="gpt-5.2",
+        model="gpt-5.5",
         mcp_servers=[server]
     )
     result = await runner.run(agent, "What files are available?")
@@ -256,7 +256,7 @@ def create_ticket(title: str, description: str, priority: str) -> str:
 support_agent = Agent(
     name="support",
     instructions="Help users with technical issues. Search knowledge base first.",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[search_knowledge_base, create_ticket]
 )
 ```
@@ -285,7 +285,7 @@ class ResponseValidator(OutputGuardrail):
 agent = Agent(
     name="safe_assistant",
     instructions="You are a helpful assistant.",
-    model="gpt-5.2",
+    model="gpt-5.5",
     input_guardrails=[ContentFilter()],
     output_guardrails=[ResponseValidator()]
 )
@@ -346,7 +346,7 @@ from agents import Agent, Runner
 agent = Agent(
     name="streamer",
     instructions="Provide detailed explanations.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 runner = Runner()
@@ -428,7 +428,7 @@ config = RunConfig(
 agent = Agent(
     name="assistant",
     instructions="You are helpful.",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 result = await runner.run(agent, "Complex task", run_config=config)

--- a/src/skills/agent-orchestration/rules/frameworks-autogen.md
+++ b/src/skills/agent-orchestration/rules/frameworks-autogen.md
@@ -19,7 +19,7 @@ from autogen_agentchat.conditions import TextMentionTermination
 from autogen_ext.models.openai import OpenAIChatCompletionClient
 
 # Create model client
-model_client = OpenAIChatCompletionClient(model="gpt-5.2")
+model_client = OpenAIChatCompletionClient(model="gpt-5.5")
 
 # Define agents
 planner = AssistantAgent(
@@ -156,21 +156,21 @@ researcher_agent = Agent(
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You are a research specialist. Gather information and facts.
 When research is complete, hand off to the writer.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 writer_agent = Agent(
     name="writer",
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You are a content writer. Create compelling content from research.""",
-    model="gpt-5.2"
+    model="gpt-5.5"
 )
 
 orchestrator = Agent(
     name="orchestrator",
     instructions=f"""{RECOMMENDED_PROMPT_PREFIX}
 You coordinate research and writing tasks.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     handoffs=[handoff(agent=researcher_agent), handoff(agent=writer_agent)]
 )
 

--- a/src/skills/agent-orchestration/rules/frameworks-comparison.md
+++ b/src/skills/agent-orchestration/rules/frameworks-comparison.md
@@ -118,7 +118,7 @@ agent = AssistantAgent(name="assistant", llm_config=config)
 # MS Agent Framework (new)
 from autogen_agentchat.agents import AssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-model_client = OpenAIChatCompletionClient(model="gpt-5.2")
+model_client = OpenAIChatCompletionClient(model="gpt-5.5")
 agent = AssistantAgent(name="assistant", model_client=model_client)
 ```
 
@@ -184,6 +184,6 @@ result = await app.ainvoke({"text": "..."})
 ```python
 # Simple task = single agent
 from langchain_openai import ChatOpenAI
-llm = ChatOpenAI(model="gpt-5.2")
+llm = ChatOpenAI(model="gpt-5.5")
 result = await llm.ainvoke("Summarize this text: ...")
 ```

--- a/src/skills/agent-orchestration/rules/frameworks-crewai.md
+++ b/src/skills/agent-orchestration/rules/frameworks-crewai.md
@@ -55,7 +55,7 @@ crew = Crew(
     agents=[manager, researcher, writer],
     tasks=[project_task],
     process=Process.hierarchical,
-    manager_llm="gpt-5.2",
+    manager_llm="gpt-5.5",
     memory=True,
     verbose=True
 )
@@ -224,6 +224,6 @@ crew = Crew(
     agents=[manager, researcher, writer, reviewer],
     tasks=[project_task],
     process=Process.hierarchical,  # Manager delegates dynamically
-    manager_llm="gpt-5.2"
+    manager_llm="gpt-5.5"
 )
 ```

--- a/src/skills/agent-orchestration/rules/loops-plan-execute.md
+++ b/src/skills/agent-orchestration/rules/loops-plan-execute.md
@@ -84,7 +84,7 @@ When done: Answer: [Final answer]`;
 
   for (let i = 0; i < maxIterations; i++) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2', messages, temperature: 0.1
+      model: 'gpt-5.5', messages, temperature: 0.1
     });
 
     const content = response.choices[0].message.content!;
@@ -135,7 +135,7 @@ export async function functionCallingAgent(task: string): Promise<AgentResult> {
   let iteration = 0;
   while (iteration < 10) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2', messages, tools: openaiTools
+      model: 'gpt-5.5', messages, tools: openaiTools
     });
 
     const message = response.choices[0].message;

--- a/src/skills/agent-orchestration/rules/multi-synthesis.md
+++ b/src/skills/agent-orchestration/rules/multi-synthesis.md
@@ -50,7 +50,7 @@ export async function multiAgentCollaboration(
 
   // 1. Coordinator plans the task
   const planResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       {
         role: 'system',
@@ -70,7 +70,7 @@ Provide a numbered plan with agent assignments.`
   const agentResults = await Promise.all(
     agents.map(async (agent) => {
       const response = await openai.chat.completions.create({
-        model: 'gpt-5.2',
+        model: 'gpt-5.5',
         messages: [
           { role: 'system', content: agent.systemPrompt },
           { role: 'user', content: `Task: ${task}\n\nPlan:\n${plan}\n\nComplete your part.` }
@@ -82,7 +82,7 @@ Provide a numbered plan with agent assignments.`
 
   // 3. Synthesize results
   const synthesisResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       { role: 'system', content: 'Synthesize agent results into a coherent final answer.' },
       { role: 'user', content: `Task: ${task}\n\nAgent Results:\n${JSON.stringify(agentResults, null, 2)}` }

--- a/src/skills/agent-orchestration/scripts/agent-workflow-template.ts
+++ b/src/skills/agent-orchestration/scripts/agent-workflow-template.ts
@@ -160,7 +160,7 @@ IMPORTANT:
 
   for (let i = 0; i < maxIterations; i++) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       messages,
       temperature: 0.1
     })
@@ -237,7 +237,7 @@ export async function functionCallingAgent(task: string): Promise<AgentResult> {
   let iteration = 0
   while (iteration < 10) {
     const response = await openai.chat.completions.create({
-      model: 'gpt-5.2',
+      model: 'gpt-5.5',
       messages,
       tools: openaiTools
     })
@@ -305,7 +305,7 @@ export async function multiAgentCollaboration(
 
   // 1. Coordinator plans the task
   const planResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       {
         role: 'system',
@@ -333,7 +333,7 @@ Provide a numbered plan with agent assignments.`
   const agentResults = await Promise.all(
     agents.map(async (agent) => {
       const response = await openai.chat.completions.create({
-        model: 'gpt-5.2',
+        model: 'gpt-5.5',
         messages: [
           { role: 'system', content: agent.systemPrompt },
           { role: 'user', content: `Task: ${task}\n\nPlan:\n${plan}\n\nComplete your part.` }
@@ -351,7 +351,7 @@ Provide a numbered plan with agent assignments.`
 
   // 3. Synthesize results
   const synthesisResponse = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages: [
       {
         role: 'system',

--- a/src/skills/agent-orchestration/scripts/crewai-crew.py
+++ b/src/skills/agent-orchestration/scripts/crewai-crew.py
@@ -11,13 +11,12 @@ Features:
 """
 
 import json
-import os
 from typing import Any
 
 import structlog
 from crewai import Agent, Crew, Process, Task
 from crewai.tools import tool
-from langfuse import observe, get_client
+from langfuse import get_client, observe
 
 logger = structlog.get_logger()
 
@@ -25,6 +24,7 @@ logger = structlog.get_logger()
 # ============================================================================
 # CUSTOM TOOLS
 # ============================================================================
+
 
 @tool("Search Database")
 def search_database(query: str) -> str:
@@ -52,11 +52,9 @@ def analyze_data(data: str, analysis_type: str) -> str:
     """
     logger.info("Analyzing data", analysis_type=analysis_type)
     # Replace with actual analysis logic
-    return json.dumps({
-        "analysis_type": analysis_type,
-        "findings": ["Finding 1", "Finding 2"],
-        "confidence": 0.85
-    })
+    return json.dumps(
+        {"analysis_type": analysis_type, "findings": ["Finding 1", "Finding 2"], "confidence": 0.85}
+    )
 
 
 @tool("Generate Report")
@@ -79,6 +77,7 @@ def generate_report(title: str, sections: str) -> str:
 # AGENT DEFINITIONS
 # ============================================================================
 
+
 def create_manager_agent() -> Agent:
     """Create the project manager agent that coordinates the team."""
     return Agent(
@@ -92,7 +91,7 @@ def create_manager_agent() -> Agent:
         memory=True,
         verbose=True,
         max_iter=15,  # Maximum iterations for task completion
-        max_retry_limit=2  # Retries on failure
+        max_retry_limit=2,  # Retries on failure
     )
 
 
@@ -108,7 +107,7 @@ def create_researcher_agent() -> Agent:
         memory=True,
         verbose=True,
         tools=[search_database],
-        max_iter=10
+        max_iter=10,
     )
 
 
@@ -124,7 +123,7 @@ def create_analyst_agent() -> Agent:
         memory=True,
         verbose=True,
         tools=[analyze_data],
-        max_iter=10
+        max_iter=10,
     )
 
 
@@ -140,13 +139,14 @@ def create_writer_agent() -> Agent:
         memory=True,
         verbose=True,
         tools=[generate_report],
-        max_iter=10
+        max_iter=10,
     )
 
 
 # ============================================================================
 # TASK DEFINITIONS
 # ============================================================================
+
 
 def create_research_task(researcher: Agent, topic: str) -> Task:
     """Create the research gathering task."""
@@ -166,7 +166,7 @@ def create_research_task(researcher: Agent, topic: str) -> Task:
         - Key findings organized by theme
         - Supporting data and sources
         - Initial observations""",
-        agent=researcher
+        agent=researcher,
     )
 
 
@@ -188,7 +188,7 @@ def create_analysis_task(analyst: Agent, research_task: Task) -> Task:
         - Top 3-5 recommendations
         - Confidence scores for findings""",
         agent=analyst,
-        context=[research_task]  # Receives research output
+        context=[research_task],  # Receives research output
     )
 
 
@@ -210,13 +210,14 @@ def create_report_task(writer: Agent, analysis_task: Task, topic: str) -> Task:
         - Recommendations with priorities
         - Appendix with supporting data""",
         agent=writer,
-        context=[analysis_task]  # Receives analysis output
+        context=[analysis_task],  # Receives analysis output
     )
 
 
 # ============================================================================
 # CREW ASSEMBLY
 # ============================================================================
+
 
 @observe()
 def create_research_crew(topic: str) -> tuple[Crew, list[Task]]:
@@ -240,11 +241,11 @@ def create_research_crew(topic: str) -> tuple[Crew, list[Task]]:
         agents=[manager, researcher, analyst, writer],
         tasks=tasks,
         process=Process.hierarchical,
-        manager_llm="gpt-5.2",  # Manager uses GPT-5.2 for coordination
+        manager_llm="gpt-5.5",  # Manager uses GPT-5.5 for coordination
         memory=True,  # Enable shared memory
         verbose=True,
         max_rpm=20,  # Rate limit API calls
-        share_crew=False  # Don't share crew state between runs
+        share_crew=False,  # Don't share crew state between runs
     )
 
     return crew, tasks
@@ -253,6 +254,7 @@ def create_research_crew(topic: str) -> tuple[Crew, list[Task]]:
 # ============================================================================
 # EXECUTION
 # ============================================================================
+
 
 @observe()
 def run_research_crew(topic: str) -> dict[str, Any]:
@@ -264,10 +266,7 @@ def run_research_crew(topic: str) -> dict[str, Any]:
     Returns:
         Dictionary with crew results and metadata
     """
-    get_client().update_current_trace(
-        name="crewai_research",
-        metadata={"topic": topic}
-    )
+    get_client().update_current_trace(name="crewai_research", metadata={"topic": topic})
 
     logger.info("Starting research crew", topic=topic)
 
@@ -282,43 +281,34 @@ def run_research_crew(topic: str) -> dict[str, Any]:
         for task in tasks:
             task_outputs[task.agent.role] = task.output.raw if task.output else None
 
-        logger.info(
-            "Research crew completed",
-            topic=topic,
-            tasks_completed=len(tasks)
-        )
+        logger.info("Research crew completed", topic=topic, tasks_completed=len(tasks))
 
         get_client().update_current_observation(
-            output={"status": "success", "tasks_completed": len(tasks)},
-            metadata={"topic": topic}
+            output={"status": "success", "tasks_completed": len(tasks)}, metadata={"topic": topic}
         )
 
         return {
             "status": "success",
             "topic": topic,
-            "final_report": result.raw if hasattr(result, 'raw') else str(result),
+            "final_report": result.raw if hasattr(result, "raw") else str(result),
             "task_outputs": task_outputs,
-            "tokens_used": result.token_usage if hasattr(result, 'token_usage') else None
+            "tokens_used": result.token_usage if hasattr(result, "token_usage") else None,
         }
 
     except Exception as e:
         logger.error("Research crew failed", topic=topic, error=str(e))
 
         get_client().update_current_observation(
-            output={"status": "error", "error": str(e)},
-            level="error"
+            output={"status": "error", "error": str(e)}, level="error"
         )
 
-        return {
-            "status": "error",
-            "topic": topic,
-            "error": str(e)
-        }
+        return {"status": "error", "topic": topic, "error": str(e)}
 
 
 # ============================================================================
 # ASYNC EXECUTION (Alternative)
 # ============================================================================
+
 
 @observe()
 async def run_research_crew_async(topic: str) -> dict[str, Any]:
@@ -341,16 +331,12 @@ async def run_research_crew_async(topic: str) -> dict[str, Any]:
         return {
             "status": "success",
             "topic": topic,
-            "final_report": result.raw if hasattr(result, 'raw') else str(result)
+            "final_report": result.raw if hasattr(result, "raw") else str(result),
         }
 
     except Exception as e:
         logger.error("Async research crew failed", error=str(e))
-        return {
-            "status": "error",
-            "topic": topic,
-            "error": str(e)
-        }
+        return {"status": "error", "topic": topic, "error": str(e)}
 
 
 # ============================================================================

--- a/src/skills/agent-orchestration/scripts/openai-multi-agent.py
+++ b/src/skills/agent-orchestration/scripts/openai-multi-agent.py
@@ -163,7 +163,7 @@ When the technical issue is resolved or requires escalation,
 hand back to the triage agent with a summary.
 
 Always be patient and clear in your explanations.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[search_knowledge_base, create_support_ticket]
 )
 
@@ -184,7 +184,7 @@ When the billing issue is resolved or requires escalation,
 hand back to the triage agent with a summary.
 
 Be empathetic and transparent about billing matters.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[check_account_status, process_refund]
 )
 
@@ -205,7 +205,7 @@ When the account matter is resolved, hand back to the
 triage agent with a summary.
 
 Be helpful and proactive in suggesting improvements.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     tools=[check_account_status]
 )
 
@@ -233,7 +233,7 @@ When specialists hand back to you:
 3. Route to another specialist if needed
 
 Always be friendly, professional, and efficient.""",
-    model="gpt-5.2",
+    model="gpt-5.5",
     handoffs=[
         handoff(agent=technical_agent),
         handoff(agent=billing_agent),

--- a/src/skills/api-design/examples/fastapi-problem-details.md
+++ b/src/skills/api-design/examples/fastapi-problem-details.md
@@ -6,7 +6,7 @@ Complete example implementing RFC 9457 Problem Details in FastAPI.
 
 ```python
 # app/core/exceptions.py
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime, timezone
 from typing import Any
 
@@ -36,8 +36,8 @@ class ProblemDetail(BaseModel):
     trace_id: str | None = None
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "type": "https://api.orchestkit.dev/problems/validation-error",
                 "title": "Validation Error",
@@ -48,6 +48,7 @@ class ProblemDetail(BaseModel):
                 "timestamp": "2026-01-07T10:30:00Z",
             }
         }
+    )
 
 
 class ValidationProblem(ProblemDetail):

--- a/src/skills/api-design/examples/orchestkit-api-design.md
+++ b/src/skills/api-design/examples/orchestkit-api-design.md
@@ -318,11 +318,13 @@ GET /api/v1/health
 **Location**: `backend/app/api/schemas/errors.py`
 
 ```python
+from pydantic import BaseModel, ConfigDict
+
 class ErrorResponse(BaseModel):
     error: dict[str, Any]
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "error": {
                     "code": "VALIDATION_ERROR",
@@ -331,6 +333,7 @@ class ErrorResponse(BaseModel):
                 }
             }
         }
+    )
 ```
 
 ### Example Error Responses

--- a/src/skills/api-design/references/rest-patterns.md
+++ b/src/skills/api-design/references/rest-patterns.md
@@ -412,6 +412,8 @@ GET /api/v1/analyses?fields=id,title,status
 
 ```python
 # app/api/schemas/errors.py
+from pydantic import BaseModel, ConfigDict
+
 class ErrorDetail(BaseModel):
     field: str
     message: str
@@ -420,8 +422,8 @@ class ErrorDetail(BaseModel):
 class ErrorResponse(BaseModel):
     error: dict[str, Any]
 
-    class Config:
-        json_schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "error": {
                     "code": "VALIDATION_ERROR",
@@ -438,6 +440,7 @@ class ErrorResponse(BaseModel):
                 }
             }
         }
+    )
 ```
 
 ### FastAPI Exception Handlers

--- a/src/skills/api-design/rules/streaming-sse.md
+++ b/src/skills/api-design/rules/streaming-sse.md
@@ -54,7 +54,7 @@ export async function GET(req: Request) {
 ```typescript
 export async function POST(req: Request) {
   const { messages } = await req.json()
-  const stream = await openai.chat.completions.create({ model: 'gpt-5.2', messages, stream: true })
+  const stream = await openai.chat.completions.create({ model: 'gpt-5.5', messages, stream: true })
   const encoder = new TextEncoder()
 
   return new Response(

--- a/src/skills/architecture-patterns/references/backend-layer-separation.md
+++ b/src/skills/architecture-patterns/references/backend-layer-separation.md
@@ -195,7 +195,7 @@ async def get_user(user_id: int) -> User:
 
 # For unavoidable sync code, use run_in_executor
 async def process_file(file_path: str) -> bytes:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None,
         lambda: open(file_path, 'rb').read()

--- a/src/skills/architecture-patterns/references/layer-rules.md
+++ b/src/skills/architecture-patterns/references/layer-rules.md
@@ -184,7 +184,7 @@ async def get_user(user_id: int) -> User:
 
 # For unavoidable sync code, use run_in_executor
 async def process_file(file_path: str) -> bytes:
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None,
         lambda: open(file_path, 'rb').read()

--- a/src/skills/architecture-patterns/rules/right-sizing-decision.md
+++ b/src/skills/architecture-patterns/rules/right-sizing-decision.md
@@ -13,17 +13,17 @@ Context-aware recommendations for ORM, auth, error handling, and testing by proj
 ```python
 # MVP with 0 users, building custom JWT from scratch
 import jwt
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from passlib.context import CryptContext
 
 pwd_context = CryptContext(schemes=["argon2"])
 
 def create_access_token(user_id: str) -> str:
-    expire = datetime.utcnow() + timedelta(minutes=15)
+    expire = datetime.now(UTC) + timedelta(minutes=15)
     return jwt.encode({"sub": user_id, "exp": expire}, SECRET_KEY)
 
 def create_refresh_token(user_id: str) -> str:
-    expire = datetime.utcnow() + timedelta(days=7)
+    expire = datetime.now(UTC) + timedelta(days=7)
     return jwt.encode({"sub": user_id, "exp": expire, "type": "refresh"}, SECRET_KEY)
 
 # +200 LOC for token rotation, revocation, middleware...

--- a/src/skills/distributed-systems/checklists/circuit-breaker-setup.md
+++ b/src/skills/distributed-systems/checklists/circuit-breaker-setup.md
@@ -281,7 +281,7 @@ Add to your service's README:
 
 | Service | Threshold | Recovery | Fallback |
 |---------|-----------|----------|----------|
-| openai | 3 failures | 60s | Use gpt-5.2-mini |
+| openai | 3 failures | 60s | Use gpt-5-mini |
 | anthropic | 3 failures | 60s | Use cache |
 | youtube | 5 failures | 120s | Return partial data |
 

--- a/src/skills/distributed-systems/examples/orchestkit-workflow-resilience.md
+++ b/src/skills/distributed-systems/examples/orchestkit-workflow-resilience.md
@@ -337,7 +337,7 @@ analysis_llm_chain = LLMFallbackChain(
         OpenAIProvider(
             LLMConfig(
                 name="fallback",
-                model="gpt-5.2-mini",
+                model="gpt-5-mini",
                 timeout=30.0,
                 max_tokens=4096,
             )

--- a/src/skills/distributed-systems/references/llm-resilience.md
+++ b/src/skills/distributed-systems/references/llm-resilience.md
@@ -355,8 +355,8 @@ class CostCircuitBreaker:
         """Calculate cost based on model pricing (Dec 2025)."""
         PRICING = {
             "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
-            "gpt-5.2": {"input": 2.5, "output": 10.0},
-            "gpt-5.2-mini": {"input": 0.15, "output": 0.60},
+            "gpt-5.5": {"input": 2.5, "output": 10.0},
+            "gpt-5-mini": {"input": 0.15, "output": 0.60},
             "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0},
         }
 
@@ -433,7 +433,7 @@ llm_chain = FallbackChain(
     fallbacks=[
         LLMConfig(
             name="fallback",
-            model="gpt-5.2-mini",
+            model="gpt-5-mini",
             timeout=20.0,
         ),
     ],

--- a/src/skills/distributed-systems/references/redis-locks.md
+++ b/src/skills/distributed-systems/references/redis-locks.md
@@ -4,6 +4,7 @@
 
 ```python
 import asyncio
+import time
 from datetime import timedelta
 from uuid import UUID
 
@@ -72,7 +73,7 @@ class RedisLock:
     async def acquire(self, timeout: timedelta | None = None) -> bool:
         """Acquire lock with optional timeout."""
         deadline = (
-            asyncio.get_event_loop().time() + timeout.total_seconds()
+            time.monotonic() + timeout.total_seconds()
             if timeout
             else None
         )
@@ -90,7 +91,7 @@ class RedisLock:
                 self._acquired = True
                 return True
 
-            if deadline and asyncio.get_event_loop().time() >= deadline:
+            if deadline and time.monotonic() >= deadline:
                 return False
 
             # Exponential backoff

--- a/src/skills/distributed-systems/references/redlock-algorithm.md
+++ b/src/skills/distributed-systems/references/redlock-algorithm.md
@@ -139,7 +139,7 @@ class Redlock:
             # Retry with delay + jitter
             if attempt < self._config.retry_count - 1:
                 delay = self._config.retry_delay.total_seconds()
-                jitter = delay * 0.1 * (0.5 - asyncio.get_event_loop().time() % 1)
+                jitter = delay * 0.1 * (0.5 - time.monotonic() % 1)
                 await asyncio.sleep(delay + jitter)
 
         return RedlockResult(acquired=False, resource=resource)

--- a/src/skills/distributed-systems/scripts/distributed-lock-template.py
+++ b/src/skills/distributed-systems/scripts/distributed-lock-template.py
@@ -9,13 +9,15 @@ Requirements:
     # Or use uuid4 fallback (less optimal for time-ordering)
 """
 
+import asyncio
+import hashlib
+import time
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import AsyncGenerator, Protocol
+from typing import Protocol
 from uuid import uuid4
-import asyncio
-import hashlib
 
 # UUIDv7 preferred for time-ordered IDs (better for indexes)
 # Falls back to uuid4 if uuid-utils not installed
@@ -119,11 +121,7 @@ class RedisDistributedLock(DistributedLock):
     async def acquire(self, timeout: timedelta | None = None) -> bool:
         """Acquire lock with retry logic."""
         ttl_ms = int(self._config.ttl.total_seconds() * 1000)
-        deadline = (
-            asyncio.get_event_loop().time() + timeout.total_seconds()
-            if timeout
-            else None
-        )
+        deadline = time.monotonic() + timeout.total_seconds() if timeout else None
 
         for attempt in range(self._config.retry_count):
             result = await self._client.eval(
@@ -139,11 +137,11 @@ class RedisDistributedLock(DistributedLock):
                 self._start_auto_extend()
                 return True
 
-            if deadline and asyncio.get_event_loop().time() >= deadline:
+            if deadline and time.monotonic() >= deadline:
                 return False
 
             # Exponential backoff with jitter
-            delay = self._config.retry_delay.total_seconds() * (2 ** attempt)
+            delay = self._config.retry_delay.total_seconds() * (2**attempt)
             jitter = delay * 0.1
             await asyncio.sleep(delay + jitter)
 
@@ -267,9 +265,7 @@ class PostgresAdvisoryLock(DistributedLock):
         else:
             # Blocking with statement timeout
             timeout_ms = int(timeout.total_seconds() * 1000) if timeout else 10000
-            await self._session.execute(
-                text(f"SET LOCAL statement_timeout = {timeout_ms}")
-            )
+            await self._session.execute(text(f"SET LOCAL statement_timeout = {timeout_ms}"))
             try:
                 await self._session.execute(
                     text(f"SELECT {func}(:lock_id)"),
@@ -279,9 +275,7 @@ class PostgresAdvisoryLock(DistributedLock):
             except Exception:
                 self._acquired = False
             finally:
-                await self._session.execute(
-                    text("SET LOCAL statement_timeout = 0")
-                )
+                await self._session.execute(text("SET LOCAL statement_timeout = 0"))
 
         return self._acquired
 
@@ -357,7 +351,7 @@ async def distributed_lock(
     name: str,
     client,  # Redis client or SQLAlchemy session
     config: LockConfig | None = None,
-) -> AsyncGenerator[DistributedLock, None]:
+) -> AsyncGenerator[DistributedLock]:
     """Factory for distributed locks.
 
     Args:

--- a/src/skills/distributed-systems/scripts/llm-fallback-chain.py
+++ b/src/skills/distributed-systems/scripts/llm-fallback-chain.py
@@ -10,7 +10,7 @@ Multi-model fallback implementation with:
 Usage:
     chain = LLMFallbackChain(
         primary=LLMProvider("claude-sonnet-4-6"),
-        fallbacks=[LLMProvider("gpt-5.2-mini")],
+        fallbacks=[LLMProvider("gpt-5-mini")],
         cache=semantic_cache,
     )
 
@@ -32,6 +32,7 @@ T = TypeVar("T")
 
 class ResponseSource(Enum):
     """Source of the LLM response."""
+
     PRIMARY = "primary"
     FALLBACK = "fallback"
     CACHE = "cache"
@@ -41,6 +42,7 @@ class ResponseSource(Enum):
 @dataclass
 class LLMResponse:
     """Response from LLM with metadata."""
+
     content: str
     source: ResponseSource
     model: str | None = None
@@ -60,6 +62,7 @@ class LLMResponse:
 @dataclass
 class LLMConfig:
     """Configuration for an LLM provider."""
+
     name: str
     model: str
     api_key: str | None = None
@@ -118,6 +121,7 @@ class SemanticCache(ABC):
 @dataclass
 class FallbackChainStats:
     """Statistics for fallback chain."""
+
     total_calls: int = 0
     primary_successes: int = 0
     fallback_successes: int = 0
@@ -309,9 +313,7 @@ class LLMFallbackChain:
                 else 0
             ),
             "cache_hit_rate": (
-                self.stats.cache_hits / self.stats.total_calls
-                if self.stats.total_calls > 0
-                else 0
+                self.stats.cache_hits / self.stats.total_calls if self.stats.total_calls > 0 else 0
             ),
         }
 
@@ -357,7 +359,9 @@ class QualityAwareFallbackChain(LLMFallbackChain):
 
         for attempt in range(self.max_quality_retries + 1):
             # Get response from chain
-            response = await super().complete(prompt, use_cache=use_cache, cache_result=cache_result, **kwargs)
+            response = await super().complete(
+                prompt, use_cache=use_cache, cache_result=cache_result, **kwargs
+            )
 
             # If no quality evaluator, return immediately
             if not self.quality_evaluator:
@@ -397,6 +401,7 @@ class QualityAwareFallbackChain(LLMFallbackChain):
 
 class AllModelsFailedError(Exception):
     """Raised when all LLM models in the chain fail."""
+
     pass
 
 
@@ -438,6 +443,7 @@ class MockLLMProvider(LLMProvider):
 
 # Example usage
 if __name__ == "__main__":
+
     async def main():
         # Create providers
         primary = MockLLMProvider(
@@ -453,7 +459,7 @@ if __name__ == "__main__":
         fallback = MockLLMProvider(
             LLMConfig(
                 name="fallback",
-                model="gpt-5.2-mini",
+                model="gpt-5-mini",
                 cost_per_million_input=0.15,
                 cost_per_million_output=0.60,
             ),
@@ -472,9 +478,11 @@ if __name__ == "__main__":
         print("Testing fallback chain:")
         for i in range(10):
             response = await chain.complete(f"Test prompt {i}")
-            print(f"  {i+1}. Source: {response.source.value}, "
-                  f"Model: {response.model}, "
-                  f"Degraded: {response.is_degraded}")
+            print(
+                f"  {i + 1}. Source: {response.source.value}, "
+                f"Model: {response.model}, "
+                f"Degraded: {response.is_degraded}"
+            )
 
         print(f"\nStats: {chain.get_stats()}")
 

--- a/src/skills/distributed-systems/scripts/token-budget.py
+++ b/src/skills/distributed-systems/scripts/token-budget.py
@@ -30,15 +30,17 @@ logger = logging.getLogger(__name__)
 
 class TruncationStrategy(Enum):
     """Strategy for truncating content that exceeds budget."""
-    TRUNCATE_END = "truncate_end"      # Cut from the end
+
+    TRUNCATE_END = "truncate_end"  # Cut from the end
     TRUNCATE_START = "truncate_start"  # Cut from the start
-    SUMMARIZE = "summarize"            # Summarize content
+    SUMMARIZE = "summarize"  # Summarize content
     SLIDING_WINDOW = "sliding_window"  # Keep most recent
 
 
 @dataclass
 class BudgetAllocation:
     """Token budget allocation by category."""
+
     system_prompt: int = 2000
     conversation: int = 20000
     retrieved_docs: int = 8000
@@ -48,17 +50,18 @@ class BudgetAllocation:
     @property
     def total_budget(self) -> int:
         return (
-            self.system_prompt +
-            self.conversation +
-            self.retrieved_docs +
-            self.output_reserve +
-            self.safety_margin
+            self.system_prompt
+            + self.conversation
+            + self.retrieved_docs
+            + self.output_reserve
+            + self.safety_margin
         )
 
 
 @dataclass
 class TokenUsage:
     """Track token usage by category."""
+
     system_prompt: int = 0
     conversation: int = 0
     retrieved_docs: int = 0
@@ -69,6 +72,7 @@ class TokenUsage:
 @dataclass
 class BudgetStats:
     """Statistics for token budget usage."""
+
     total_requests: int = 0
     truncations: int = 0
     summarizations: int = 0
@@ -85,8 +89,7 @@ class TokenBudgetError(Exception):
         self.required = required
         self.available = available
         super().__init__(
-            f"Token budget exceeded for {category}: "
-            f"required {required}, available {available}"
+            f"Token budget exceeded for {category}: required {required}, available {available}"
         )
 
 
@@ -100,8 +103,8 @@ class TokenCounter:
     # Model to encoding mapping
     MODEL_ENCODINGS = {
         "gpt-4": "cl100k_base",
-        "gpt-5.2": "o200k_base",
-        "gpt-5.2-mini": "o200k_base",
+        "gpt-5.5": "o200k_base",
+        "gpt-5-mini": "o200k_base",
         "gpt-3.5-turbo": "cl100k_base",
         "text-embedding-3-small": "cl100k_base",
         "text-embedding-3-large": "cl100k_base",
@@ -119,9 +122,7 @@ class TokenCounter:
 
             # Try model-specific encoding
             if self.model in self.MODEL_ENCODINGS:
-                self._encoding = tiktoken.get_encoding(
-                    self.MODEL_ENCODINGS[self.model]
-                )
+                self._encoding = tiktoken.get_encoding(self.MODEL_ENCODINGS[self.model])
             else:
                 # Try to get encoding for model directly
                 try:
@@ -129,9 +130,7 @@ class TokenCounter:
                 except KeyError:
                     # Fall back to cl100k_base for unknown models
                     self._encoding = tiktoken.get_encoding("cl100k_base")
-                    logger.warning(
-                        f"Unknown model '{self.model}', using cl100k_base encoding"
-                    )
+                    logger.warning(f"Unknown model '{self.model}', using cl100k_base encoding")
 
         except ImportError:
             logger.warning("tiktoken not available, using approximation")
@@ -350,8 +349,7 @@ class TokenBudgetGuard:
         self.stats.total_tokens_saved += tokens_saved
 
         logger.info(
-            f"Truncated messages from {current_tokens} to {used} tokens "
-            f"(saved {tokens_saved})"
+            f"Truncated messages from {current_tokens} to {used} tokens (saved {tokens_saved})"
         )
 
         return fitted
@@ -411,16 +409,15 @@ class TokenBudgetGuard:
         PRICING = {
             "claude-sonnet-4-6": {"input": 3.0, "output": 15.0},
             "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0},
-            "gpt-5.2": {"input": 2.5, "output": 10.0},
-            "gpt-5.2-mini": {"input": 0.15, "output": 0.60},
+            "gpt-5.5": {"input": 2.5, "output": 10.0},
+            "gpt-5-mini": {"input": 0.15, "output": 0.60},
         }
 
         prices = PRICING.get(self.model, {"input": 1.0, "output": 3.0})
 
-        return (
-            (input_tokens / 1_000_000) * prices["input"] +
-            (output_tokens / 1_000_000) * prices["output"]
-        )
+        return (input_tokens / 1_000_000) * prices["input"] + (output_tokens / 1_000_000) * prices[
+            "output"
+        ]
 
     def get_stats(self) -> dict:
         """Get budget guard statistics."""

--- a/src/skills/interaction-patterns/rules/interaction-form-ux.md
+++ b/src/skills/interaction-patterns/rules/interaction-form-ux.md
@@ -90,7 +90,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
 const schema = z.object({
-  email: z.string().email('Enter a valid email address (e.g. name@company.com)'),
+  email: z.email('Enter a valid email address (e.g. name@company.com)'),
   phone: z.string().regex(/^\+?[\d\s-]{7,}$/, 'Enter a phone number (e.g. +1 555 0100)').optional(),
 })
 

--- a/src/skills/json-render-catalog/references/storybook-import.md
+++ b/src/skills/json-render-catalog/references/storybook-import.md
@@ -52,7 +52,7 @@ The script applies a deterministic mapping. Anything outside this list is **drop
 | `{ control: 'select', options: [...] }` | `z.enum([...])` | Best case — fully constrained |
 | `{ control: 'radio', options: [...] }` | `z.enum([...])` | Same |
 | `{ control: 'color' }` | `z.string().regex(/^#[0-9a-fA-F]{6}$/)` | Hex only |
-| `{ control: 'date' }` | `z.string().datetime()` | ISO-8601 |
+| `{ control: 'date' }` | `z.iso.datetime()` | ISO-8601 |
 | `{ control: 'object' }` | **DROPPED** | Too open-ended for AI safety; add manually with explicit shape |
 | `{ control: 'array' }` | `z.array(z.string()).max(20)` | Length cap; assumed string elements |
 | TypeScript `ReactNode` | `children: 'allowed'` | Marks the catalog entry as a container |

--- a/src/skills/json-render-catalog/rules/prop-constraints.md
+++ b/src/skills/json-render-catalog/rules/prop-constraints.md
@@ -65,7 +65,7 @@ GoodComponent: {
 | Numeric | `z.number()` | `z.number().int().min(0).max(100)` |
 | Boolean flags | (no constraint) | `z.boolean().default(false)` |
 | Freeform object | `z.record(z.any())` | `z.object({ specific: z.string() })` |
-| URL/image | `z.string()` | `z.string().url().max(2048)` |
+| URL/image | `z.string()` | `z.url().max(2048)` |
 
 ### Refinements for Complex Validation
 

--- a/src/skills/json-render-catalog/scripts/storybook-to-catalog.mjs
+++ b/src/skills/json-render-catalog/scripts/storybook-to-catalog.mjs
@@ -83,7 +83,7 @@ function argToZod(argType) {
     case 'color':
       return { zod: 'z.string().regex(/^#[0-9a-fA-F]{6}$/)' }
     case 'date':
-      return { zod: 'z.string().datetime()' }
+      return { zod: 'z.iso.datetime()' }
     case 'array': {
       const max = argType.max ?? 20
       return { zod: `z.array(z.string()).max(${max})` }

--- a/src/skills/llm-integration/SKILL.md
+++ b/src/skills/llm-integration/SKILL.md
@@ -163,7 +163,7 @@ Design, version, and optimize prompts for production LLM applications.
 | Training epochs | 1-3 (more risks overfitting) |
 | Context compression | Anchored iterative (60-80%) |
 | Compress trigger | 70% utilization, target 50% |
-| Judge model | `claude-haiku-4-5-20251001` (cost tier) or `gpt-5.2` |
+| Judge model | `claude-haiku-4-5-20251001` (cost tier) or `gpt-5.5` |
 | Quality threshold | 0.7 production, 0.6 drafts |
 | Few-shot examples | 3-5 diverse, representative |
 | Prompt versioning | Langfuse with labels |

--- a/src/skills/llm-integration/references/dpo-alignment.md
+++ b/src/skills/llm-integration/references/dpo-alignment.md
@@ -176,7 +176,7 @@ async def generate_preference_pairs(
     for prompt in prompts:
         # Generate good response
         good = await client.chat.completions.create(
-            model="gpt-5.2",
+            model="gpt-5.5",
             messages=[
                 {"role": "system", "content": "Provide a helpful, accurate response."},
                 {"role": "user", "content": prompt}
@@ -185,7 +185,7 @@ async def generate_preference_pairs(
 
         # Generate bad response
         bad = await client.chat.completions.create(
-            model="gpt-5.2",
+            model="gpt-5.5",
             messages=[
                 {"role": "system", "content": "Provide a response that is vague, "
                  "unhelpful, or slightly incorrect."},

--- a/src/skills/llm-integration/references/synthetic-data.md
+++ b/src/skills/llm-integration/references/synthetic-data.md
@@ -7,7 +7,7 @@ Synthetic data generation uses large teacher models (GPT-4, Claude) to create tr
 ## Teacher-Student Paradigm
 
 ```
-Teacher Model (GPT-5.2) → Generate Examples → Train Student (Llama-8B)
+Teacher Model (GPT-5.5) → Generate Examples → Train Student (Llama-8B)
                                                     ↓
                                               Deploy Student (cheaper)
 ```
@@ -339,16 +339,16 @@ def estimate_generation_cost(
     num_examples: int,
     avg_input_tokens: int = 100,
     avg_output_tokens: int = 300,
-    model: str = "gpt-5.2",
+    model: str = "gpt-5.5",
 ) -> float:
     """Estimate synthetic data generation cost."""
-    # GPT-5.2 pricing (as of 2026)
+    # GPT-5.5 pricing (as of 2026)
     prices = {
-        "gpt-5.2": {"input": 2.50 / 1_000_000, "output": 10.00 / 1_000_000},
+        "gpt-5.5": {"input": 2.50 / 1_000_000, "output": 10.00 / 1_000_000},
         "claude-haiku-4-5-20251001": {"input": 0.15 / 1_000_000, "output": 0.60 / 1_000_000},
     }
 
-    price = prices.get(model, prices["gpt-5.2"])
+    price = prices.get(model, prices["gpt-5.5"])
 
     input_cost = num_examples * avg_input_tokens * price["input"]
     output_cost = num_examples * avg_output_tokens * price["output"]
@@ -356,7 +356,7 @@ def estimate_generation_cost(
     return input_cost + output_cost
 
 
-# Example: 10,000 examples with GPT-4o
+# Example: 10,000 examples with GPT-5.5
 cost = estimate_generation_cost(10000)
 print(f"Estimated cost: ${cost:.2f}")  # ~$32.50
 ```

--- a/src/skills/llm-integration/rules/calling-validation.md
+++ b/src/skills/llm-integration/rules/calling-validation.md
@@ -69,7 +69,7 @@ class ToolRegistry:
 async def run_tool_loop(
     registry: ToolRegistry,
     user_message: str,
-    model: str = "gpt-5.2",
+    model: str = "gpt-5.5",
     max_iterations: int = 10
 ) -> str:
     """Run tool execution loop with iteration guard."""

--- a/src/skills/llm-integration/rules/evaluation-metrics.md
+++ b/src/skills/llm-integration/rules/evaluation-metrics.md
@@ -60,7 +60,7 @@ List any unsupported claims."""
 ```
 
 Key decisions:
-- Judge model: `claude-haiku-4-5-20251001` or `gpt-5.2` (different from evaluated model)
+- Judge model: `claude-haiku-4-5-20251001` or `gpt-5.5` (different from evaluated model)
 - Quality threshold: 0.7 production, 0.6 drafts
 - Dimensions: 3-5 most relevant to use case
 - Sample size: 50+ for reliable metrics

--- a/src/skills/llm-integration/rules/local-gpu-optimization.md
+++ b/src/skills/llm-integration/rules/local-gpu-optimization.md
@@ -28,7 +28,7 @@ def get_llm_provider(task_type: str = "general"):
     else:
         # Fall back to cloud API
         from langchain_openai import ChatOpenAI
-        return ChatOpenAI(model="gpt-5.2")
+        return ChatOpenAI(model="gpt-5.5")
 
 # Usage
 llm = get_llm_provider(task_type="coding")
@@ -109,7 +109,7 @@ async def prewarm_models() -> None:
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-5.2")  # Always uses cloud, ignores local setup
+llm = ChatOpenAI(model="gpt-5.5")  # Always uses cloud, ignores local setup
 response = await llm.ainvoke("Generate code...")
 ```
 
@@ -122,7 +122,7 @@ from langchain_openai import ChatOpenAI
 def get_llm_provider(task_type: str = "general"):
     if os.getenv("OLLAMA_ENABLED") == "true":
         return ChatOllama(model="qwen2.5-coder:32b", keep_alive="5m")
-    return ChatOpenAI(model="gpt-5.2")
+    return ChatOpenAI(model="gpt-5.5")
 
 llm = get_llm_provider(task_type="coding")
 ```

--- a/src/skills/llm-integration/rules/streaming-sse.md
+++ b/src/skills/llm-integration/rules/streaming-sse.md
@@ -17,7 +17,7 @@ client = AsyncOpenAI()
 async def async_stream(prompt: str):
     """Async streaming for better concurrency."""
     stream = await client.chat.completions.create(
-        model="gpt-5.2",
+        model="gpt-5.5",
         messages=[{"role": "user", "content": prompt}],
         stream=True
     )

--- a/src/skills/llm-integration/rules/streaming-structured.md
+++ b/src/skills/llm-integration/rules/streaming-structured.md
@@ -13,7 +13,7 @@ tags: [streaming, tool-calls, partial-json, chunk-accumulation, structured]
 async def stream_with_tools(messages: list, tools: list):
     """Handle streaming responses that include tool calls."""
     stream = await client.chat.completions.create(
-        model="gpt-5.2",
+        model="gpt-5.5",
         messages=messages,
         tools=tools,
         stream=True

--- a/src/skills/llm-integration/rules/tuning-dataset-prep.md
+++ b/src/skills/llm-integration/rules/tuning-dataset-prep.md
@@ -19,7 +19,7 @@ client = AsyncOpenAI()
 async def generate_training_example(topic: str) -> dict:
     """Generate a single training example using teacher model."""
     response = await client.chat.completions.create(
-        model="gpt-5.2",  # Teacher
+        model="gpt-5.5",  # Teacher
         messages=[{
             "role": "system",
             "content": f"Generate a training example about {topic}. "

--- a/src/skills/llm-integration/scripts/function-def.py
+++ b/src/skills/llm-integration/scripts/function-def.py
@@ -18,6 +18,7 @@ from openai import AsyncOpenAI
 
 # --- Tool Registry ---
 
+
 class ToolRegistry:
     """Registry for managing tool definitions and execution."""
 
@@ -52,9 +53,9 @@ class ToolRegistry:
                     "type": "object",
                     "properties": properties,
                     "required": list(properties.keys()),
-                    "additionalProperties": False
-                }
-            }
+                    "additionalProperties": False,
+                },
+            },
         }
 
     def _python_to_json_type(self, hint) -> str:
@@ -73,11 +74,9 @@ class ToolRegistry:
 
 # --- Tool Execution Loop ---
 
+
 async def run_tool_loop(
-    registry: ToolRegistry,
-    user_message: str,
-    model: str = "gpt-5.2",
-    max_iterations: int = 10
+    registry: ToolRegistry, user_message: str, model: str = "gpt-5.5", max_iterations: int = 10
 ) -> str:
     """Run tool execution loop until completion."""
     client = AsyncOpenAI()
@@ -88,7 +87,7 @@ async def run_tool_loop(
             model=model,
             messages=messages,
             tools=registry.schemas,
-            parallel_tool_calls=False  # Required for strict mode
+            parallel_tool_calls=False,  # Required for strict mode
         )
 
         message = response.choices[0].message
@@ -100,14 +99,11 @@ async def run_tool_loop(
 
         for tool_call in message.tool_calls:
             result = await registry.execute(
-                tool_call.function.name,
-                json.loads(tool_call.function.arguments)
+                tool_call.function.name, json.loads(tool_call.function.arguments)
             )
-            messages.append({
-                "role": "tool",
-                "tool_call_id": tool_call.id,
-                "content": json.dumps(result)
-            })
+            messages.append(
+                {"role": "tool", "tool_call_id": tool_call.id, "content": json.dumps(result)}
+            )
 
     raise RuntimeError("Max iterations reached")
 

--- a/src/skills/llm-integration/test-cases.json
+++ b/src/skills/llm-integration/test-cases.json
@@ -117,7 +117,7 @@
       "rule": "tuning-dataset-prep",
       "query": "Generate synthetic training data for fine-tuning",
       "expectedBehavior": [
-        "Uses teacher model (GPT-5.2) to generate examples",
+        "Uses teacher model (GPT-5.5) to generate examples",
         "Validates examples with separate validator model",
         "Deduplicates using embedding similarity to remove semantically redundant training examples",
         "Formats as Alpaca or ChatML template for consistent training data structure"

--- a/src/skills/monitoring-observability/checklists/langfuse-setup-checklist.md
+++ b/src/skills/monitoring-observability/checklists/langfuse-setup-checklist.md
@@ -141,15 +141,14 @@ Langfuse v3 requires ClickHouse (analytics), Redis (queuing), MinIO (blob storag
 
 **Python (backend/app/core/config.py):**
 ```python
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     LANGFUSE_PUBLIC_KEY: str
     LANGFUSE_SECRET_KEY: str
     LANGFUSE_HOST: str = "https://cloud.langfuse.com"
 
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()
 ```
@@ -311,7 +310,7 @@ async def call_claude(prompt: str, model: str = "claude-sonnet-4-6") -> str:
 
 ```python
 @observe(name="llm_call")
-async def call_openai(prompt: str, model: str = "gpt-5.2") -> str:
+async def call_openai(prompt: str, model: str = "gpt-5.5") -> str:
     """Call OpenAI with cost tracking."""
 
     get_client().update_current_observation(
@@ -324,7 +323,7 @@ async def call_openai(prompt: str, model: str = "gpt-5.2") -> str:
         messages=[{"role": "user", "content": prompt}]
     )
 
-    # OpenAI pricing (gpt-5.2: $2.50/MTok input, $10/MTok output)
+    # OpenAI pricing (gpt-5.5: $2.50/MTok input, $10/MTok output)
     input_tokens = response.usage.prompt_tokens
     output_tokens = response.usage.completion_tokens
     cost_usd = (input_tokens / 1_000_000) * 2.50 + (output_tokens / 1_000_000) * 10.00

--- a/src/skills/monitoring-observability/references/agent-observability.md
+++ b/src/skills/monitoring-observability/references/agent-observability.md
@@ -249,7 +249,7 @@ async def run_openai_agent(query: str):
     agent = Agent(
         name="analyst",
         instructions="You are a code analyst.",
-        model="gpt-5.2",
+        model="gpt-5.5",
     )
     # OpenAI Agents SDK supports Langfuse via OTEL exporter
     result = await Runner.run(agent, query)

--- a/src/skills/monitoring-observability/references/experiments-api.md
+++ b/src/skills/monitoring-observability/references/experiments-api.md
@@ -286,7 +286,7 @@ async def ab_test_models(dataset_name: str):
 
     configs = {
         "sonnet": {"model": "claude-sonnet-4-6", "temperature": 0.7},
-        "gpt5": {"model": "gpt-5.2", "temperature": 0.7},
+        "gpt5": {"model": "gpt-5.5", "temperature": 0.7},
     }
 
     for name, config in configs.items():

--- a/src/skills/monitoring-observability/references/framework-integrations.md
+++ b/src/skills/monitoring-observability/references/framework-integrations.md
@@ -77,7 +77,7 @@ async def run_openai_agents(query: str):
     agent = Agent(
         name="research_agent",
         instructions="You are a research assistant.",
-        model="gpt-5.2",
+        model="gpt-5.5",
         tools=[search_docs],
     )
 
@@ -86,7 +86,7 @@ async def run_openai_agents(query: str):
 
     get_client().update_current_observation(
         output=result.final_output,
-        metadata={"agent": "research_agent", "model": "gpt-5.2"},
+        metadata={"agent": "research_agent", "model": "gpt-5.5"},
     )
     return result.final_output
 ```
@@ -217,7 +217,7 @@ async def run_voice_agent(session_id: str):
     assistant = VoiceAssistant(
         vad=silero.VAD.load(),
         stt=openai.STT(),
-        llm=openai.LLM(model="gpt-5.2"),
+        llm=openai.LLM(model="gpt-5.5"),
         tts=openai.TTS(),
     )
 

--- a/src/skills/monitoring-observability/references/online-evaluators.md
+++ b/src/skills/monitoring-observability/references/online-evaluators.md
@@ -21,7 +21,7 @@ Online evaluators are LLM-as-judge rules configured in the Langfuse UI that run 
 3. Configure:
    - **Name** — e.g., `response-quality`, `safety-check`, `hallucination-detector`
    - **Evaluator type** — select **LLM-as-judge**
-   - **Model** — e.g., `claude-sonnet-4-6`, `gpt-4o`
+   - **Model** — e.g., `claude-sonnet-4-6`, `gpt-5.5`
    - **Score name** — the key stored on the trace (e.g., `quality`, `safety`)
    - **Filter** — which traces to evaluate (by tag, model, metadata field, etc.)
    - **Sampling rate** — evaluate 100% or a random sample (e.g., 10% for high-volume endpoints)

--- a/src/skills/rag-retrieval/examples/chatbot-with-rag-example.ts
+++ b/src/skills/rag-retrieval/examples/chatbot-with-rag-example.ts
@@ -29,7 +29,7 @@ export async function POST(req: Request) {
 
   // 4. Generate streaming response
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     messages,
     stream: true
   })
@@ -51,7 +51,7 @@ export async function POST(req: Request) {
 async function shouldUseRAG(message: string, _history: unknown[]): Promise<boolean> {
   // Use a cheap model to determine if RAG is needed
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2-mini',
+    model: 'gpt-5-mini',
     messages: [
       {
         role: 'system',

--- a/src/skills/rag-retrieval/rules/hyde-fallback.md
+++ b/src/skills/rag-retrieval/rules/hyde-fallback.md
@@ -28,7 +28,7 @@ async def hyde_with_fallback(
 ```
 
 **Performance Tips:**
-- Use fast model (gpt-5.2-mini, claude-haiku-4-5) for generation
+- Use fast model (gpt-5-mini, claude-haiku-4-5) for generation
 - Cache aggressively (queries often repeat)
 - Set tight timeouts (2-3s) with fallback
 - Keep hypothetical docs concise (100-200 tokens)

--- a/src/skills/rag-retrieval/rules/hyde-generation.md
+++ b/src/skills/rag-retrieval/rules/hyde-generation.md
@@ -31,7 +31,7 @@ async def generate_hyde(
 ) -> HyDEResult:
     """Generate hypothetical document and embed it."""
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content":
                 "Write a short paragraph that would answer this query. "
@@ -66,7 +66,7 @@ async def generate_hyde(
 ```python
 async def generate_hyde(query: str) -> HyDEResult:
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[{"role": "user", "content": query}],
         max_tokens=150
     )
@@ -79,7 +79,7 @@ async def generate_hyde(query: str) -> HyDEResult:
 ```python
 async def generate_hyde(query: str) -> HyDEResult:
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": "Write a short paragraph that would answer this query."},
             {"role": "user", "content": query}
@@ -96,7 +96,7 @@ async def generate_hyde(query: str) -> HyDEResult:
 
 **Key rules:**
 - Embed the hypothetical document, NOT the original query
-- Use fast/cheap model (gpt-5.2-mini, claude-haiku-4-5) for generation
+- Use fast/cheap model (gpt-5-mini, claude-haiku-4-5) for generation
 - Temperature 0.3 for consistent, factual hypothetical docs
 - Keep hypothetical docs concise: 100-200 tokens
 - Adds ~500ms latency — always implement with timeout fallback

--- a/src/skills/rag-retrieval/rules/query-decompose.md
+++ b/src/skills/rag-retrieval/rules/query-decompose.md
@@ -19,7 +19,7 @@ class ConceptExtraction(BaseModel):
 
 async def decompose_query(query: str, llm: AsyncOpenAI) -> list[str]:
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content":
                 "Extract 2-4 independent concepts from this query. "
@@ -79,7 +79,7 @@ async def decomposed_search(query: str, top_k: int = 10) -> list[dict]:
 
 **Key rules:**
 - Max 2-4 concepts per query (more increases latency without proportional benefit)
-- Use gpt-5.2-mini for decomposition (fast, cheap, good at concept extraction)
+- Use gpt-5-mini for decomposition (fast, cheap, good at concept extraction)
 - RRF fusion is robust and parameter-free for combining per-concept results
 - Cache decomposition results — same query often asked repeatedly
 - Set timeout with fallback to original query if decomposition fails

--- a/src/skills/rag-retrieval/rules/reranking-llm.md
+++ b/src/skills/rag-retrieval/rules/reranking-llm.md
@@ -15,7 +15,7 @@ async def llm_rerank(query: str, documents: list[dict], llm: AsyncOpenAI, top_k:
     docs_text = "\n\n".join([f"[Doc {i+1}]\n{doc['content'][:300]}..." for i, doc in enumerate(documents)])
 
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": "Rate each document's relevance to the query (0.0-1.0).\nOutput one score per line."},
             {"role": "user", "content": f"Query: {query}\n\nDocuments:\n{docs_text}"}
@@ -62,7 +62,7 @@ async def llm_rerank(query: str, documents: list[dict]) -> list[dict]:
     scores = []
     for doc in documents:  # Sequential LLM calls!
         response = await llm.chat.completions.create(
-            model="gpt-5.2-mini",
+            model="gpt-5-mini",
             messages=[{"role": "user", "content": f"Rate relevance (0-1):\nQuery: {query}\nDoc: {doc['content']}"}]
         )
         scores.append(float(response.choices[0].message.content))
@@ -79,7 +79,7 @@ async def llm_rerank(query: str, documents: list[dict], top_k: int = 10) -> list
     ])
 
     response = await llm.chat.completions.create(
-        model="gpt-5.2-mini",
+        model="gpt-5-mini",
         messages=[
             {"role": "system", "content": "Rate each document's relevance (0.0-1.0). One score per line."},
             {"role": "user", "content": f"Query: {query}\n\nDocuments:\n{docs_text}"}

--- a/src/skills/rag-retrieval/scripts/rag-pipeline-template.ts
+++ b/src/skills/rag-retrieval/scripts/rag-pipeline-template.ts
@@ -163,7 +163,7 @@ async function generateAnswer(
 
   // Generate answer with LLM
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2',
+    model: 'gpt-5.5',
     temperature: 0.1, // Low temperature for factual responses
     messages: [
       {
@@ -279,7 +279,7 @@ async function condenseQuestion(
   }
 
   const response = await openai.chat.completions.create({
-    model: 'gpt-5.2-mini', // Cheaper model for this task
+    model: 'gpt-5-mini', // Cheaper model for this task
     messages: [
       {
         role: 'system',

--- a/src/skills/rag-retrieval/scripts/scripts/crag-workflow.py
+++ b/src/skills/rag-retrieval/scripts/scripts/crag-workflow.py
@@ -27,12 +27,12 @@ import logging
 import operator
 from dataclasses import dataclass
 from enum import Enum
-from typing import Annotated, Literal, Protocol
+from typing import Annotated, Protocol
 
 from langchain_core.documents import Document
 from langchain_core.runnables import Runnable
 from langgraph.graph import END, START, StateGraph
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +135,7 @@ class CRAGState(BaseModel):
     max_retries: int = 2
     used_web_search: bool = False
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 # =============================================================================
@@ -270,9 +269,7 @@ async def grade_documents(state: CRAGState, config: CRAGConfig) -> dict:
     for i, doc in enumerate(state.documents):
         doc_id = doc.metadata.get("id", f"doc_{i}")
 
-        result = await grader.ainvoke(
-            {"question": state.question, "document": doc.page_content}
-        )
+        result = await grader.ainvoke({"question": state.question, "document": doc.page_content})
 
         grading_results[doc_id] = result
 
@@ -336,7 +333,7 @@ async def rewrite_query(state: CRAGState, config: CRAGConfig) -> dict:
     # Provide context about what was retrieved
     ambiguous_topics = [doc.page_content[:100] for doc in state.ambiguous_docs[:3]]
     context = (
-        f"\n\nPrevious retrieval returned these partially relevant topics:\n"
+        "\n\nPrevious retrieval returned these partially relevant topics:\n"
         + "\n".join(ambiguous_topics)
         if ambiguous_topics
         else ""
@@ -369,9 +366,7 @@ async def web_search(state: CRAGState, config: CRAGConfig) -> dict:
     # Use original question for web search (more natural phrasing)
     query = state.original_question or state.question
 
-    web_docs = await searcher.search(
-        query, max_results=config.web_search_max_results
-    )
+    web_docs = await searcher.search(query, max_results=config.web_search_max_results)
 
     # Add to correct docs (web results assumed relevant)
     combined_correct = state.correct_docs + web_docs
@@ -517,9 +512,7 @@ async def crag_query(
     Returns:
         Dict with generation, sources_used, and metadata
     """
-    config = CRAGConfig(
-        retriever=retriever, llm=llm, tavily_api_key=tavily_api_key
-    )
+    config = CRAGConfig(retriever=retriever, llm=llm, tavily_api_key=tavily_api_key)
 
     graph = build_crag(config)
     result = await graph.ainvoke({"question": question})
@@ -541,11 +534,11 @@ async def crag_query(
 
 async def example_usage():
     """Example of using CRAG workflow."""
-    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
     from langchain_community.vectorstores import FAISS
+    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
     # Setup components
-    llm = ChatOpenAI(model="gpt-5.2-mini", temperature=0)
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
 
     # Create a simple retriever
     embeddings = OpenAIEmbeddings()
@@ -577,10 +570,7 @@ async def example_usage():
     print(f"\nSources: {result['sources_used']}")
     print(f"Retries: {result['retry_count']}")
     print(f"Web search used: {result['used_web_search']}")
-    print(
-        f"Docs: {len(result['correct_docs'])} correct, "
-        f"{len(result['ambiguous_docs'])} ambiguous"
-    )
+    print(f"Docs: {len(result['correct_docs'])} correct, {len(result['ambiguous_docs'])} ambiguous")
 
 
 if __name__ == "__main__":

--- a/src/skills/rag-retrieval/scripts/scripts/self-rag-graph.py
+++ b/src/skills/rag-retrieval/scripts/scripts/self-rag-graph.py
@@ -25,13 +25,13 @@ from __future__ import annotations
 
 import logging
 import operator
-from dataclasses import dataclass, field
-from typing import Annotated, Any, Literal, Protocol
+from dataclasses import dataclass
+from typing import Annotated, Literal, Protocol
 
 from langchain_core.documents import Document
 from langchain_core.runnables import Runnable
 from langgraph.graph import END, START, StateGraph
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 logger = logging.getLogger(__name__)
 
@@ -69,9 +69,7 @@ class LLM(Protocol):
 class RetrievalDecision(BaseModel):
     """Decision on whether to retrieve documents."""
 
-    needs_retrieval: bool = Field(
-        description="Whether retrieval would help answer this query"
-    )
+    needs_retrieval: bool = Field(description="Whether retrieval would help answer this query")
     confidence: float = Field(
         ge=0.0, le=1.0, description="Confidence in answering without retrieval"
     )
@@ -132,8 +130,7 @@ class SelfRAGState(BaseModel):
     max_retries: int = 2
     skip_retrieval: bool = False
 
-    class Config:
-        arbitrary_types_allowed = True
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
 # =============================================================================
@@ -260,9 +257,7 @@ async def grade_documents(state: SelfRAGState, config: SelfRAGConfig) -> dict:
     for i, doc in enumerate(state.documents):
         doc_id = doc.metadata.get("id", f"doc_{i}")
 
-        grade = await grader.ainvoke(
-            {"question": state.question, "document": doc.page_content}
-        )
+        grade = await grader.ainvoke({"question": state.question, "document": doc.page_content})
 
         grades[doc_id] = grade
         logger.debug(f"Graded {doc_id}: {grade.is_relevant}")
@@ -327,9 +322,7 @@ async def verify_support(state: SelfRAGState, config: SelfRAGConfig) -> dict:
 
     context = "\n\n".join([doc.page_content for doc in state.documents])
 
-    verification = await verifier.ainvoke(
-        {"generation": state.generation, "context": context}
-    )
+    verification = await verifier.ainvoke({"generation": state.generation, "context": context})
 
     logger.info(f"Support verification: {verification.is_supported}")
 
@@ -347,19 +340,15 @@ async def rewrite_query(state: SelfRAGState, config: SelfRAGConfig) -> dict:
             doc.page_content[:100]
             for i, doc in enumerate(state.documents)
             if state.document_grades.get(doc.metadata.get("id", f"doc_{i}"), None)
-            and state.document_grades[
-                doc.metadata.get("id", f"doc_{i}")
-            ].is_relevant
-            == "no"
+            and state.document_grades[doc.metadata.get("id", f"doc_{i}")].is_relevant == "no"
         ][:3]
         if irrelevant_topics:
-            failed_context = f"\n\nPrevious retrieval returned these irrelevant topics:\n" + "\n".join(
-                irrelevant_topics
+            failed_context = (
+                "\n\nPrevious retrieval returned these irrelevant topics:\n"
+                + "\n".join(irrelevant_topics)
             )
 
-    rewritten = await rewriter.ainvoke(
-        {"question": state.question, "context": failed_context}
-    )
+    rewritten = await rewriter.ainvoke({"question": state.question, "context": failed_context})
 
     logger.info(f"Query rewritten: {rewritten.query[:100]}...")
 
@@ -381,9 +370,7 @@ def route_after_grading(state: SelfRAGState, config: SelfRAGConfig) -> str:
     if state.skip_retrieval:
         return "generate"
 
-    relevant_count = sum(
-        1 for g in state.document_grades.values() if g.is_relevant == "yes"
-    )
+    relevant_count = sum(1 for g in state.document_grades.values() if g.is_relevant == "yes")
 
     if relevant_count >= config.min_relevant_docs:
         return "generate"
@@ -401,9 +388,11 @@ def route_after_verification(state: SelfRAGState, config: SelfRAGConfig) -> str:
 
     support_level = state.support_verification.is_supported
 
-    if support_level == "fully":
-        return END
-    elif support_level == "partially" and config.support_threshold == "partially":
+    if (
+        support_level == "fully"
+        or support_level == "partially"
+        and config.support_threshold == "partially"
+    ):
         return END
     elif state.retry_count < config.max_retries:
         return "rewrite"
@@ -429,24 +418,12 @@ def build_self_rag(config: SelfRAGConfig) -> StateGraph:
     workflow = StateGraph(SelfRAGState)
 
     # Add nodes with config binding
-    workflow.add_node(
-        "decide_retrieval", lambda s: decide_retrieval(s, config)
-    )
-    workflow.add_node(
-        "retrieve", lambda s: retrieve_documents(s, config)
-    )
-    workflow.add_node(
-        "grade", lambda s: grade_documents(s, config)
-    )
-    workflow.add_node(
-        "generate", lambda s: generate_answer(s, config)
-    )
-    workflow.add_node(
-        "verify", lambda s: verify_support(s, config)
-    )
-    workflow.add_node(
-        "rewrite", lambda s: rewrite_query(s, config)
-    )
+    workflow.add_node("decide_retrieval", lambda s: decide_retrieval(s, config))
+    workflow.add_node("retrieve", lambda s: retrieve_documents(s, config))
+    workflow.add_node("grade", lambda s: grade_documents(s, config))
+    workflow.add_node("generate", lambda s: generate_answer(s, config))
+    workflow.add_node("verify", lambda s: verify_support(s, config))
+    workflow.add_node("rewrite", lambda s: rewrite_query(s, config))
 
     # Define edges
     workflow.add_edge(START, "decide_retrieval")
@@ -489,11 +466,11 @@ def build_self_rag(config: SelfRAGConfig) -> StateGraph:
 
 async def example_usage():
     """Example of using Self-RAG workflow."""
-    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
     from langchain_community.vectorstores import FAISS
+    from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
     # Setup components (replace with your actual setup)
-    llm = ChatOpenAI(model="gpt-5.2-mini", temperature=0)
+    llm = ChatOpenAI(model="gpt-5-mini", temperature=0)
 
     # Create a simple retriever (replace with your vector store)
     embeddings = OpenAIEmbeddings()

--- a/src/skills/rag-retrieval/test-cases.json
+++ b/src/skills/rag-retrieval/test-cases.json
@@ -119,7 +119,7 @@
       "expectedBehavior": [
         "Generates a hypothetical answer document that mirrors the expected retrieval target language",
         "Embeds the hypothetical doc, NOT the query",
-        "Uses a fast model like gpt-5.2-mini to generate hypothetical documents with low latency",
+        "Uses a fast model like gpt-5-mini to generate hypothetical documents with low latency",
         "Sets temperature to 0.3 for consistent and focused hypothetical document generation output"
       ]
     },

--- a/src/skills/react-server-components-framework/references/tanstack-router-patterns.md
+++ b/src/skills/react-server-components-framework/references/tanstack-router-patterns.md
@@ -115,7 +115,7 @@ import { useActionState, use } from 'react'
 import { z } from 'zod'
 
 const UrlSchema = z.object({
-  url: z.string().url('Please enter a valid URL'),
+  url: z.url('Please enter a valid URL'),
 })
 
 async function submitUrl(

--- a/src/skills/security-patterns/SKILL.md
+++ b/src/skills/security-patterns/SKILL.md
@@ -74,7 +74,7 @@ token = jwt.encode(payload, SECRET_KEY, algorithm='HS256')
 // Zod v4 schema validation
 import { z } from 'zod';
 const UserSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   name: z.string().min(2).max(100),
   role: z.enum(['user', 'admin']).default('user'),
 });

--- a/src/skills/security-patterns/examples/validation-patterns.md
+++ b/src/skills/security-patterns/examples/validation-patterns.md
@@ -7,7 +7,7 @@ import { z } from 'zod';
 
 // Request body schema
 const CreateUserSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   password: z.string().min(8).max(100),
   name: z.string().min(2).max(100).transform(s => s.trim()),
   role: z.enum(['user', 'admin']).default('user'),
@@ -74,7 +74,7 @@ app.get('/api/users', validateQuery(PaginationSchema), (req, res) => {
 const NotificationSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('email'),
-    email: z.string().email(),
+    email: z.email(),
     subject: z.string().min(1),
     body: z.string().min(1),
   }),
@@ -152,8 +152,7 @@ function validateFileContent(buffer: Buffer, mimeType: string): boolean {
 ```typescript
 const ALLOWED_DOMAINS = ['api.example.com', 'cdn.example.com'] as const;
 
-const UrlSchema = z.string()
-  .url()
+const UrlSchema = z.url()
   .refine(
     (url) => {
       const { hostname, protocol } = new URL(url);
@@ -237,7 +236,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 const SignupSchema = z.object({
-  email: z.string().email('Invalid email'),
+  email: z.email('Invalid email'),
   password: z.string()
     .min(8, 'Password must be at least 8 characters')
     .regex(/[A-Z]/, 'Must contain uppercase')

--- a/src/skills/security-patterns/rules/guardrails-nemo.md
+++ b/src/skills/security-patterns/rules/guardrails-nemo.md
@@ -21,7 +21,7 @@ return response  # Raw, unvalidated output!
 models:
   - type: main
     engine: openai
-    model: gpt-5.2
+    model: gpt-5.5
 
 rails:
   config:
@@ -81,7 +81,7 @@ if not input_result.validation_passed:
     return "Invalid input"
 
 llm_output = llm.generate(input_result.validated_output)
-output_result = guard(llm_api=openai.chat.completions.create, model="gpt-5.2",
+output_result = guard(llm_api=openai.chat.completions.create, model="gpt-5.5",
                       messages=[{"role": "user", "content": user_input}])
 
 if output_result.validation_passed:

--- a/src/skills/security-patterns/rules/validation-input.md
+++ b/src/skills/security-patterns/rules/validation-input.md
@@ -21,7 +21,7 @@ tags: input-validation, zod, pydantic, schema-validation, allowlist
 import { z } from 'zod';
 
 const UserSchema = z.object({
-  email: z.string().email(),
+  email: z.email(),
   name: z.string().min(2).max(100),
   age: z.coerce.number().int().min(0).max(150),
   role: z.enum(['user', 'admin']).default('user'),
@@ -135,7 +135,7 @@ if (email.includes('@')) {
 **Correct — Server-side schema validation with Zod ensures all input is validated:**
 ```typescript
 app.post('/api/users', validateBody(z.object({
-  email: z.string().email(),
+  email: z.email(),
 })), async (req, res) => {
   // req.body.email is validated regardless of client
 });

--- a/src/skills/security-patterns/rules/validation-schemas.md
+++ b/src/skills/security-patterns/rules/validation-schemas.md
@@ -14,7 +14,7 @@ tags: file-validation, discriminated-unions, magic-bytes, upload-security
 const NotificationSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('email'),
-    email: z.string().email(),
+    email: z.email(),
     subject: z.string().min(1),
     body: z.string().min(1),
   }),
@@ -63,8 +63,7 @@ function validateFileContent(buffer: Buffer, mimeType: string): boolean {
 ```typescript
 const ALLOWED_DOMAINS = ['api.example.com', 'cdn.example.com'] as const;
 
-const SafeUrlSchema = z.string()
-  .url()
+const SafeUrlSchema = z.url()
   .refine(
     (url) => {
       const { hostname, protocol } = new URL(url);
@@ -82,7 +81,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 
 const SignupSchema = z.object({
-  email: z.string().email('Invalid email'),
+  email: z.email('Invalid email'),
   password: z.string()
     .min(8, 'Password must be at least 8 characters')
     .regex(/[A-Z]/, 'Must contain uppercase')

--- a/src/skills/security-patterns/scripts/validation-schemas.ts
+++ b/src/skills/security-patterns/scripts/validation-schemas.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 // Common Field Schemas
 // =============================================================================
 
-export const email = z.string().email();
+export const email = z.email();
 
 export const password = z.string()
   .min(8, 'Password must be at least 8 characters')
@@ -19,7 +19,7 @@ export const password = z.string()
   .regex(/[a-z]/, 'Must contain lowercase letter')
   .regex(/[0-9]/, 'Must contain number');
 
-export const uuid = z.string().uuid();
+export const uuid = z.uuid();
 
 export const slug = z.string()
   .min(1)
@@ -29,7 +29,7 @@ export const slug = z.string()
 export const phone = z.string()
   .regex(/^\+[1-9]\d{1,14}$/, 'Invalid phone number (E.164 format)');
 
-export const url = z.string().url();
+export const url = z.url();
 
 export const isoDate = z.coerce.date();
 
@@ -135,8 +135,7 @@ export type FileUpload = z.infer<typeof FileUploadSchema>;
 
 const ALLOWED_DOMAINS = ['api.example.com', 'cdn.example.com'] as const;
 
-export const SafeUrlSchema = z.string()
-  .url()
+export const SafeUrlSchema = z.url()
   .refine(
     (urlString) => {
       try {
@@ -156,8 +155,7 @@ export const SafeUrlSchema = z.string()
 // =============================================================================
 
 // For async validations like uniqueness checks
-export const UniqueEmailSchema = z.string()
-  .email()
+export const UniqueEmailSchema = z.email()
   .refine(
     async (email) => {
       // Replace with actual database check

--- a/src/skills/testing-e2e/rules/validation-end-to-end.md
+++ b/src/skills/testing-e2e/rules/validation-end-to-end.md
@@ -36,7 +36,7 @@ export const appRouter = t.router({
     }),
 
   createUser: t.procedure
-    .input(z.object({ email: z.string().email(), name: z.string() }))
+    .input(z.object({ email: z.email(), name: z.string() }))
     .mutation(async ({ input }) => {
       return await db.user.create({ data: input })
     })

--- a/src/skills/testing-integration/rules/validation-zod-schema.md
+++ b/src/skills/testing-integration/rules/validation-zod-schema.md
@@ -24,8 +24,8 @@ const data: any = await fetch('/api').then(r => r.json())
 import { z } from 'zod'
 
 const UserSchema = z.object({
-  id: z.string().uuid(),
-  email: z.string().email(),
+  id: z.uuid(),
+  email: z.email(),
   age: z.number().int().positive().max(120),
   role: z.enum(['admin', 'user', 'guest']),
   createdAt: z.date().default(() => new Date())
@@ -43,8 +43,8 @@ const user: User = result.data
 
 **Correct -- branded types to prevent ID confusion:**
 ```typescript
-const UserId = z.string().uuid().brand<'UserId'>()
-const AnalysisId = z.string().uuid().brand<'AnalysisId'>()
+const UserId = z.uuid().brand<'UserId'>()
+const AnalysisId = z.uuid().brand<'AnalysisId'>()
 
 type UserId = z.infer<typeof UserId>
 type AnalysisId = z.infer<typeof AnalysisId>

--- a/src/skills/ui-components/rules/forms-react-hook-form.md
+++ b/src/skills/ui-components/rules/forms-react-hook-form.md
@@ -32,7 +32,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
 const userSchema = z.object({
-  email: z.string().email('Please enter a valid email'),
+  email: z.email('Please enter a valid email'),
   password: z.string().min(8, 'Minimum 8 characters'),
   confirmPassword: z.string(),
 }).refine((data) => data.password === data.confirmPassword, {

--- a/tests/skills/test-storybook-catalog-import.sh
+++ b/tests/skills/test-storybook-catalog-import.sh
@@ -120,7 +120,7 @@ cat > "$TMP/extra.json" <<'EOF'
 }
 EOF
 node "$SCRIPT" "$TMP/extra.json" --out "$TMP/cal.ts" --project-root "$PROJ" 2>/dev/null
-check "date control -> z.string().datetime()"           grep -q "z.string().datetime()" "$TMP/cal.ts"
+check "date control -> z.iso.datetime()"           grep -q "z.iso.datetime()" "$TMP/cal.ts"
 check "array control -> z.array(z.string()).max(20)"    grep -q "z.array(z.string()).max(20)" "$TMP/cal.ts"
 check "boolean control -> z.boolean()"                  grep -q "z.boolean()" "$TMP/cal.ts"
 echo


### PR DESCRIPTION
## Summary

The **residual** of the [2026-05-31 library-currency audit](../blob/fix/lib-currency-residual/docs/playgrounds/lib-currency-audit-2026-05-31.html) — the deprecated patterns that lived in skills the 14-cluster audit never scoped. Applied by **16 sub-agents** (one per skill) + an aggregate gap-sweep, **judgment-aware** (no blind replace). Branches off `main` with Lanes 1–3 already merged (#2142, #2143).

| pattern | fix | result |
|---|---|---|
| `gpt-5.2` / `gpt-4o` (plain defaults) | → `gpt-5.5` | 0 plain remaining |
| `gpt-5.2-mini` / `gpt-4o-mini` | → `gpt-5-mini` | cheap-tier preserved |
| `z.string().email()/.uuid()/.url()/.datetime()` | → `z.email()`/`z.uuid()`/`z.url()`/`z.iso.datetime()` | 0 (real schema code) |
| `asyncio.get_event_loop()` | → `get_running_loop()` / `time.monotonic()` | 0 |
| Pydantic `class Config` | → `model_config = SettingsConfigDict`/`ConfigDict` (per base class) | 0 |
| `datetime.utcnow()` | → `datetime.now(UTC)` | 0 |

68 files across 16 skills (heaviest: agent-orchestration 38× gpt-5.2→5.5, rag-retrieval, security-patterns Zod across 6 files, distributed-systems/architecture-patterns asyncio+utcnow).

## Left intentionally (judgment, logged — not blind-swept)

- `gpt-5.2-codex` ×20 (dedicated `gpt-5-2-codex.md` + sibling pricing/routing rows) — specialized model; deferred to a separate codex-lineup pass rather than create an incoherent "gpt-5.5 standard beside gpt-5.2-codex" doc.
- `gpt-5.2-realtime` / `gpt-4o-transcribe` — current specialized voice/transcription models; mapping to `gpt-5.5` would strip the capability.
- `gpt-3.5-turbo` — a deliberate cheap/legacy fallback-tier cost illustration.
- 3× `z.string().email` in `zod-v4-api.md` — **comments** documenting what the new form replaced (code is already `z.email()`).

## Verification

- ✅ `npm run build` → `git diff --quiet plugins/` clean (68 mirrors committed)
- ✅ `npm run test:skills` SUCCESS (0 failures)
- ✅ gap-sweep: 0 plain-default model ids / Zod method-forms / `get_event_loop` / `class Config` / `utcnow` remaining — only the logged leaves
- ⚠️ markdown/script **samples** (not CI-executed) — verification is grep + per-occurrence judgment + spot-build

## Audit status

Lane 1 (#2142) + Lane 2/3 (#2143) + this = the **entire 2026-05-31 library-currency audit remediated**, save the explicitly-deferred **codex/realtime model-lineup verification** (its own small pass — say the word).

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/fix/lib-currency-residual/docs/fix--lib-currency-residual/residual-sweep.html)** — the mapping, the leave-list, per-skill counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
