### PR TITLE
docs(rules): correct drift register from adversarial re-audit (#2217)

### DIFF
--- a/docs/docs--drift-register-correction/drift-reaudit-playground.html
+++ b/docs/docs--drift-register-correction/drift-reaudit-playground.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Drift Register Re-Audit — the audit was 60% wrong · OrchestKit</title>
+<style>
+  :root{
+    --bg:#0d1117;--panel:#161b22;--panel2:#1c2330;--border:#30363d;
+    --txt:#e6edf3;--dim:#8b949e;--accent:#58a6ff;--green:#3fb950;
+    --amber:#d29922;--red:#f85149;--redhi:#ff7b72;--purple:#bc8cff;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--txt);font-family:var(--mono);font-size:14px;line-height:1.55;padding:28px 20px 80px}
+  .wrap{max-width:1060px;margin:0 auto}
+  h1{font-size:22px;margin:0 0 4px;letter-spacing:-.3px}
+  h2{font-size:14px;text-transform:uppercase;letter-spacing:1px;color:var(--dim);margin:30px 0 12px;border-bottom:1px solid var(--border);padding-bottom:6px}
+  .sub{color:var(--dim);margin:0 0 6px}
+  .tag{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;border:1px solid var(--border);color:var(--dim)}
+  .toolbar{margin:14px 0 4px;display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  .btn{background:var(--panel2);border:1px solid var(--border);color:var(--txt);border-radius:6px;padding:5px 12px;font-family:var(--mono);font-size:12px;cursor:pointer}
+  .btn.active{border-color:var(--accent);color:var(--accent)}
+  .btn:hover{border-color:var(--accent)}
+  .dash{display:grid;grid-template-columns:repeat(5,1fr);gap:10px;margin-top:14px}
+  .metric{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:13px;text-align:center}
+  .metric .n{font-size:23px;font-weight:700}
+  .metric .l{font-size:10.5px;color:var(--dim);text-transform:uppercase;letter-spacing:.4px;margin-top:3px}
+  table{width:100%;border-collapse:collapse;margin-top:10px}
+  th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--border);vertical-align:top}
+  th{color:var(--dim);font-weight:600;font-size:11.5px;text-transform:uppercase;letter-spacing:.5px}
+  tr.row{cursor:pointer;transition:background .12s}
+  tr.row:hover{background:var(--panel2)}
+  .id{color:var(--accent);font-weight:700}
+  .chip{display:inline-block;font-size:11px;padding:1px 8px;border-radius:9px;border:1px solid var(--border);white-space:nowrap}
+  .keep{color:var(--green);border-color:var(--green)}
+  .done{color:var(--accent);border-color:var(--accent)}
+  .thin{color:var(--amber);border-color:var(--amber)}
+  .del{color:var(--redhi);border-color:var(--redhi)}
+  .arrow{color:var(--dim)}
+  .flip{color:var(--redhi);font-size:11px}
+  .hold{color:var(--green);font-size:11px}
+  .ev{display:none}
+  .ev.show{display:table-row}
+  .ev td{background:#0a0d12;border-left:3px solid var(--accent);color:var(--dim);font-size:12.5px}
+  .ev code{color:var(--purple);background:rgba(188,140,255,.08);padding:1px 5px;border-radius:4px}
+  .ev .ref{color:var(--amber);margin-top:8px;display:block}
+  .gates{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}
+  .gate{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:14px}
+  .gate b{color:var(--txt)}
+  .ba{background:#0a0d12;border:1px solid var(--border);border-radius:8px;padding:12px 14px;margin-top:12px;font-size:12.5px}
+  .ba .x{color:var(--redhi)}.ba .ok{color:var(--green)}
+  .outbox{background:#0a0d12;border:1px solid var(--border);border-radius:8px;padding:14px 16px;margin-top:10px;white-space:pre-wrap;font-size:12.5px;position:relative}
+  .copy{position:absolute;top:10px;right:10px;background:var(--panel2);border:1px solid var(--border);color:var(--txt);border-radius:6px;padding:4px 10px;font-family:var(--mono);font-size:11px;cursor:pointer}
+  .copy:hover{border-color:var(--accent);color:var(--accent)}
+  .copy.done2{color:var(--green);border-color:var(--green)}
+  .note{font-size:12px;color:var(--dim);margin-top:10px}
+  code{font-family:var(--mono)}
+  a{color:var(--accent)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>🔬 Drift Register Re-Audit</h1>
+  <p class="sub">OrchestKit · cc-native-first #2217 · the first-pass audit was <b style="color:var(--redhi)">~60% wrong</b></p>
+  <span class="tag">adversarially verified · click a row for evidence + the refutation that failed</span>
+
+  <h2>📊 Outcome</h2>
+  <div class="dash">
+    <div class="metric"><div class="n">5</div><div class="l">surfaces</div></div>
+    <div class="metric"><div class="n" style="color:var(--accent)">1</div><div class="l">removal shipped</div></div>
+    <div class="metric"><div class="n" style="color:var(--amber)">1</div><div class="l">real THIN open</div></div>
+    <div class="metric"><div class="n" style="color:var(--green)">3</div><div class="l">load-bearing KEEP</div></div>
+    <div class="metric"><div class="n" style="color:var(--redhi)">~60%</div><div class="l">audit wrong</div></div>
+  </div>
+
+  <h2>🎯 Verdict matrix</h2>
+  <div class="toolbar">
+    <span class="sub" style="margin:0">show:</span>
+    <button class="btn active" id="bV" onclick="setView('verified')">verified verdict</button>
+    <button class="btn" id="bO" onclick="setView('original')">original audit</button>
+    <span class="note" style="margin:0 0 0 8px">(toggle to see what flipped)</span>
+  </div>
+  <table>
+    <thead><tr><th>#</th><th>surface</th><th id="vcol">verified verdict</th><th>changed?</th></tr></thead>
+    <tbody id="rows"></tbody>
+  </table>
+
+  <h2>🚦 The two mandatory audit gates (the lesson)</h2>
+  <div class="gates">
+    <div class="gate"><b>1 · CC-capability check</b><br><br>Feature-detect what the native surface actually does on the current CC version. Never infer parity from a one-line changelog claim.<br><br><span style="color:var(--redhi)">Caught:</span> notification THIN (terminalSequence is terminal-dependent) + version-check DELETE (requiredMinimumVersion is managed-only).</div>
+    <div class="gate"><b>2 · Read the consumer, don't grep</b><br><br>Trace imports, FK constraints, and call-sites <i>in the consuming function</i>. "Used somewhere" is not a consumer.<br><br><span style="color:var(--redhi)">Caught:</span> the version-matrix verdict — and my own re-audit's mistake on it.</div>
+  </div>
+  <div class="ba">
+    <span class="x">grep heuristic:</span> <code style="color:var(--purple)">cc-file-adoption-issues.sh</code> matched "feature" → flagged as a matrix consumer (KEEP).<br>
+    <span class="ok">read the file:</span> it consumes <code style="color:var(--purple)">cc-adoption-gaps.json</code> <code style="color:var(--purple)">.features[]</code> — <b>NOT the matrix</b>. Verdict flips back to THIN. ✓
+  </div>
+
+  <h2>📦 Corrected register (copy-out)</h2>
+  <div class="outbox"><button class="copy" id="cp">copy</button><span id="out"></span></div>
+
+  <p class="note" style="margin-top:22px">Generated by the <code style="color:var(--purple)">/ork:brainstorm</code> → drift-cleanup thread · re-verified by a 6-agent workflow (5 adversarial + 1 synthesis) · rule: <code style="color:var(--purple)">shared/rules/cc-native-first.md</code></p>
+</div>
+<script>
+const rows=[
+ {n:1,s:'session-registry',o:'THIN (~325ln)',oc:'thin',v:'KEEP',vc:'keep',changed:true,
+  why:'<code>sessions</code> is the enforced-FK parent (<code>PRAGMA foreign_keys=ON</code>) of locks/settings_overrides/worktree_links. <code>enter-registrar.ts:54-57</code> does a two-phase insert <i>because</i> <code>worktree_links.child_sid</code> FK requires the session row first — the spine is load-bearing, not liveness drift.',
+  ref:'Refutation tried: "rows never deleted, so FK is cosmetic; de-normalize into worktree_links." Failed: the FK actively blocks the INSERT order (enter-registrar comment). Only ~59ln heartbeat + dead last_heartbeat is marginal drift.'},
+ {n:2,s:'goal-emitter',o:'DELETE',oc:'del',v:'DONE',vc:'done',changed:false,
+  why:'Genuine Shadow — read CC-owned <code>goal-current.json</code>, re-wrote <code>goal-history.jsonl</code>, emitted <code>goal_converged</code> with zero in-repo consumers. Removed in #2219. The M140 budget trio it was confused with is independently KEEP (per-session turn/token ceilings native /goal lacks).',
+  ref:'Refutation tried: "events.jsonl is a designed bus; emitter is a placeholder" + "M140 duplicates native /goal budgets." Failed: zero consumers of goal_converged; native /goal has no per-session ceiling enforcement.'},
+ {n:3,s:'notification',o:'THIN / migrate',oc:'thin',v:'KEEP',vc:'keep',changed:true,
+  why:'<b>Overturned.</b> <code>terminalSequence</code> is a raw OSC escape, terminal-emulator-dependent (silent in Apple Terminal / VS Code / tmux), title+body only. CC has <b>no</b> native OS-level notification. <code>osascript</code>/<code>notify-send</code> reaches the OS notification center across ALL terminals, rich (repo+branch+issue#).',
+  ref:'Refutation tried: "terminalSequence dedupes osascript; losing some terminals is acceptable." Failed: it is a strict downgrade — silent failure + lost subtitle for a user-facing alert. #1847 → won\'t-do.'},
+ {n:4,s:'version-matrix',o:'THIN',oc:'thin',v:'THIN',vc:'thin',changed:false,flip:true,
+  why:'<b>The one real open drift.</b> <code>hasFeature</code>/<code>getAvailableFeatures</code>/<code>getMissingFeatures</code> have <b>zero</b> production call-sites; the only consumers (<code>cc-version-check.ts:42</code>, <code>generate-docs-data.js</code>) each read a single scalar (latest version / MIN_CC_VERSION). The 478-row catalogue collapses to 2 constants + <code>compareCCVersions()</code>.',
+  ref:'My quick re-audit wrongly called this KEEP ("feeds the pipeline") — the grep heuristic. The workflow agent READ the consumers and confirmed THIN. Open future refactor (drop or auto-generate).'},
+ {n:5,s:'version-check',o:'DELETE',oc:'del',v:'KEEP',vc:'keep',changed:true,
+  why:'<code>requiredMinimumVersion</code> (2.1.163) is <b>managed-settings-only</b> (admin/MDM, hard-blocks before plugins load). A publicly-distributed plugin\'s users cannot set it — so ork\'s SessionStart floor-warning is the only below-floor notice they get.',
+  ref:'Refutation tried: "native enforcement is strictly stronger, delete the warning." Failed: managed-only ≠ available to public users. The matrix-derived adoption-nudge is a sequenced THIN only after surface 4 thins.'},
+];
+let view='verified';
+function setView(v){view=v;document.getElementById('bV').classList.toggle('active',v==='verified');document.getElementById('bO').classList.toggle('active',v==='original');document.getElementById('vcol').textContent=v==='verified'?'verified verdict':'original audit';render();}
+function render(){
+  document.getElementById('rows').innerHTML=rows.map((r,i)=>{
+    const verd = view==='verified' ? `<span class="chip ${r.vc}">${r.v}</span>` : `<span class="chip ${r.oc}">${r.o}</span>`;
+    const ch = r.flip ? '<span class="hold">held (orig was right)</span>' : (r.changed?'<span class="flip">▲ flipped</span>':'<span class="hold">held</span>');
+    return `<tr class="row" data-i="${i}"><td class="id">${r.n}</td><td>${r.s}</td><td>${verd}</td><td>${ch}</td></tr>
+    <tr class="ev" data-ev="${i}"><td></td><td colspan="3">🔬 ${r.why}<span class="ref">↳ ${r.ref}</span></td></tr>`;
+  }).join('');
+  document.querySelectorAll('tr.row').forEach(tr=>tr.addEventListener('click',()=>{
+    document.querySelector(`tr[data-ev="${tr.dataset.i}"]`).classList.toggle('show');
+  }));
+}
+const summary=[
+"cc-native-first drift register — RE-AUDITED 2026-06-05 (#2217), adversarially verified",
+"",
+"1  session-registry   KEEP   enforced-FK parent (PRAGMA foreign_keys=ON); load-bearing spine",
+"2  goal-emitter       DONE   genuine Shadow, removed #2219; M140 budget trio kept",
+"3  notification       KEEP   terminalSequence terminal-dependent; THIN overturned (#1847 won't-do)",
+"4  version-matrix     THIN   478 rows -> 2 scalars; zero feature-helper callers; THE open drift",
+"5  version-check      KEEP   requiredMinimumVersion is managed-only; only floor warning public users get",
+"",
+"Net: original audit ~60% wrong. Real drift = goal-emitter (shipped) + matrix catalogue (open THIN).",
+"Gates before acting on any 'rely on CC native' verdict:",
+"  1. CC-capability check  — feature-detect, never infer from a changelog line.",
+"  2. read the consumer    — trace call-sites in the consuming function, not a grep.",
+].join("\n");
+document.getElementById('out').textContent=summary;
+document.getElementById('cp').addEventListener('click',e=>{navigator.clipboard.writeText(summary).then(()=>{e.target.textContent='copied ✓';e.target.classList.add('done2');setTimeout(()=>{e.target.textContent='copy';e.target.classList.remove('done2');},1400);});});
+render();
+</script>
+</body>
+</html>

--- a/shared/rules/cc-native-first.md
+++ b/shared/rules/cc-native-first.md
@@ -64,23 +64,23 @@ subtraction" there.
 ## Drift register (audit targets)
 
 Mechanisms where ork overlaps a CC-native equivalent. Each must `DELETE`, `THIN`, or
-carry a written `KEEP` justification. Update this table as the audit resolves each.
+carry a written `KEEP` justification.
 
-| ork mechanism | CC-native equivalent | Type | Status |
-|---------------|----------------------|------|--------|
-| `lifecycle/session-registrar.ts` + `session-finalizer.ts` + `posttool/heartbeat.ts` (sessions.db liveness) | `claude agents --json waitingFor` (2.1.162), `done/total` (2.1.161) | Shadow | 🟠 **THIN** — delete the liveness triplet (~325 ln, 3 hooks, `sessions` table); keep `worktree_links`/`settings_overrides`/`skill_invocation`/`locks` (orthogonal). 24h sweep + `last_heartbeat` have zero in-repo readers. [#2217] |
-| `stop/goal-convergence-emitter.ts` (M168 bridge) | CC owns `goal-current.json` natively | Shadow | 🔴 **DELETE** — duplicates `stop/goal-tracker`'s history write; `events.jsonl` `goal_converged` has no consumer. [#2217] |
-| `prompt/goal-tracker.ts` + `stop/goal-tracker.ts` + `lifecycle/goal-budget-guard.ts` (M140 trio) | native `/goal` evaluator (2.1.139+) | Shadow | ✅ **KEEP** (justified below) |
-| `notification/desktop.ts` + `unified-dispatcher.ts` + `entries/notification.ts` (osascript) | hook `terminalSequence` field (2.1.141) | Wrap | 🟠 **THIN** — migrate desktop → `terminalSequence` (~305 ln gone); **KEEP** `notification/sound.ts` (afplay/paplay — no CC-native sound, orthogonal); defer `denial-notification.ts` (different event). Verify `entries/notification.ts` registration before deleting. [#1847, #2217] |
-| `lib/cc-version-matrix.ts` (615 lines / 478 entries) | CC's own changelog / runtime capability | Mirror | 🔴 **THIN (big)** — **0 runtime feature-gate consumers**; all 478 catalogue rows are read only by a count-canary test. Keep `MIN_CC_VERSION` + `compareCCVersions()`. Catalogue is documentation-debt → human call: drop, or auto-generate from a CC changelog feed. [#2217] |
-| `lifecycle/cc-version-check.ts` | polices the Mirror **and** Shadows CC 2.1.163 `requiredMinimumVersion` | Workaround+Shadow | 🔴 **DELETE (sequenced)** — `requiredMinimumVersion` (2.1.163) enforces the floor at startup (stronger: refuses to launch); the adoption-nudge is moot once the Mirror thins. Delete once matrix thins + `requiredMinimumVersion` adopted. Keep `shared/cc-support.json` (decoupled SoT). [#2217] |
+> **Re-audited 2026-06-05 (#2217), adversarially verified.** The first-pass audit (by
+> code-only agents) was **~60% wrong** — it inferred "redundant with CC" from surface
+> overlap without checking CC runtime behavior or structural dependencies. Every "rely
+> on native" verdict was re-tested with a CC-capability check **and** a read of the
+> consuming code. Net real drift across all 5 surfaces: the goal-emitter (shipped) and
+> the version-matrix catalogue (open). The other three are load-bearing KEEPs.
 
-> **Confirmed KEEP (not drift):** the M140 goal trio enforces **hard per-session
-> turn/token ceilings** (`ORK_GOAL_MAX_TURNS_PER_SESSION`=30,
-> `ORK_GOAL_MAX_TOKENS_PER_SESSION`=250k) that native `/goal` has no equivalent for —
-> `goal-budget-guard` (SessionEnd) writes a brake file that `prompt/goal-tracker`
-> reads to gate the next `/goal` via `continueOnBlock`. Orthogonal safety guarantee;
-> stays. (Audited 2026-06-05, #2217.)
+| ork mechanism | CC-native equivalent | Verdict (verified) |
+|---------------|----------------------|--------------------|
+| `lifecycle/session-registrar.ts` + `session-finalizer.ts` + `posttool/heartbeat.ts` (sessions.db) | `claude agents --json` liveness (2.1.161/162) | 🟢 **KEEP** — `sessions` is the **enforced-FK parent** (`PRAGMA foreign_keys=ON`) of `locks`/`settings_overrides`/`worktree_links`; `enter-registrar.ts:54-57` does a two-phase insert *because* `worktree_links.child_sid` FK requires the session row first. The spine is load-bearing, not liveness drift. Only `posttool/heartbeat.ts` + the dead `last_heartbeat` column (~59 ln) is marginal removable drift. |
+| `stop/goal-convergence-emitter.ts` (M168 bridge) | CC owns `goal-current.json` | ✅ **DONE (#2219)** — genuine Shadow (read CC-owned state, re-wrote `goal-history.jsonl`, emitted `goal_converged` with zero consumers). Removed. The M140 trio it was confused with is independently KEEP (below). |
+| `prompt/goal-tracker.ts` + `stop/goal-tracker.ts` + `lifecycle/goal-budget-guard.ts` (M140 trio) | native `/goal` (2.1.139+) | 🟢 **KEEP** — enforces hard per-session turn/token ceilings (`ORK_GOAL_MAX_TURNS_PER_SESSION`=30, `ORK_GOAL_MAX_TOKENS_PER_SESSION`=250k) native `/goal` lacks; `goal-budget-guard` writes a brake file `prompt/goal-tracker` reads to gate the next `/goal` via `continueOnBlock`. Orthogonal safety guarantee. |
+| `notification/desktop.ts` + `unified-dispatcher.ts` + `entries/notification.ts` (osascript) | hook `terminalSequence` (2.1.141) | 🟢 **KEEP** — *original THIN overturned.* `terminalSequence` is a raw OSC escape, **terminal-emulator-dependent** (silent in Apple Terminal / VS Code / tmux), title+body only; CC has **no native OS-level notification**. `osascript`/`notify-send` reaches the OS notification center across **all** terminals with rich content (repo+branch+issue#). Irreplaceable. [#1847 → won't-do] |
+| `lib/cc-version-matrix.ts` (615 lines / 478 entries) | CC has **no** runtime capability API | 🟠 **THIN (confirmed)** — `hasFeature`/`getAvailableFeatures`/`getMissingFeatures` have **zero production call-sites**; the only consumers (`cc-version-check.ts:42`, `generate-docs-data.js`) each read a single scalar (latest known version / `MIN_CC_VERSION`). The 478-row catalogue collapses to `MIN_CC_VERSION` + a `LATEST_KNOWN_CC` constant + `compareCCVersions()`. Genuine documentation-debt — open future refactor (drop or auto-generate). [#2217] |
+| `lifecycle/cc-version-check.ts` | CC 2.1.163 `requiredMinimumVersion` | 🟢 **KEEP** — `requiredMinimumVersion` is **managed-settings-only** (admin/MDM, hard-blocks before plugins load); a publicly-distributed plugin's users **cannot** set it. ork's SessionStart floor-warning is the only below-floor notice they get. The matrix-derived *adoption nudge* becomes a sequenced THIN only after the matrix thins. |
 
 ## Adopting a CC feature = often deleting ork code
 
@@ -90,11 +90,32 @@ When a CC release adds a native mechanism, frame the adoption **subtractively**:
 |------------------------|----------------------------|
 | "Use the new Stop `additionalContext`" | Retire the homegrown turn-continuation state machine it replaces |
 | "Trust subshell-aware `if:` matching" | Delete any PreToolUse hook re-parsing Bash to gate the same commands |
-| "Document `requiredMinimumVersion`" | Recognize ork's `MIN_CC_VERSION` is a toothless declaration; the native setting *enforces* — lean on it, keep only the policy doc |
+| "Document `requiredMinimumVersion`" | But it is **managed-settings-only** (admin/MDM) — a public plugin's users can't set it, so it does **not** replace a user-facing floor warning (see surface 5). Don't delete the warning hook on its account. |
+
+## Auditing this register — two mandatory gates
+
+The first-pass audit of this register was ~60% wrong because it reasoned from the file
+*under* audit alone. Before acting on any "rely on CC native / this is drift" verdict:
+
+1. **CC-capability check.** Actively feature-detect what the native surface
+   (`terminalSequence`, native `/goal`, `requiredMinimumVersion`, capability APIs) can
+   and cannot do on the current CC version. Never infer parity from a one-line changelog
+   claim — that is exactly how the notification THIN was wrong (terminalSequence is
+   terminal-dependent) and the version-check DELETE was wrong (`requiredMinimumVersion`
+   is managed-only).
+2. **Read the consumer, don't grep it.** Trace actual imports, FK constraints, and
+   call-sites *in the consuming function* — never the "used somewhere" heuristic. Reading
+   `cc-version-check.ts` revealed its only need is a scalar; reading `enter-registrar.ts`
+   revealed the `sessions` FK is load-bearing; a grep that matched the word "feature"
+   falsely flagged `cc-file-adoption-issues.sh` as a matrix consumer.
+
+A grep for call-sites **plus a read of the consuming function** beats any verdict reasoned
+from the audited file alone.
 
 ## Reference
 
 - Origin: `/ork:brainstorm` no-drift analysis, CC 2.1.163 adoption window (2026-06-05)
+- Re-audited + adversarially verified: 2026-06-05 (#2217)
 - Pairs with: `shared/rules/cc-support-policy.md`
-- Notification migration: #1847
-- Version matrix: `src/hooks/src/lib/cc-version-matrix.ts`
+- Notification migration #1847: closed won't-do (terminalSequence would degrade)
+- Version matrix: `src/hooks/src/lib/cc-version-matrix.ts` (the one open THIN)


### PR DESCRIPTION
## Summary

The first-pass `cc-native-first` drift audit (#2217) was **~60% wrong**. Code-only agents inferred "redundant with CC-native" from surface overlap without checking what CC actually does at runtime or the structural dependencies in ork's code. This corrects the register after re-verifying every verdict with two gates — a **CC-capability check** and a **read of the consuming code** — via a 6-agent adversarial workflow (one refuter per surface + synthesis).

## Corrected register

| # | surface | audit → verified | why the audit was wrong |
|---|---------|------------------|--------------------------|
| 1 | session-registry | THIN → **KEEP** | `sessions` is the enforced-FK parent (`PRAGMA foreign_keys=ON`) of locks/settings_overrides/worktree_links; `enter-registrar.ts:54-57` two-phase insert proves it's load-bearing |
| 2 | goal-emitter | DELETE → **DONE** (#2219) | genuinely a Shadow — shipped correctly |
| 3 | notification | THIN → **KEEP** (overturned) | `terminalSequence` is terminal-dependent (silent in Apple Terminal/VS Code); CC has no OS-level notification; osascript is irreplaceable |
| 4 | version-matrix | THIN → **THIN** (confirmed) | the one real open drift: feature helpers have 0 production callers; consumers read a single scalar; 478 rows → 2 constants |
| 5 | version-check | DELETE → **KEEP** | `requiredMinimumVersion` is managed-settings-only → ork's floor warning is the only one public users get |

## Also

- Adds the **two mandatory audit gates** to the rule (CC-capability check + read-the-consumer, don't grep).
- Fixes the now-wrong `requiredMinimumVersion` "lean on it" line in the subtractive-framing table.

## Net

Real drift across all 5 surfaces: goal-emitter (shipped) + the matrix catalogue (open). The no-drift **principle** stands; the per-mechanism **register** was the problem — and that's a documented, generalizable lesson now.

## Playground

`docs/docs--drift-register-correction/drift-reaudit-playground.html` — interactive verdict matrix (toggle original/verified, click rows for evidence + the refutation that failed) + the two-gate lesson.

Refs #2217

Generated with [Claude Code](https://claude.com/claude-code)