### PR TITLE
feat(skills): adversarial verification engine + assess pilot (#2231)

### DIFF
--- a/docs/feat--adversarial-verify-skills/adversarial-verify-playground.html
+++ b/docs/feat--adversarial-verify-skills/adversarial-verify-playground.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Adversarial Verification — assess pilot · OrchestKit</title>
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--panel2:#1c2330;--border:#30363d;--txt:#e6edf3;--dim:#8b949e;--accent:#58a6ff;--green:#3fb950;--amber:#d29922;--redhi:#ff7b72;--purple:#bc8cff;--mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--txt);font-family:var(--mono);font-size:14px;line-height:1.55;padding:28px 20px 80px}
+  .wrap{max-width:1020px;margin:0 auto}
+  h1{font-size:21px;margin:0 0 4px}
+  h2{font-size:14px;text-transform:uppercase;letter-spacing:1px;color:var(--dim);margin:30px 0 12px;border-bottom:1px solid var(--border);padding-bottom:6px}
+  .sub{color:var(--dim);margin:0 0 6px}
+  .tag{display:inline-block;padding:1px 8px;border-radius:10px;font-size:11px;border:1px solid var(--border);color:var(--dim)}
+  .flow{display:grid;grid-template-columns:1fr auto 1fr auto 1fr;gap:8px;align-items:center;margin-top:14px;font-size:12.5px}
+  .box{background:var(--panel);border:1px solid var(--border);border-radius:8px;padding:12px}
+  .box b{color:var(--txt)}
+  .arr{color:var(--accent);text-align:center;font-size:18px}
+  .blind{border-color:var(--redhi)}
+  .rules{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px}
+  .rule{background:var(--panel);border:1px solid var(--border);border-radius:7px;padding:9px 11px;font-size:12.5px;cursor:pointer;transition:background .12s}
+  .rule:hover{background:var(--panel2)}
+  .rule .t{color:var(--accent);font-weight:600}
+  .rule .d{color:var(--dim);display:none;margin-top:5px}
+  .rule.open .d{display:block}
+  table{width:100%;border-collapse:collapse;margin-top:8px}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--border);font-size:12.5px;vertical-align:top}
+  th{color:var(--dim);font-size:11px;text-transform:uppercase}
+  .chip{display:inline-block;font-size:11px;padding:1px 8px;border-radius:9px;border:1px solid var(--border)}
+  .ship{color:var(--green);border-color:var(--green)}
+  .defer{color:var(--amber);border-color:var(--amber)}
+  .gate{background:#0a0d12;border:1px solid var(--border);border-radius:8px;padding:10px 13px;margin-top:8px;font-size:12.5px}
+  .gate b{color:var(--amber)}
+  code{color:var(--purple);background:rgba(188,140,255,.08);padding:1px 5px;border-radius:4px}
+  .note{font-size:12px;color:var(--dim);margin-top:10px}
+  .outbox{background:#0a0d12;border:1px solid var(--border);border-radius:8px;padding:14px 16px;margin-top:10px;white-space:pre-wrap;font-size:12.5px;position:relative}
+  .copy{position:absolute;top:10px;right:10px;background:var(--panel2);border:1px solid var(--border);color:var(--txt);border-radius:6px;padding:4px 10px;font-family:var(--mono);font-size:11px;cursor:pointer}
+  .copy:hover{border-color:var(--accent);color:var(--accent)}.copy.done{color:var(--green);border-color:var(--green)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>🛡️ Adversarial Verification — assess pilot</h1>
+  <p class="sub">#2231 · removes self-preferential bias from evaluative skills · designed by a workflow that dogfooded the pattern</p>
+  <span class="tag">3 blind challengers found all 3 designs unsound (10/10/7 weaknesses) → Opus synthesized the fixes</span>
+
+  <h2>🔄 The blind-refuter flow</h2>
+  <div class="flow">
+    <div class="box"><b>Producer</b><br>assessor scores a dimension 0-10 (its own subject)</div>
+    <div class="arr">→</div>
+    <div class="box blind"><b>Blind refuter</b><br>sees ONLY the code + rubric + neutral claim — <b>not</b> the score, identity, or prose. Scores independently FIRST.</div>
+    <div class="arr">→</div>
+    <div class="box"><b>Orchestrator</b><br>compares out-of-band, verifies the citation, applies quorum → ledger</div>
+  </div>
+  <p class="note">The key fix the adversarial pass forced: the refuter never sees the producer's number — handing it over pre-loads anchoring. It scores from the code itself; the orchestrator (not the refuter) decides SURVIVES/OVERTURNED.</p>
+
+  <h2>📜 The 10 engine rules (click)</h2>
+  <div class="rules" id="rules"></div>
+
+  <h2>🎯 Scope — ship the safe pilot, defer the risky wiring</h2>
+  <p class="sub">The synthesis flagged its own risks: false-negative inversion in a merge gate, "high coordination cost for one PR."</p>
+  <table>
+    <thead><tr><th>skill</th><th>this PR</th><th>why</th></tr></thead>
+    <tbody>
+      <tr><td><code>assess</code></td><td><span class="chip ship">SHIP</span></td><td>scores quality — doesn't gate merges or security. Lowest blast radius. Effort-gated Phase 2.5.</td></tr>
+      <tr><td><code>review-pr</code></td><td><span class="chip defer">DEFER</span></td><td>gates merges — false-negative inversion could drop a real blocker. Needs no-auto-flip + conformance enforcement first.</td></tr>
+      <tr><td><code>audit-full</code></td><td><span class="chip defer">DEFER</span></td><td>security findings — same risk; deterministic-exemption + cross-file rules must be enforced, not advisory.</td></tr>
+      <tr><td><i>conformance grader</i></td><td><span class="chip defer">DEFER</span></td><td>"the spec is advisory unless a grader enforces it" — the adoption-gap follow-up.</td></tr>
+    </tbody>
+  </table>
+  <div class="gate"><b>Honest residual:</b> a one-sided "your job is to REFUTE" pass raises false negatives. For a merge gate that's the costlier error — which is exactly why review-pr/audit-full are deferred until the enforcement gates are real, not just documented.</div>
+
+  <h2>📦 What lands</h2>
+  <div class="outbox"><button class="copy" id="cp">copy</button><span id="out"></span></div>
+
+  <p class="note" style="margin-top:22px">Engine: <code>src/skills/shared/rules/adversarial-refutation.md</code> · adapter: <code>src/skills/assess/references/adversarial-refutation.md</code> · designed by the <code>adversarial-verify-design</code> workflow (7 agents)</p>
+</div>
+<script>
+const rules=[
+ ['1 · Blindness contract','Refuter prompt may contain code+rubric+neutral claim; NEVER the producer number, identity, prose, or evidence list — those ARE the reasoning being de-biased.'],
+ ['2 · Independent-score-first','Refuter scores from the code itself; orchestrator compares out-of-band. Revise to the near band edge, never the midpoint. Kills anchoring.'],
+ ['3 · Citation-verification','Re-open the cited file:line before honoring a kill. Hallucinated/assertion-only → UPHELD.'],
+ ['4 · Quorum','Top-tier 3 refuters majority; mid-tier 2; single only for advisory. A 1-of-N dissent never revises — it drops confidence to low.'],
+ ['5 · Cross-file UPHELD-default','"Couldn\'t reproduce the traced flow" → UPHELD. A narrow refuter can\'t kill a true cross-file finding it couldn\'t see.'],
+ ['6 · Deterministic exemption','Never refute build/test/lint/CVE ground truth — only a reachability CLAIM on a CVE is refutable.'],
+ ['7 · No-auto-flip','Refutation alone can\'t flip block→approve or raise a headline score. Keep producer + post-refutation scores; human signs off.'],
+ ['8 · Spawn ceiling','Dedup to root-cause first; cap 24 refuters/run; rank by severity×distance-to-boundary; flag the rest, never silently truncate.'],
+ ['9 · Always-isolated spawn','Refuters are plain Agent() Tasks with NO team_name even in Agent-Teams mode — joining the mesh leaks producer reasoning via SendMessage.'],
+ ['10 · Refutation ledger','Persist {votes, verified_citations, outcome, original/revised} so wrong KEEPs AND wrong KILLs are auditable cross-session.'],
+];
+document.getElementById('rules').innerHTML=rules.map((r,i)=>`<div class="rule" data-i="${i}"><div class="t">${r[0]}</div><div class="d">${r[1]}</div></div>`).join('');
+document.querySelectorAll('.rule').forEach(el=>el.addEventListener('click',()=>el.classList.toggle('open')));
+const out=[
+"#2231 — adversarial verification, assess pilot (one PR)",
+"",
+"NEW  src/skills/shared/rules/adversarial-refutation.md   the 10-rule blind-refuter engine",
+"NEW  src/skills/assess/references/adversarial-refutation.md   assess bindings + scope/effort gate",
+"EDIT src/skills/assess/SKILL.md   + Phase 2.5 (effort-gated: low/med skip, high advisory, xhigh majority-revise)",
+"EDIT src/skills/shared/rules/_sections.md   catalog entry",
+"",
+"DEFER (follow-ups, #157):  review-pr wiring · audit-full wiring · conformance grader",
+"Reason: false-negative inversion in a merge gate is the costlier error — enforce before bulk-wiring.",
+].join("\n");
+document.getElementById('out').textContent=out;
+document.getElementById('cp').addEventListener('click',e=>{navigator.clipboard.writeText(out).then(()=>{e.target.textContent='copied ✓';e.target.classList.add('done');setTimeout(()=>{e.target.textContent='copy';e.target.classList.remove('done');},1400);});});
+</script>
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/assess.mdx
+++ b/docs/site/content/docs/reference/skills/assess.mdx
@@ -246,6 +246,25 @@ Load `Read("$\{CLAUDE_SKILL_DIR\}/references/agent-spawn-definitions.md")` for T
 
 ---
 
+## Phase 2.5: Adversarial Refutation (effort-gated)
+
+The assessor that scores a dimension is also its only judge — self-preferential bias.
+A separate **blind refuter** verifies decision-bearing scores before they reach the
+composite. **Effort gate:** `low`/`medium` skip this phase entirely; `high` runs up-to-4
+single refuters (advisory, no auto-swing); `xhigh` runs 3-refuter majority with auto-revise.
+
+Load the protocol + assess bindings: `Read("$\{CLAUDE_SKILL_DIR\}/references/adversarial-refutation.md")`
+(which loads the shared engine `$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 2 returns, before the composite/grade and Phases 3-7. Refuters are ALWAYS
+isolated `Agent(...)` Task spawns (never team members, even in Agent Teams mode) fed only the
+serialized claim — no producer score, identity, or prose. Revised scores recompute the
+composite; the refutation ledger (`02b-refutation.json`) records survived/killed/downgraded
+so wrong scores are auditable. Keep the producer-basis score AND a labeled post-refutation
+score — refutation never silently raises the grade.
+
+---
+
 ## Phases 3-7: Analysis, Comparison & Report
 
 Load `Read("$\{CLAUDE_SKILL_DIR\}/references/phase-templates.md")` for output templates for pros/cons, alternatives, improvements, effort, and the final report.
@@ -554,7 +573,56 @@ Action: Decompose into subtasks before starting
 
 ---
 
-## References (10)
+## References (11)
+
+### Adversarial Refutation
+
+# Adversarial Refutation — assess bindings
+
+Thin adapter. Loads the shared engine, then binds it to assess's scoring model.
+
+**Load the engine first:** `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's assess-specific.
+
+## Bindings
+
+| Engine concept | assess binding |
+|----------------|----------------|
+| "finding" | a per-dimension 0-10 score from Phase 2 (`02-evaluation.json`) |
+| rubric | `quality-gates/references/unified-scoring-framework.md` + `references/quality-model.md` |
+| refuter agent | the same `subagent_type` that scored the dimension (code-quality-reviewer / security-auditor / *-performance-engineer / test-generator), spawned blind |
+| code artifact | the Phase 1.5 scoped file list (`references/scope-discovery.md`) + the ≤12-tool-call budget |
+| ledger | `02b-refutation.json` (new Phase Handoffs row) |
+| revised output | recomputed composite + a "Refuted?" note in the Phase 7 report; `refuted` + `original_score` fields on the Phase 7b dashboard dimension objects |
+
+## Scope filter (which scores get a refuter)
+
+A dimension score qualifies only if decision-bearing — ANY of:
+- score **≥8** (praise-inflation: the assessor patting the subject on the back) or **≤4** (over-penalty)
+- **high-weight** dimension (Security 0.20; Correctness/Maintainability/Compliance 0.15)
+- within **±0.5 of a grade boundary** (refutation could flip the letter grade)
+- a Phase 5 **Quick Win** (effort ≤2, impact ≥4) that `/ork:implement` will act on
+
+Skip: mid-band (5-7) scores on low-weight dimensions (Scalability/Simplicity 0.10) not near a
+boundary, and descriptive pros/cons with no score. Bounds spawns to ~2-4 per assessment.
+
+## Effort gate (assess-specific)
+
+- `low` / `medium` → **skip Phase 2.5 entirely**
+- `high` → up-to-4 **single** refuters, advisory only (a single refuter never auto-swings a
+  score; OVERTURNED-with-verified-citation is surfaced for the user, not auto-applied)
+- `xhigh` → **3-refuter majority** per qualifying score; auto-revise to the near band edge only
+  on ≥2-of-3 VERIFIED overturns; a 1-of-3 dissent writes the existing `confidence`/`caveats`
+  channel and drops that dimension's confidence to "low"
+
+## Isolation note
+
+Even when Phase 2 ran in Agent Teams mode, Phase 2.5 refuters are ALWAYS standalone
+`Agent(...)` Task spawns with **no `team_name`** — fed only the serialized claim from
+`02-evaluation.json`. Joining the mesh would leak producer reasoning (engine rule 9).
+
 
 ### Agent Spawn Definitions
 

--- a/plugins/ork/commands/assess.md
+++ b/plugins/ork/commands/assess.md
@@ -230,6 +230,24 @@ Load `Read("${CLAUDE_SKILL_DIR}/references/agent-spawn-definitions.md")` for Tas
 **Composite Score:** Weighted average of all 6 dimensions (see quality-model.md).
 
 
+## Phase 2.5: Adversarial Refutation (effort-gated)
+
+The assessor that scores a dimension is also its only judge — self-preferential bias.
+A separate **blind refuter** verifies decision-bearing scores before they reach the
+composite. **Effort gate:** `low`/`medium` skip this phase entirely; `high` runs up-to-4
+single refuters (advisory, no auto-swing); `xhigh` runs 3-refuter majority with auto-revise.
+
+Load the protocol + assess bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 2 returns, before the composite/grade and Phases 3-7. Refuters are ALWAYS
+isolated `Agent(...)` Task spawns (never team members, even in Agent Teams mode) fed only the
+serialized claim — no producer score, identity, or prose. Revised scores recompute the
+composite; the refutation ledger (`02b-refutation.json`) records survived/killed/downgraded
+so wrong scores are auditable. Keep the producer-basis score AND a labeled post-refutation
+score — refutation never silently raises the grade.
+
+
 ## Phases 3-7: Analysis, Comparison & Report
 
 Load `Read("${CLAUDE_SKILL_DIR}/references/phase-templates.md")` for output templates for pros/cons, alternatives, improvements, effort, and the final report.

--- a/plugins/ork/skills/assess/SKILL.md
+++ b/plugins/ork/skills/assess/SKILL.md
@@ -266,6 +266,25 @@ Load `Read("${CLAUDE_SKILL_DIR}/references/agent-spawn-definitions.md")` for Tas
 
 ---
 
+## Phase 2.5: Adversarial Refutation (effort-gated)
+
+The assessor that scores a dimension is also its only judge — self-preferential bias.
+A separate **blind refuter** verifies decision-bearing scores before they reach the
+composite. **Effort gate:** `low`/`medium` skip this phase entirely; `high` runs up-to-4
+single refuters (advisory, no auto-swing); `xhigh` runs 3-refuter majority with auto-revise.
+
+Load the protocol + assess bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 2 returns, before the composite/grade and Phases 3-7. Refuters are ALWAYS
+isolated `Agent(...)` Task spawns (never team members, even in Agent Teams mode) fed only the
+serialized claim — no producer score, identity, or prose. Revised scores recompute the
+composite; the refutation ledger (`02b-refutation.json`) records survived/killed/downgraded
+so wrong scores are auditable. Keep the producer-basis score AND a labeled post-refutation
+score — refutation never silently raises the grade.
+
+---
+
 ## Phases 3-7: Analysis, Comparison & Report
 
 Load `Read("${CLAUDE_SKILL_DIR}/references/phase-templates.md")` for output templates for pros/cons, alternatives, improvements, effort, and the final report.

--- a/plugins/ork/skills/assess/references/adversarial-refutation.md
+++ b/plugins/ork/skills/assess/references/adversarial-refutation.md
@@ -1,0 +1,45 @@
+# Adversarial Refutation — assess bindings
+
+Thin adapter. Loads the shared engine, then binds it to assess's scoring model.
+
+**Load the engine first:** `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's assess-specific.
+
+## Bindings
+
+| Engine concept | assess binding |
+|----------------|----------------|
+| "finding" | a per-dimension 0-10 score from Phase 2 (`02-evaluation.json`) |
+| rubric | `quality-gates/references/unified-scoring-framework.md` + `references/quality-model.md` |
+| refuter agent | the same `subagent_type` that scored the dimension (code-quality-reviewer / security-auditor / *-performance-engineer / test-generator), spawned blind |
+| code artifact | the Phase 1.5 scoped file list (`references/scope-discovery.md`) + the ≤12-tool-call budget |
+| ledger | `02b-refutation.json` (new Phase Handoffs row) |
+| revised output | recomputed composite + a "Refuted?" note in the Phase 7 report; `refuted` + `original_score` fields on the Phase 7b dashboard dimension objects |
+
+## Scope filter (which scores get a refuter)
+
+A dimension score qualifies only if decision-bearing — ANY of:
+- score **≥8** (praise-inflation: the assessor patting the subject on the back) or **≤4** (over-penalty)
+- **high-weight** dimension (Security 0.20; Correctness/Maintainability/Compliance 0.15)
+- within **±0.5 of a grade boundary** (refutation could flip the letter grade)
+- a Phase 5 **Quick Win** (effort ≤2, impact ≥4) that `/ork:implement` will act on
+
+Skip: mid-band (5-7) scores on low-weight dimensions (Scalability/Simplicity 0.10) not near a
+boundary, and descriptive pros/cons with no score. Bounds spawns to ~2-4 per assessment.
+
+## Effort gate (assess-specific)
+
+- `low` / `medium` → **skip Phase 2.5 entirely**
+- `high` → up-to-4 **single** refuters, advisory only (a single refuter never auto-swings a
+  score; OVERTURNED-with-verified-citation is surfaced for the user, not auto-applied)
+- `xhigh` → **3-refuter majority** per qualifying score; auto-revise to the near band edge only
+  on ≥2-of-3 VERIFIED overturns; a 1-of-3 dissent writes the existing `confidence`/`caveats`
+  channel and drops that dimension's confidence to "low"
+
+## Isolation note
+
+Even when Phase 2 ran in Agent Teams mode, Phase 2.5 refuters are ALWAYS standalone
+`Agent(...)` Task spawns with **no `team_name`** — fed only the serialized claim from
+`02-evaluation.json`. Joining the mesh would leak producer reasoning (engine rule 9).

--- a/plugins/ork/skills/shared/rules/_sections.md
+++ b/plugins/ork/skills/shared/rules/_sections.md
@@ -16,3 +16,10 @@ Cross-cutting evidence requirements for all skill completion claims.
 Anti-sycophancy and direct communication standards for review and feedback skills.
 
 - `anti-sycophancy.md` — Ban performative agreement, require direct technical statements
+
+## 3. Adversarial Verification (adversarial) — HIGH — 1 rule
+
+Blind-refuter protocol for evaluative skills (assess, review-pr, audit-full) — removes
+self-preferential bias by verifying decision-bearing findings with a separate, blind agent.
+
+- `adversarial-refutation.md` — Blindness contract, independent-score-first, citation-verify, quorum, no-auto-flip

--- a/plugins/ork/skills/shared/rules/adversarial-refutation.md
+++ b/plugins/ork/skills/shared/rules/adversarial-refutation.md
@@ -1,0 +1,109 @@
+---
+title: "Adversarial Refutation Engine"
+impact: HIGH
+impactDescription: "Shared blind-refuter protocol that removes self-preferential bias from evaluative skills — the producer of a finding can't be its own fair judge"
+tags: [verification, adversarial, evaluation, anti-bias]
+---
+
+# Adversarial Refutation Engine
+
+Shared protocol for evaluative skills (`assess`, `review-pr`, `audit-full`) to verify
+their own decision-bearing findings with a **separate, blind refuter** — the structural
+fix for self-preferential bias. A verifier with skin in the game can't be a fair verifier;
+the producer's number, evidence list, and prose ARE its reasoning, so forwarding them
+re-introduces the anchoring the pass is meant to remove.
+
+> Evidence this matters: the #2217 drift-register audit was ~60% wrong because findings
+> judged themselves. An adversarial pass (this protocol) caught a wrong "KEEP" verdict.
+
+Each skill loads this engine via a thin `references/adversarial-refutation.md` adapter that
+supplies its bindings (which field = "finding", which rubric, where survivors/kills land).
+
+## 1. Blindness contract
+
+The refuter prompt MAY contain: `{file, line, category, raw code slice (PRIMARY artifact),
+rubric excerpt, sanitized accepted conventions}` and a **neutral claim** naming ONLY the
+category + location.
+
+It MUST NOT contain: the producer's identity/`subagent_type`, the producer's **number or
+severity label**, the producer's description/impact/suggestion prose, the producer's curated
+evidence list, sibling findings, the original producer prompt, or "known-weakness" priors.
+
+## 2. Independent-score-first
+
+The refuter never sees the producer's value. It (a) reads the cited code itself, (b) forms
+its OWN severity/score band from the rubric, (c) returns an existence verdict. The
+**orchestrator** — not the refuter — computes SURVIVES/OVERTURNED by comparing the
+producer's value against the refuter's independent band. Revise only when the producer
+value sits OUTSIDE the band, and revise to the **near band edge** (never the midpoint).
+
+## 3. Citation-verification gate
+
+Before any KILL/OVERTURN/DOWNGRADE is honored, the orchestrator re-opens the refuter's
+cited `file:line` and confirms it exists and supports the verdict. Unverifiable/hallucinated
+citation → downgrade to UPHELD. "No refutation found" or assertion-only (no citation) → UPHELD.
+
+## 4. Quorum (no lone judge on either side)
+
+| Finding tier | Refuters | Rule |
+|--------------|----------|------|
+| Top (CRITICAL audit / request-changes blocker / high-weight score near a grade boundary) | 3 | majority — ≥2 of 3 with VERIFIED counter-evidence |
+| Mid (HIGH severity / decision-bearing dimension) | 2 | majority — never a single unilateral kill that changes a verdict |
+| Advisory (cannot change a merge verdict or headline score) | 1 | single refuter allowed |
+
+A 1-of-N dissent never revises — record it as a caveat and drop that finding's confidence
+to "low".
+
+## 5. Cross-file UPHELD-by-default
+
+If the finding asserts a multi-file flow (taint / data-flow / cross-module), the card MUST
+carry the producer's full traced file set. Refuter instruction: "could not reproduce the
+traced flow" → **UPHELD** (never REFUTED). A narrow-context refuter must not kill a true
+cross-file finding it simply couldn't see.
+
+## 6. Deterministic exemption
+
+NEVER refute ground truth: failing build/test/lint output, npm-audit/CVSS tool matches,
+type-check errors. Only a reachability **claim** layered on top of a CVE is refutable — and
+only that claim.
+
+## 7. No-auto-flip (human-facing gates)
+
+Refutation alone MAY demote a finding's display bucket but may NOT, by itself, flip a
+human-facing merge/ship verdict from block→approve, nor silently raise a headline score.
+Keep the producer-basis headline score AND publish a separately-labeled "post-refutation"
+score. Surface every killed CRITICAL/HIGH prominently (not buried); require explicit user
+confirmation before a kill removes a blocker.
+
+## 8. Global spawn ceiling
+
+Dedup to root-cause BEFORE counting. Hard cap total refuter spawns per run (default **24**).
+If `material findings × refuters-per-finding` exceeds the cap, rank by
+`severity-weight × distance-from-decision-boundary`, refute the top-K, and ship the rest
+flagged "not independently refuted — manual review required". Never silently truncate.
+
+## 9. Always-isolated spawn
+
+Refuters are ALWAYS plain Task-tool `Agent(...)` spawns with **no `team_name`**, even when
+the producer phase ran in Agent-Teams mode — joining the mesh leaks producer reasoning via
+`SendMessage` history and destroys blindness. Delivery is prompt/`additionalContext`-only
+(cache-safe; no mid-session system-prompt mutation).
+
+## 10. Refutation ledger (shared output schema)
+
+Persist per finding so wrong KEEPs AND wrong KILLs are auditable cross-session:
+
+```json
+{ "finding_id": "...", "refuters": 3, "votes": {"refuted": 2, "upheld": 1, "downgrade": 0},
+  "verified_citations": ["file:line"], "outcome": "survived|killed|downgraded|unrefuted",
+  "confidence": "high|low", "original_value": "...", "revised_value": "..." }
+```
+
+## Known residual bias (state it, don't hide it)
+
+A one-sided "your job is to REFUTE" pass raises **false negatives** — for a merge gate or
+security audit, dropping a real bug is costlier than a noisy false positive. The gates above
+(citation-verify, raised quorum, cross-file UPHELD-default, no-auto-flip) bound it, but N
+same-model refuters share blind spots: majority buys variance reduction, not independent
+bias correction. Recomputing the headline over survivors is itself a new self-preference —
+that's why both scores are published and a human signs off.

--- a/src/skills/assess/SKILL.md
+++ b/src/skills/assess/SKILL.md
@@ -266,6 +266,25 @@ Load `Read("${CLAUDE_SKILL_DIR}/references/agent-spawn-definitions.md")` for Tas
 
 ---
 
+## Phase 2.5: Adversarial Refutation (effort-gated)
+
+The assessor that scores a dimension is also its only judge — self-preferential bias.
+A separate **blind refuter** verifies decision-bearing scores before they reach the
+composite. **Effort gate:** `low`/`medium` skip this phase entirely; `high` runs up-to-4
+single refuters (advisory, no auto-swing); `xhigh` runs 3-refuter majority with auto-revise.
+
+Load the protocol + assess bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 2 returns, before the composite/grade and Phases 3-7. Refuters are ALWAYS
+isolated `Agent(...)` Task spawns (never team members, even in Agent Teams mode) fed only the
+serialized claim — no producer score, identity, or prose. Revised scores recompute the
+composite; the refutation ledger (`02b-refutation.json`) records survived/killed/downgraded
+so wrong scores are auditable. Keep the producer-basis score AND a labeled post-refutation
+score — refutation never silently raises the grade.
+
+---
+
 ## Phases 3-7: Analysis, Comparison & Report
 
 Load `Read("${CLAUDE_SKILL_DIR}/references/phase-templates.md")` for output templates for pros/cons, alternatives, improvements, effort, and the final report.

--- a/src/skills/assess/references/adversarial-refutation.md
+++ b/src/skills/assess/references/adversarial-refutation.md
@@ -1,0 +1,45 @@
+# Adversarial Refutation — assess bindings
+
+Thin adapter. Loads the shared engine, then binds it to assess's scoring model.
+
+**Load the engine first:** `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's assess-specific.
+
+## Bindings
+
+| Engine concept | assess binding |
+|----------------|----------------|
+| "finding" | a per-dimension 0-10 score from Phase 2 (`02-evaluation.json`) |
+| rubric | `quality-gates/references/unified-scoring-framework.md` + `references/quality-model.md` |
+| refuter agent | the same `subagent_type` that scored the dimension (code-quality-reviewer / security-auditor / *-performance-engineer / test-generator), spawned blind |
+| code artifact | the Phase 1.5 scoped file list (`references/scope-discovery.md`) + the ≤12-tool-call budget |
+| ledger | `02b-refutation.json` (new Phase Handoffs row) |
+| revised output | recomputed composite + a "Refuted?" note in the Phase 7 report; `refuted` + `original_score` fields on the Phase 7b dashboard dimension objects |
+
+## Scope filter (which scores get a refuter)
+
+A dimension score qualifies only if decision-bearing — ANY of:
+- score **≥8** (praise-inflation: the assessor patting the subject on the back) or **≤4** (over-penalty)
+- **high-weight** dimension (Security 0.20; Correctness/Maintainability/Compliance 0.15)
+- within **±0.5 of a grade boundary** (refutation could flip the letter grade)
+- a Phase 5 **Quick Win** (effort ≤2, impact ≥4) that `/ork:implement` will act on
+
+Skip: mid-band (5-7) scores on low-weight dimensions (Scalability/Simplicity 0.10) not near a
+boundary, and descriptive pros/cons with no score. Bounds spawns to ~2-4 per assessment.
+
+## Effort gate (assess-specific)
+
+- `low` / `medium` → **skip Phase 2.5 entirely**
+- `high` → up-to-4 **single** refuters, advisory only (a single refuter never auto-swings a
+  score; OVERTURNED-with-verified-citation is surfaced for the user, not auto-applied)
+- `xhigh` → **3-refuter majority** per qualifying score; auto-revise to the near band edge only
+  on ≥2-of-3 VERIFIED overturns; a 1-of-3 dissent writes the existing `confidence`/`caveats`
+  channel and drops that dimension's confidence to "low"
+
+## Isolation note
+
+Even when Phase 2 ran in Agent Teams mode, Phase 2.5 refuters are ALWAYS standalone
+`Agent(...)` Task spawns with **no `team_name`** — fed only the serialized claim from
+`02-evaluation.json`. Joining the mesh would leak producer reasoning (engine rule 9).

--- a/src/skills/shared/rules/_sections.md
+++ b/src/skills/shared/rules/_sections.md
@@ -16,3 +16,10 @@ Cross-cutting evidence requirements for all skill completion claims.
 Anti-sycophancy and direct communication standards for review and feedback skills.
 
 - `anti-sycophancy.md` — Ban performative agreement, require direct technical statements
+
+## 3. Adversarial Verification (adversarial) — HIGH — 1 rule
+
+Blind-refuter protocol for evaluative skills (assess, review-pr, audit-full) — removes
+self-preferential bias by verifying decision-bearing findings with a separate, blind agent.
+
+- `adversarial-refutation.md` — Blindness contract, independent-score-first, citation-verify, quorum, no-auto-flip

--- a/src/skills/shared/rules/adversarial-refutation.md
+++ b/src/skills/shared/rules/adversarial-refutation.md
@@ -1,0 +1,109 @@
+---
+title: "Adversarial Refutation Engine"
+impact: HIGH
+impactDescription: "Shared blind-refuter protocol that removes self-preferential bias from evaluative skills — the producer of a finding can't be its own fair judge"
+tags: [verification, adversarial, evaluation, anti-bias]
+---
+
+# Adversarial Refutation Engine
+
+Shared protocol for evaluative skills (`assess`, `review-pr`, `audit-full`) to verify
+their own decision-bearing findings with a **separate, blind refuter** — the structural
+fix for self-preferential bias. A verifier with skin in the game can't be a fair verifier;
+the producer's number, evidence list, and prose ARE its reasoning, so forwarding them
+re-introduces the anchoring the pass is meant to remove.
+
+> Evidence this matters: the #2217 drift-register audit was ~60% wrong because findings
+> judged themselves. An adversarial pass (this protocol) caught a wrong "KEEP" verdict.
+
+Each skill loads this engine via a thin `references/adversarial-refutation.md` adapter that
+supplies its bindings (which field = "finding", which rubric, where survivors/kills land).
+
+## 1. Blindness contract
+
+The refuter prompt MAY contain: `{file, line, category, raw code slice (PRIMARY artifact),
+rubric excerpt, sanitized accepted conventions}` and a **neutral claim** naming ONLY the
+category + location.
+
+It MUST NOT contain: the producer's identity/`subagent_type`, the producer's **number or
+severity label**, the producer's description/impact/suggestion prose, the producer's curated
+evidence list, sibling findings, the original producer prompt, or "known-weakness" priors.
+
+## 2. Independent-score-first
+
+The refuter never sees the producer's value. It (a) reads the cited code itself, (b) forms
+its OWN severity/score band from the rubric, (c) returns an existence verdict. The
+**orchestrator** — not the refuter — computes SURVIVES/OVERTURNED by comparing the
+producer's value against the refuter's independent band. Revise only when the producer
+value sits OUTSIDE the band, and revise to the **near band edge** (never the midpoint).
+
+## 3. Citation-verification gate
+
+Before any KILL/OVERTURN/DOWNGRADE is honored, the orchestrator re-opens the refuter's
+cited `file:line` and confirms it exists and supports the verdict. Unverifiable/hallucinated
+citation → downgrade to UPHELD. "No refutation found" or assertion-only (no citation) → UPHELD.
+
+## 4. Quorum (no lone judge on either side)
+
+| Finding tier | Refuters | Rule |
+|--------------|----------|------|
+| Top (CRITICAL audit / request-changes blocker / high-weight score near a grade boundary) | 3 | majority — ≥2 of 3 with VERIFIED counter-evidence |
+| Mid (HIGH severity / decision-bearing dimension) | 2 | majority — never a single unilateral kill that changes a verdict |
+| Advisory (cannot change a merge verdict or headline score) | 1 | single refuter allowed |
+
+A 1-of-N dissent never revises — record it as a caveat and drop that finding's confidence
+to "low".
+
+## 5. Cross-file UPHELD-by-default
+
+If the finding asserts a multi-file flow (taint / data-flow / cross-module), the card MUST
+carry the producer's full traced file set. Refuter instruction: "could not reproduce the
+traced flow" → **UPHELD** (never REFUTED). A narrow-context refuter must not kill a true
+cross-file finding it simply couldn't see.
+
+## 6. Deterministic exemption
+
+NEVER refute ground truth: failing build/test/lint output, npm-audit/CVSS tool matches,
+type-check errors. Only a reachability **claim** layered on top of a CVE is refutable — and
+only that claim.
+
+## 7. No-auto-flip (human-facing gates)
+
+Refutation alone MAY demote a finding's display bucket but may NOT, by itself, flip a
+human-facing merge/ship verdict from block→approve, nor silently raise a headline score.
+Keep the producer-basis headline score AND publish a separately-labeled "post-refutation"
+score. Surface every killed CRITICAL/HIGH prominently (not buried); require explicit user
+confirmation before a kill removes a blocker.
+
+## 8. Global spawn ceiling
+
+Dedup to root-cause BEFORE counting. Hard cap total refuter spawns per run (default **24**).
+If `material findings × refuters-per-finding` exceeds the cap, rank by
+`severity-weight × distance-from-decision-boundary`, refute the top-K, and ship the rest
+flagged "not independently refuted — manual review required". Never silently truncate.
+
+## 9. Always-isolated spawn
+
+Refuters are ALWAYS plain Task-tool `Agent(...)` spawns with **no `team_name`**, even when
+the producer phase ran in Agent-Teams mode — joining the mesh leaks producer reasoning via
+`SendMessage` history and destroys blindness. Delivery is prompt/`additionalContext`-only
+(cache-safe; no mid-session system-prompt mutation).
+
+## 10. Refutation ledger (shared output schema)
+
+Persist per finding so wrong KEEPs AND wrong KILLs are auditable cross-session:
+
+```json
+{ "finding_id": "...", "refuters": 3, "votes": {"refuted": 2, "upheld": 1, "downgrade": 0},
+  "verified_citations": ["file:line"], "outcome": "survived|killed|downgraded|unrefuted",
+  "confidence": "high|low", "original_value": "...", "revised_value": "..." }
+```
+
+## Known residual bias (state it, don't hide it)
+
+A one-sided "your job is to REFUTE" pass raises **false negatives** — for a merge gate or
+security audit, dropping a real bug is costlier than a noisy false positive. The gates above
+(citation-verify, raised quorum, cross-file UPHELD-default, no-auto-flip) bound it, but N
+same-model refuters share blind spots: majority buys variance reduction, not independent
+bias correction. Recomputing the headline over survivors is itself a new self-preference —
+that's why both scores are published and a human signs off.


### PR DESCRIPTION
## Summary

Adopts the Dynamic-Workflows **adversarial-verification** pattern (#2231) to remove self-preferential bias from evaluative skills — the producer of a finding can't be its own fair judge. This PR ships the **engine + the assess pilot**; the higher-risk wiring is deferred (see Scope).

## How it was designed — the pattern verified itself

A 7-agent workflow dogfooded #2231's own pattern: 3 independent designs (assess/review-pr/audit-full) → 3 **blind** challengers (no knowledge of the designer) → Opus synthesis. The challengers found **all 3 designs unsound** (10/10/7 weaknesses) and forced the load-bearing fixes — most importantly: the refuter **never sees the producer's score** (handing it over pre-loads anchoring); it scores from the code itself, and the orchestrator decides SURVIVES/OVERTURNED out-of-band.

## What lands

- **NEW** `src/skills/shared/rules/adversarial-refutation.md` — the 10-rule blind-refuter engine: blindness contract, independent-score-first, citation-verification gate, quorum (no lone judge), cross-file UPHELD-by-default, deterministic exemption (never refute build/test/CVE ground truth), no-auto-flip, 24-agent ceiling, always-isolated spawn (never joins the Agent-Teams mesh), refutation ledger.
- **NEW** `src/skills/assess/references/adversarial-refutation.md` — assess bindings + scope filter (only decision-bearing scores) + effort gate.
- **EDIT** `assess/SKILL.md` — Phase 2.5 (`low`/`medium` skip · `high` advisory · `xhigh` majority-revise). 421 ln, under budget.
- **EDIT** `shared/rules/_sections.md` — catalog entry.

## Scope — ship safe, defer risky (the synthesis flagged its own risks)

| target | this PR | why |
|--------|---------|-----|
| `assess` | **SHIP** | scores quality — no merge/security gate, lowest blast radius |
| `review-pr` | defer → #157 | merge gate — false-negative inversion could drop a real blocker |
| `audit-full` | defer → #157 | security findings — same risk |
| conformance grader | defer → #157 | "the spec is advisory unless a grader enforces it" |

**Honest residual:** a one-sided "your job is to REFUTE" pass raises false negatives; for a merge gate that's the costlier error — which is exactly why review-pr/audit-full wait until no-auto-flip + a conformance grader are *enforced*, not just documented.

## Verification

- `test:skills` exit 0 (internal-link validation passed — the reference chain resolves; new rule frontmatter valid)
- build OK; counts unchanged; gated docs (`reference/skills/assess.mdx`) committed, ungated churn reverted

## Playground

`docs/feat--adversarial-verify-skills/adversarial-verify-playground.html` — the blind-refuter flow, the 10 engine rules (click to expand), and the ship/defer scope.

Refs #2231

Generated with [Claude Code](https://claude.com/claude-code)