### PR TITLE
feat(skills): adversarial verification for review-pr + audit-full

### DIFF
--- a/docs/feat--adversarial-verify-review-audit/adversarial-refutation-rollout-playground.html
+++ b/docs/feat--adversarial-verify-review-audit/adversarial-refutation-rollout-playground.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Adversarial Refutation Rollout — OrchestKit</title>
+    <style>
+      :root {
+        --bg:#0b0e14; --panel:#141925; --panel2:#1b2233; --ink:#e6edf3; --mut:#94a3b8;
+        --cyan:#06b6d4; --green:#22c55e; --amber:#f59e0b; --red:#ef4444; --line:#243049;
+      }
+      *{box-sizing:border-box}
+      body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.55 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+      header{padding:26px 22px;border-bottom:1px solid var(--line);background:linear-gradient(180deg,#101521,#0b0e14)}
+      h1{margin:0 0 6px;font-size:21px}
+      .sub{color:var(--mut);font-size:14px}
+      main{max-width:1020px;margin:0 auto;padding:22px}
+      h2{font-size:16px;border-left:3px solid var(--cyan);padding-left:10px;margin-top:30px}
+      .tabs{display:flex;gap:8px;margin:14px 0}
+      .tab{padding:8px 16px;border-radius:8px;border:1px solid var(--line);background:var(--panel);color:var(--ink);cursor:pointer;font-weight:600;font-size:13px}
+      .tab.active{background:var(--cyan);color:#04222a;border-color:var(--cyan)}
+      .tab .done{color:var(--green);font-size:11px}
+      table{width:100%;border-collapse:collapse;margin-top:10px;font-size:13.5px}
+      th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+      th{color:var(--mut);font-weight:600;width:200px}
+      code{font-family:ui-monospace,Menlo,monospace;background:var(--panel2);padding:1px 5px;border-radius:4px;font-size:12.5px}
+      .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:6px 18px 16px}
+      .rules{display:grid;gap:10px;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));margin-top:12px}
+      .rule{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:12px 14px}
+      .rule b{color:var(--cyan)}
+      .rule p{margin:6px 0 0;color:var(--mut);font-size:13px}
+      .pill{display:inline-block;font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px}
+      .ship{background:rgba(34,197,94,.15);color:var(--green)}
+      .matrix td{font-size:13px}
+      .matrix .skip{color:var(--mut)} .matrix .adv{color:var(--amber)} .matrix .quo{color:var(--green)}
+      .legend{color:var(--mut);font-size:12.5px;margin-top:10px}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>🧪 Adversarial Refutation — rollout across evaluative skills</h1>
+      <div class="sub">A <b>blind refuter</b> verifies a skill's own decision-bearing findings — the structural fix for self-preferential bias (a producer can't be its own fair judge). Closes <code>#2231</code>.</div>
+    </header>
+    <main>
+      <h2>Rollout status</h2>
+      <div class="card">
+        <p style="margin-top:14px">
+          <span class="pill ship">SHIPPED</span> <code>assess</code> (#2235 pilot) &nbsp;·&nbsp;
+          <span class="pill ship">THIS PR</span> <code>review-pr</code> &nbsp;·&nbsp;
+          <span class="pill ship">THIS PR</span> <code>audit-full</code>
+        </p>
+        <p class="legend">One shared engine (<code>shared/rules/adversarial-refutation.md</code>) + a thin per-skill adapter that binds it. All three evaluative skills now refute before they emit a headline score / merge verdict / severity report.</p>
+      </div>
+
+      <h2>Per-skill bindings</h2>
+      <div class="tabs" id="tabs"></div>
+      <div class="card"><table id="bind"></table></div>
+
+      <h2>Effort gate (when refutation runs)</h2>
+      <div class="card">
+        <table class="matrix">
+          <tr><th>/effort</th><td>assess (Phase 2.5)</td><td>review-pr (Phase 4.5)</td><td>audit-full (STEP 3.5)</td></tr>
+          <tr><td>low / medium</td><td class="skip">skip</td><td class="skip">skip</td><td class="skip">skip</td></tr>
+          <tr><td>high</td><td class="adv">≤4 single, advisory</td><td class="adv">≤6 single, advisory</td><td class="adv">single, advisory</td></tr>
+          <tr><td>xhigh</td><td class="quo">3-vote majority</td><td class="quo">3 blocker / 2 HIGH</td><td class="quo">3 CRITICAL / 2 HIGH</td></tr>
+        </table>
+        <p class="legend">Advisory = surfaced, never auto-applied. Quorum = majority with VERIFIED counter-evidence. A 1-of-N dissent never revises (records a caveat, drops confidence to low).</p>
+      </div>
+
+      <h2>The shared engine's 10 guardrails</h2>
+      <div class="rules" id="rules"></div>
+    </main>
+
+    <script>
+      const skills = {
+        "review-pr": {
+          phase: "Phase 4.5 (after findings + validation, before the verdict)",
+          rows: [
+            ["finding", "a Phase-3 conventional comment classified <code>issue</code> (esp. a request-changes blocker)"],
+            ["rubric", "code-review-playbook + the producing agent's domain rubric"],
+            ["refuter", "the same <code>subagent_type</code> that raised it, spawned blind, no team_name"],
+            ["artifact", "the CHANGED_FILES diff slice — refuter re-reads it itself"],
+            ["ledger", "<code>refutation-ledger.json</code>"],
+            ["guardrail", "refutation may NOT flip request-changes→approve without user confirm"],
+          ],
+        },
+        "audit-full": {
+          phase: "STEP 3.5 (after analysis, before the report)",
+          rows: [
+            ["finding", "a severity-ranked STEP-3 finding (CRITICAL/HIGH)"],
+            ["rubric", "the relevant audit guide + severity-matrix"],
+            ["refuter", "blind <code>Agent()</code> by domain — audit-full's ONLY sub-agent spawns"],
+            ["artifact", "the cited file:line slice (narrow — cross-file stays UPHELD)"],
+            ["ledger", "<code>refutation-ledger.json</code>"],
+            ["guardrail", "CVE/CVSS/build/test are ground truth — never refuted; only reachability claims are"],
+          ],
+        },
+        "assess": {
+          phase: "Phase 2.5 (after scoring, before the composite/grade) — shipped in #2235",
+          rows: [
+            ["finding", "a per-dimension 0-10 score"],
+            ["rubric", "unified-scoring-framework + quality-model"],
+            ["refuter", "the same scorer subagent, spawned blind"],
+            ["artifact", "the scoped file list + ≤12-tool-call budget"],
+            ["ledger", "<code>02b-refutation.json</code>"],
+            ["guardrail", "publishes producer-basis AND post-refutation score; never silently raises the grade"],
+          ],
+        },
+      };
+      const rules = [
+        ["1 · Blindness contract","Refuter never sees the producer's number, prose, evidence list, or identity — only category + location + raw code."],
+        ["2 · Independent-score-first","Refuter forms its OWN band from the rubric; the orchestrator (not the refuter) decides SURVIVES/OVERTURNED."],
+        ["3 · Citation-verify gate","Every KILL/DOWNGRADE re-opens the cited file:line; unverifiable citation → UPHELD."],
+        ["4 · Quorum","Top findings need 3 refuters (majority), mid need 2; a lone judge never flips a verdict."],
+        ["5 · Cross-file UPHELD-default","A narrow-context refuter that 'can't reproduce' a traced flow UPHOLDS — never kills what it couldn't see."],
+        ["6 · Deterministic exemption","Build/test/lint output, CVE/CVSS matches, type errors are never refuted — only claims layered on them."],
+        ["7 · No-auto-flip","Refutation alone can't flip a human-facing block→approve nor silently raise a headline score."],
+        ["8 · Global spawn ceiling","Dedup to root-cause, cap total refuters (default 24), rank by severity×boundary-distance, flag the overflow."],
+        ["9 · Always-isolated spawn","Refuters are always plain Agent() with no team_name — joining a mesh leaks producer reasoning."],
+        ["10 · Refutation ledger","Persist votes + verified citations + outcome per finding, so wrong KEEPs AND wrong KILLs are auditable."],
+      ];
+
+      const tabs = document.getElementById("tabs");
+      const order = ["review-pr","audit-full","assess"];
+      order.forEach((k,i)=>{
+        const b=document.createElement("button");
+        b.className="tab"+(i===0?" active":"");
+        b.innerHTML=k+(k==="assess"?' <span class="done">✓ #2235</span>':'');
+        b.onclick=()=>{document.querySelectorAll(".tab").forEach(t=>t.classList.remove("active"));b.classList.add("active");render(k)};
+        tabs.appendChild(b);
+      });
+      function render(k){
+        const s=skills[k];
+        document.getElementById("bind").innerHTML =
+          `<tr><th>placement</th><td>${s.phase}</td></tr>`+
+          s.rows.map(([a,b])=>`<tr><th>${a}</th><td>${b}</td></tr>`).join("");
+      }
+      document.getElementById("rules").innerHTML = rules.map(([t,d])=>`<div class="rule"><b>${t}</b><p>${d}</p></div>`).join("");
+      render("review-pr");
+    </script>
+  </body>
+</html>

--- a/docs/site/content/docs/reference/skills/audit-full.mdx
+++ b/docs/site/content/docs/reference/skills/audit-full.mdx
@@ -137,6 +137,26 @@ For multi-mode audits (Full), each mode's findings appear as they complete. This
 
 ---
 
+## STEP 3.5: Adversarial Refutation (effort-gated)
+
+Before the report, a separate **blind refuter** verifies CRITICAL/HIGH findings — the
+structural fix for self-preferential bias (a single-context pass grading its own findings
+anchors on its own reasoning). `low`/`medium` skip this step; `high` runs single advisory
+refuters; `xhigh` runs the engine's quorum (3 for CRITICAL, 2 for HIGH).
+
+Load the protocol + audit-full bindings: `Read("$\{CLAUDE_SKILL_DIR\}/references/adversarial-refutation.md")`
+(which loads the shared engine `$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/adversarial-refutation.md`).
+
+These refuters are audit-full's **only** sub-agent spawns (the producer is single-context),
+always isolated `Agent(...)` with no `team_name`, fed only a neutral claim (category +
+`file:line`). **Deterministic ground truth is exempt** — CVE/CVSS matches, failing build/test,
+type errors are never refuted; only a *reachability claim* on top of a CVE is. Cross-file
+findings the refuter can't reproduce from its narrow slice stay **UPHELD** (engine §5).
+Refutation never silently drops a CRITICAL — the ledger (`refutation-ledger.json`) records
+survived/killed/downgraded, and removing a CRITICAL/HIGH from the report needs user confirmation.
+
+---
+
 ## STEP 4: Generate Report
 
 Load the report template: `Read("$\{CLAUDE_SKILL_DIR\}/assets/audit-report-template.md")`.
@@ -214,6 +234,7 @@ Load on demand with `Read("$\{CLAUDE_SKILL_DIR\}/references/&lt;file&gt;")`:
 | `references/security-audit-guide.md` | Cross-file vulnerability patterns |
 | `references/architecture-review-guide.md` | Pattern and coupling analysis |
 | `references/dependency-audit-guide.md` | CVE, license, currency checks |
+| `references/adversarial-refutation.md` | Blind-refuter bindings (STEP 3.5) — loads the shared engine |
 | `references/token-estimation.md` | File type ratios and budget planning |
 | `assets/audit-report-template.md` | Structured output format |
 | `assets/severity-matrix.md` | Finding classification criteria |
@@ -377,7 +398,66 @@ find src/api src/auth src/middleware \
 
 ---
 
-## References (7)
+## References (8)
+
+### Adversarial Refutation
+
+# Adversarial Refutation — audit-full bindings
+
+Thin adapter. Loads the shared engine, then binds it to audit-full's severity-ranked findings.
+
+**Load the engine first:** `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's audit-full-specific.
+
+## Bindings
+
+| Engine concept | audit-full binding |
+|----------------|--------------------|
+| "finding" | a severity-ranked finding from STEP 3 (Security / Architecture / Dependency), tagged CRITICAL/HIGH/MEDIUM/LOW |
+| rubric | the relevant STEP-3 guide (`security-audit-guide.md` / `architecture-review-guide.md` / `dependency-audit-guide.md`) + `assets/severity-matrix.md` |
+| refuter agent | a blind `Agent(...)` chosen by finding domain — `security-auditor` (security), `backend-system-architect` (architecture), `code-quality-reviewer` (dependency/other). **audit-full's producer is single-context Opus, so these refuters are its ONLY sub-agent spawns** |
+| code artifact | the cited `file:line` slice — the refuter re-reads it from the codebase itself (it does NOT get the whole-codebase context the producer had, so cross-file findings follow engine §5 UPHELD-default) |
+| ledger | `refutation-ledger.json` in the audit job dir (`$CLAUDE_JOB_DIR`) |
+| revised output | a "Refuted?" column on the STEP 4 finding table + `refuted` / `original_severity` fields; severity changes honor **no-auto-flip** (§7) |
+
+## Scope filter (which findings get a refuter)
+
+A finding qualifies only if decision-bearing — ANY of:
+- **CRITICAL** or **HIGH** severity (these drive the report's headline + remediation timeline)
+- a finding that asserts **exploitability/reachability** (a claim, not a tool match)
+
+Skip: MEDIUM/LOW informational findings, and **deterministic ground truth** — a CVE/CVSS match
+from a dependency scan, a failing build/test, a type error (engine §6). Only a *reachability
+claim* layered on top of a CVE ("this CVE is exploitable because input reaches it") is
+refutable, and only that claim. Dedup to root-cause BEFORE counting; respect the global spawn
+ceiling (default 24, engine §8) — rank by `severity × distance-from-decision-boundary` and
+flag any un-refuted overflow "manual review required".
+
+## Cross-file caution (audit-full-specific)
+
+audit-full's edge is whole-codebase cross-file reasoning (taint flows, auth-boundary gaps
+spanning modules). A refuter only gets the cited slice, so per engine §5 a "could not
+reproduce the traced flow" result is **UPHELD, never REFUTED** — the card MUST carry the
+producer's full traced file set so the refuter knows what it's missing. A narrow-context
+refuter must never kill a true cross-file finding it simply couldn't see.
+
+## Effort gate (audit-full-specific)
+
+audit-full is already a heavy single-context pass; keep refutation bounded:
+- `low` / `medium` → **skip STEP 3.5 entirely**
+- `high` → up-to-ceiling **single** refuters on CRITICAL/HIGH, **advisory only** (surfaced, not
+  auto-applied; a single refuter never demotes a CRITICAL on its own — §7)
+- `xhigh` → **quorum** (§4): 3-refuter majority for CRITICAL, 2 for HIGH; a kill that would drop
+  a CRITICAL from the report requires explicit user confirmation (§7)
+
+## Isolation note
+
+Refuters are ALWAYS standalone `Agent(...)` Task spawns with **no `team_name`**, fed only the
+serialized claim (category + `file:line`, NO producer severity/prose). audit-full has no mesh
+to leak into, but the rule holds: delivery is prompt/`additionalContext`-only (engine §9).
+
 
 ### Architecture Review Guide
 

--- a/docs/site/content/docs/reference/skills/review-pr.mdx
+++ b/docs/site/content/docs/reference/skills/review-pr.mdx
@@ -363,6 +363,25 @@ Set `ORK_DISABLE_ULTRAREVIEW=1` or `.claude/settings.json` → `"ork.disableUltr
 
 Load validation commands: `Read("$\{CLAUDE_SKILL_DIR\}/references/validation-commands.md")`
 
+## Phase 4.5: Adversarial Refutation (effort-gated)
+
+A separate **blind refuter** verifies decision-bearing findings before they reach the
+Phase 5 verdict — the structural fix for self-preferential bias (the agent that raised a
+finding can't be its own fair judge). `low`/`medium` skip this phase; `high` runs single
+advisory refuters (no auto-flip); `xhigh` runs the engine's quorum (3 for a request-changes
+blocker, 2 for HIGH).
+
+Load the protocol + review-pr bindings: `Read("$\{CLAUDE_SKILL_DIR\}/references/adversarial-refutation.md")`
+(which loads the shared engine `$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 3 findings (and any Phase 3.5 ultrareview merge) and Phase 4 validation,
+before the Phase 5 synthesis and Phase 6 verdict. Refuters are ALWAYS isolated `Agent(...)`
+spawns with no `team_name`. Refutation alone may demote a finding's bucket but may **NOT**
+flip `request-changes`→`approve` without explicit user confirmation, and ground truth
+(failing CI/tests/lint, npm-audit/CVSS) is never refuted. The ledger
+(`refutation-ledger.json`) records survived/killed/downgraded so wrong calls — wrong KEEPs
+and wrong KILLs — are auditable cross-session.
+
 ## Phase 5: Synthesize Review
 
 Combine all agent feedback into a structured report. Load template: `Read("$\{CLAUDE_SKILL_DIR\}/references/review-report-template.md")`
@@ -472,6 +491,7 @@ Load on demand with `Read("$\{CLAUDE_SKILL_DIR\}/references/&lt;file&gt;")`:
 |------|---------|
 | `review-template.md` | Review checklist template |
 | `review-report-template.md` | Structured review report |
+| `adversarial-refutation.md` | Blind-refuter bindings (Phase 4.5) — loads the shared engine |
 | `orchestration-mode-selection.md` | Task tool vs Agent Teams |
 | `validation-commands.md` | Build/test/lint commands |
 | `task-metrics-template.md` | Task metrics format |
@@ -977,7 +997,66 @@ if pr_contains_llm_code:
 
 ---
 
-## References (6)
+## References (7)
+
+### Adversarial Refutation
+
+# Adversarial Refutation — review-pr bindings
+
+Thin adapter. Loads the shared engine, then binds it to review-pr's finding + verdict model.
+
+**Load the engine first:** `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's review-pr-specific.
+
+## Bindings
+
+| Engine concept | review-pr binding |
+|----------------|-------------------|
+| "finding" | a Phase 3 conventional comment classified `issue` (especially a **request-changes blocker**) or a decision-bearing `suggestion`, from the 6-agent JSON |
+| rubric | `code-review-playbook` + the producing agent's domain rubric (security→OWASP, perf→Core Web Vitals, tests→coverage-gap) |
+| refuter agent | the **same** `subagent_type` that produced the finding (code-quality-reviewer / security-auditor / test-generator / backend-system-architect / frontend-performance-engineer / accessibility-specialist), spawned blind |
+| code artifact | the `CHANGED_FILES` diff slice for the cited `file:line` (Phase 1 scope) — the refuter re-reads the diff itself, never the producer's quoted snippet |
+| ledger | `refutation-ledger.json` in the review job dir (`$CLAUDE_JOB_DIR`) |
+| revised output | a `refuted` + `original_severity` field on each finding object + a "Refuted?" note in the Phase 5 report; the Phase 6 verdict honors **no-auto-flip** (§7) |
+
+## Scope filter (which findings get a refuter)
+
+A finding qualifies only if decision-bearing — ANY of:
+- it is a **request-changes blocker** (the verdict flips on it)
+- **CRITICAL or HIGH** severity (security / correctness / data-loss)
+- it is the **sole** blocker standing between the PR and `approve`
+- a finding `/ork:implement` or the author will act on immediately (concrete code change demanded)
+
+Skip: `praise`, `nitpick`, and low/style `suggestion` comments; mid-severity advisory notes
+that cannot change the merge verdict. Dedup duplicate findings to root-cause BEFORE counting
+(engine §8). Bounds spawns to ~2-6 per review.
+
+## Effort gate (review-pr-specific)
+
+- `low` / `medium` → **skip Phase 4.5 entirely**
+- `high` → up-to-6 **single** refuters, **advisory only** — an `OVERTURNED`-with-verified-citation
+  is surfaced for the user (engine §7 no-auto-flip; a single refuter never demotes a blocker on
+  its own)
+- `xhigh` → **quorum** per engine §4: 3-refuter majority for a request-changes blocker, 2 for a
+  HIGH finding; a kill that would remove a blocker still requires explicit user confirmation
+  before the verdict changes (§7)
+
+## Verdict guardrail (review-pr-specific)
+
+Refutation MAY demote a finding's display bucket and drop its confidence, but it may **NOT**
+by itself flip the human-facing verdict from `request-changes` → `approve` (engine §7). Keep
+the producer-basis verdict AND a labeled "post-refutation" view; surface every killed
+CRITICAL/HIGH prominently. Ground truth (failing CI/tests/lint, npm-audit/CVSS matches) is
+exempt — never refuted (engine §6); only a *reachability claim* layered on a CVE is refutable.
+
+## Isolation note
+
+Even when Phase 3 ran in Agent Teams mode, Phase 4.5 refuters are ALWAYS standalone
+`Agent(...)` Task spawns with **no `team_name`** — fed only the serialized claim + diff slice.
+Joining the mesh would leak producer reasoning via `SendMessage` history (engine §9).
+
 
 ### Memory Persistence
 

--- a/plugins/ork/commands/review-pr.md
+++ b/plugins/ork/commands/review-pr.md
@@ -352,6 +352,25 @@ Set `ORK_DISABLE_ULTRAREVIEW=1` or `.claude/settings.json` → `"ork.disableUltr
 
 Load validation commands: `Read("${CLAUDE_SKILL_DIR}/references/validation-commands.md")`
 
+## Phase 4.5: Adversarial Refutation (effort-gated)
+
+A separate **blind refuter** verifies decision-bearing findings before they reach the
+Phase 5 verdict — the structural fix for self-preferential bias (the agent that raised a
+finding can't be its own fair judge). `low`/`medium` skip this phase; `high` runs single
+advisory refuters (no auto-flip); `xhigh` runs the engine's quorum (3 for a request-changes
+blocker, 2 for HIGH).
+
+Load the protocol + review-pr bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 3 findings (and any Phase 3.5 ultrareview merge) and Phase 4 validation,
+before the Phase 5 synthesis and Phase 6 verdict. Refuters are ALWAYS isolated `Agent(...)`
+spawns with no `team_name`. Refutation alone may demote a finding's bucket but may **NOT**
+flip `request-changes`→`approve` without explicit user confirmation, and ground truth
+(failing CI/tests/lint, npm-audit/CVSS) is never refuted. The ledger
+(`refutation-ledger.json`) records survived/killed/downgraded so wrong calls — wrong KEEPs
+and wrong KILLs — are auditable cross-session.
+
 ## Phase 5: Synthesize Review
 
 Combine all agent feedback into a structured report. Load template: `Read("${CLAUDE_SKILL_DIR}/references/review-report-template.md")`
@@ -461,6 +480,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 |------|---------|
 | `review-template.md` | Review checklist template |
 | `review-report-template.md` | Structured review report |
+| `adversarial-refutation.md` | Blind-refuter bindings (Phase 4.5) — loads the shared engine |
 | `orchestration-mode-selection.md` | Task tool vs Agent Teams |
 | `validation-commands.md` | Build/test/lint commands |
 | `task-metrics-template.md` | Task metrics format |

--- a/plugins/ork/skills/audit-full/SKILL.md
+++ b/plugins/ork/skills/audit-full/SKILL.md
@@ -147,6 +147,26 @@ For multi-mode audits (Full), each mode's findings appear as they complete. This
 
 ---
 
+## STEP 3.5: Adversarial Refutation (effort-gated)
+
+Before the report, a separate **blind refuter** verifies CRITICAL/HIGH findings — the
+structural fix for self-preferential bias (a single-context pass grading its own findings
+anchors on its own reasoning). `low`/`medium` skip this step; `high` runs single advisory
+refuters; `xhigh` runs the engine's quorum (3 for CRITICAL, 2 for HIGH).
+
+Load the protocol + audit-full bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+These refuters are audit-full's **only** sub-agent spawns (the producer is single-context),
+always isolated `Agent(...)` with no `team_name`, fed only a neutral claim (category +
+`file:line`). **Deterministic ground truth is exempt** — CVE/CVSS matches, failing build/test,
+type errors are never refuted; only a *reachability claim* on top of a CVE is. Cross-file
+findings the refuter can't reproduce from its narrow slice stay **UPHELD** (engine §5).
+Refutation never silently drops a CRITICAL — the ledger (`refutation-ledger.json`) records
+survived/killed/downgraded, and removing a CRITICAL/HIGH from the report needs user confirmation.
+
+---
+
 ## STEP 4: Generate Report
 
 Load the report template: `Read("${CLAUDE_SKILL_DIR}/assets/audit-report-template.md")`.
@@ -224,6 +244,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `references/security-audit-guide.md` | Cross-file vulnerability patterns |
 | `references/architecture-review-guide.md` | Pattern and coupling analysis |
 | `references/dependency-audit-guide.md` | CVE, license, currency checks |
+| `references/adversarial-refutation.md` | Blind-refuter bindings (STEP 3.5) — loads the shared engine |
 | `references/token-estimation.md` | File type ratios and budget planning |
 | `assets/audit-report-template.md` | Structured output format |
 | `assets/severity-matrix.md` | Finding classification criteria |

--- a/plugins/ork/skills/audit-full/references/adversarial-refutation.md
+++ b/plugins/ork/skills/audit-full/references/adversarial-refutation.md
@@ -1,0 +1,55 @@
+# Adversarial Refutation — audit-full bindings
+
+Thin adapter. Loads the shared engine, then binds it to audit-full's severity-ranked findings.
+
+**Load the engine first:** `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's audit-full-specific.
+
+## Bindings
+
+| Engine concept | audit-full binding |
+|----------------|--------------------|
+| "finding" | a severity-ranked finding from STEP 3 (Security / Architecture / Dependency), tagged CRITICAL/HIGH/MEDIUM/LOW |
+| rubric | the relevant STEP-3 guide (`security-audit-guide.md` / `architecture-review-guide.md` / `dependency-audit-guide.md`) + `assets/severity-matrix.md` |
+| refuter agent | a blind `Agent(...)` chosen by finding domain — `security-auditor` (security), `backend-system-architect` (architecture), `code-quality-reviewer` (dependency/other). **audit-full's producer is single-context Opus, so these refuters are its ONLY sub-agent spawns** |
+| code artifact | the cited `file:line` slice — the refuter re-reads it from the codebase itself (it does NOT get the whole-codebase context the producer had, so cross-file findings follow engine §5 UPHELD-default) |
+| ledger | `refutation-ledger.json` in the audit job dir (`$CLAUDE_JOB_DIR`) |
+| revised output | a "Refuted?" column on the STEP 4 finding table + `refuted` / `original_severity` fields; severity changes honor **no-auto-flip** (§7) |
+
+## Scope filter (which findings get a refuter)
+
+A finding qualifies only if decision-bearing — ANY of:
+- **CRITICAL** or **HIGH** severity (these drive the report's headline + remediation timeline)
+- a finding that asserts **exploitability/reachability** (a claim, not a tool match)
+
+Skip: MEDIUM/LOW informational findings, and **deterministic ground truth** — a CVE/CVSS match
+from a dependency scan, a failing build/test, a type error (engine §6). Only a *reachability
+claim* layered on top of a CVE ("this CVE is exploitable because input reaches it") is
+refutable, and only that claim. Dedup to root-cause BEFORE counting; respect the global spawn
+ceiling (default 24, engine §8) — rank by `severity × distance-from-decision-boundary` and
+flag any un-refuted overflow "manual review required".
+
+## Cross-file caution (audit-full-specific)
+
+audit-full's edge is whole-codebase cross-file reasoning (taint flows, auth-boundary gaps
+spanning modules). A refuter only gets the cited slice, so per engine §5 a "could not
+reproduce the traced flow" result is **UPHELD, never REFUTED** — the card MUST carry the
+producer's full traced file set so the refuter knows what it's missing. A narrow-context
+refuter must never kill a true cross-file finding it simply couldn't see.
+
+## Effort gate (audit-full-specific)
+
+audit-full is already a heavy single-context pass; keep refutation bounded:
+- `low` / `medium` → **skip STEP 3.5 entirely**
+- `high` → up-to-ceiling **single** refuters on CRITICAL/HIGH, **advisory only** (surfaced, not
+  auto-applied; a single refuter never demotes a CRITICAL on its own — §7)
+- `xhigh` → **quorum** (§4): 3-refuter majority for CRITICAL, 2 for HIGH; a kill that would drop
+  a CRITICAL from the report requires explicit user confirmation (§7)
+
+## Isolation note
+
+Refuters are ALWAYS standalone `Agent(...)` Task spawns with **no `team_name`**, fed only the
+serialized claim (category + `file:line`, NO producer severity/prose). audit-full has no mesh
+to leak into, but the rule holds: delivery is prompt/`additionalContext`-only (engine §9).

--- a/plugins/ork/skills/review-pr/SKILL.md
+++ b/plugins/ork/skills/review-pr/SKILL.md
@@ -384,6 +384,25 @@ Set `ORK_DISABLE_ULTRAREVIEW=1` or `.claude/settings.json` → `"ork.disableUltr
 
 Load validation commands: `Read("${CLAUDE_SKILL_DIR}/references/validation-commands.md")`
 
+## Phase 4.5: Adversarial Refutation (effort-gated)
+
+A separate **blind refuter** verifies decision-bearing findings before they reach the
+Phase 5 verdict — the structural fix for self-preferential bias (the agent that raised a
+finding can't be its own fair judge). `low`/`medium` skip this phase; `high` runs single
+advisory refuters (no auto-flip); `xhigh` runs the engine's quorum (3 for a request-changes
+blocker, 2 for HIGH).
+
+Load the protocol + review-pr bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 3 findings (and any Phase 3.5 ultrareview merge) and Phase 4 validation,
+before the Phase 5 synthesis and Phase 6 verdict. Refuters are ALWAYS isolated `Agent(...)`
+spawns with no `team_name`. Refutation alone may demote a finding's bucket but may **NOT**
+flip `request-changes`→`approve` without explicit user confirmation, and ground truth
+(failing CI/tests/lint, npm-audit/CVSS) is never refuted. The ledger
+(`refutation-ledger.json`) records survived/killed/downgraded so wrong calls — wrong KEEPs
+and wrong KILLs — are auditable cross-session.
+
 ## Phase 5: Synthesize Review
 
 Combine all agent feedback into a structured report. Load template: `Read("${CLAUDE_SKILL_DIR}/references/review-report-template.md")`
@@ -493,6 +512,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 |------|---------|
 | `review-template.md` | Review checklist template |
 | `review-report-template.md` | Structured review report |
+| `adversarial-refutation.md` | Blind-refuter bindings (Phase 4.5) — loads the shared engine |
 | `orchestration-mode-selection.md` | Task tool vs Agent Teams |
 | `validation-commands.md` | Build/test/lint commands |
 | `task-metrics-template.md` | Task metrics format |

--- a/plugins/ork/skills/review-pr/references/adversarial-refutation.md
+++ b/plugins/ork/skills/review-pr/references/adversarial-refutation.md
@@ -1,0 +1,55 @@
+# Adversarial Refutation — review-pr bindings
+
+Thin adapter. Loads the shared engine, then binds it to review-pr's finding + verdict model.
+
+**Load the engine first:** `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's review-pr-specific.
+
+## Bindings
+
+| Engine concept | review-pr binding |
+|----------------|-------------------|
+| "finding" | a Phase 3 conventional comment classified `issue` (especially a **request-changes blocker**) or a decision-bearing `suggestion`, from the 6-agent JSON |
+| rubric | `code-review-playbook` + the producing agent's domain rubric (security→OWASP, perf→Core Web Vitals, tests→coverage-gap) |
+| refuter agent | the **same** `subagent_type` that produced the finding (code-quality-reviewer / security-auditor / test-generator / backend-system-architect / frontend-performance-engineer / accessibility-specialist), spawned blind |
+| code artifact | the `CHANGED_FILES` diff slice for the cited `file:line` (Phase 1 scope) — the refuter re-reads the diff itself, never the producer's quoted snippet |
+| ledger | `refutation-ledger.json` in the review job dir (`$CLAUDE_JOB_DIR`) |
+| revised output | a `refuted` + `original_severity` field on each finding object + a "Refuted?" note in the Phase 5 report; the Phase 6 verdict honors **no-auto-flip** (§7) |
+
+## Scope filter (which findings get a refuter)
+
+A finding qualifies only if decision-bearing — ANY of:
+- it is a **request-changes blocker** (the verdict flips on it)
+- **CRITICAL or HIGH** severity (security / correctness / data-loss)
+- it is the **sole** blocker standing between the PR and `approve`
+- a finding `/ork:implement` or the author will act on immediately (concrete code change demanded)
+
+Skip: `praise`, `nitpick`, and low/style `suggestion` comments; mid-severity advisory notes
+that cannot change the merge verdict. Dedup duplicate findings to root-cause BEFORE counting
+(engine §8). Bounds spawns to ~2-6 per review.
+
+## Effort gate (review-pr-specific)
+
+- `low` / `medium` → **skip Phase 4.5 entirely**
+- `high` → up-to-6 **single** refuters, **advisory only** — an `OVERTURNED`-with-verified-citation
+  is surfaced for the user (engine §7 no-auto-flip; a single refuter never demotes a blocker on
+  its own)
+- `xhigh` → **quorum** per engine §4: 3-refuter majority for a request-changes blocker, 2 for a
+  HIGH finding; a kill that would remove a blocker still requires explicit user confirmation
+  before the verdict changes (§7)
+
+## Verdict guardrail (review-pr-specific)
+
+Refutation MAY demote a finding's display bucket and drop its confidence, but it may **NOT**
+by itself flip the human-facing verdict from `request-changes` → `approve` (engine §7). Keep
+the producer-basis verdict AND a labeled "post-refutation" view; surface every killed
+CRITICAL/HIGH prominently. Ground truth (failing CI/tests/lint, npm-audit/CVSS matches) is
+exempt — never refuted (engine §6); only a *reachability claim* layered on a CVE is refutable.
+
+## Isolation note
+
+Even when Phase 3 ran in Agent Teams mode, Phase 4.5 refuters are ALWAYS standalone
+`Agent(...)` Task spawns with **no `team_name`** — fed only the serialized claim + diff slice.
+Joining the mesh would leak producer reasoning via `SendMessage` history (engine §9).

--- a/src/skills/audit-full/SKILL.md
+++ b/src/skills/audit-full/SKILL.md
@@ -147,6 +147,26 @@ For multi-mode audits (Full), each mode's findings appear as they complete. This
 
 ---
 
+## STEP 3.5: Adversarial Refutation (effort-gated)
+
+Before the report, a separate **blind refuter** verifies CRITICAL/HIGH findings — the
+structural fix for self-preferential bias (a single-context pass grading its own findings
+anchors on its own reasoning). `low`/`medium` skip this step; `high` runs single advisory
+refuters; `xhigh` runs the engine's quorum (3 for CRITICAL, 2 for HIGH).
+
+Load the protocol + audit-full bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+These refuters are audit-full's **only** sub-agent spawns (the producer is single-context),
+always isolated `Agent(...)` with no `team_name`, fed only a neutral claim (category +
+`file:line`). **Deterministic ground truth is exempt** — CVE/CVSS matches, failing build/test,
+type errors are never refuted; only a *reachability claim* on top of a CVE is. Cross-file
+findings the refuter can't reproduce from its narrow slice stay **UPHELD** (engine §5).
+Refutation never silently drops a CRITICAL — the ledger (`refutation-ledger.json`) records
+survived/killed/downgraded, and removing a CRITICAL/HIGH from the report needs user confirmation.
+
+---
+
 ## STEP 4: Generate Report
 
 Load the report template: `Read("${CLAUDE_SKILL_DIR}/assets/audit-report-template.md")`.
@@ -224,6 +244,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `references/security-audit-guide.md` | Cross-file vulnerability patterns |
 | `references/architecture-review-guide.md` | Pattern and coupling analysis |
 | `references/dependency-audit-guide.md` | CVE, license, currency checks |
+| `references/adversarial-refutation.md` | Blind-refuter bindings (STEP 3.5) — loads the shared engine |
 | `references/token-estimation.md` | File type ratios and budget planning |
 | `assets/audit-report-template.md` | Structured output format |
 | `assets/severity-matrix.md` | Finding classification criteria |

--- a/src/skills/audit-full/references/adversarial-refutation.md
+++ b/src/skills/audit-full/references/adversarial-refutation.md
@@ -1,0 +1,55 @@
+# Adversarial Refutation — audit-full bindings
+
+Thin adapter. Loads the shared engine, then binds it to audit-full's severity-ranked findings.
+
+**Load the engine first:** `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's audit-full-specific.
+
+## Bindings
+
+| Engine concept | audit-full binding |
+|----------------|--------------------|
+| "finding" | a severity-ranked finding from STEP 3 (Security / Architecture / Dependency), tagged CRITICAL/HIGH/MEDIUM/LOW |
+| rubric | the relevant STEP-3 guide (`security-audit-guide.md` / `architecture-review-guide.md` / `dependency-audit-guide.md`) + `assets/severity-matrix.md` |
+| refuter agent | a blind `Agent(...)` chosen by finding domain — `security-auditor` (security), `backend-system-architect` (architecture), `code-quality-reviewer` (dependency/other). **audit-full's producer is single-context Opus, so these refuters are its ONLY sub-agent spawns** |
+| code artifact | the cited `file:line` slice — the refuter re-reads it from the codebase itself (it does NOT get the whole-codebase context the producer had, so cross-file findings follow engine §5 UPHELD-default) |
+| ledger | `refutation-ledger.json` in the audit job dir (`$CLAUDE_JOB_DIR`) |
+| revised output | a "Refuted?" column on the STEP 4 finding table + `refuted` / `original_severity` fields; severity changes honor **no-auto-flip** (§7) |
+
+## Scope filter (which findings get a refuter)
+
+A finding qualifies only if decision-bearing — ANY of:
+- **CRITICAL** or **HIGH** severity (these drive the report's headline + remediation timeline)
+- a finding that asserts **exploitability/reachability** (a claim, not a tool match)
+
+Skip: MEDIUM/LOW informational findings, and **deterministic ground truth** — a CVE/CVSS match
+from a dependency scan, a failing build/test, a type error (engine §6). Only a *reachability
+claim* layered on top of a CVE ("this CVE is exploitable because input reaches it") is
+refutable, and only that claim. Dedup to root-cause BEFORE counting; respect the global spawn
+ceiling (default 24, engine §8) — rank by `severity × distance-from-decision-boundary` and
+flag any un-refuted overflow "manual review required".
+
+## Cross-file caution (audit-full-specific)
+
+audit-full's edge is whole-codebase cross-file reasoning (taint flows, auth-boundary gaps
+spanning modules). A refuter only gets the cited slice, so per engine §5 a "could not
+reproduce the traced flow" result is **UPHELD, never REFUTED** — the card MUST carry the
+producer's full traced file set so the refuter knows what it's missing. A narrow-context
+refuter must never kill a true cross-file finding it simply couldn't see.
+
+## Effort gate (audit-full-specific)
+
+audit-full is already a heavy single-context pass; keep refutation bounded:
+- `low` / `medium` → **skip STEP 3.5 entirely**
+- `high` → up-to-ceiling **single** refuters on CRITICAL/HIGH, **advisory only** (surfaced, not
+  auto-applied; a single refuter never demotes a CRITICAL on its own — §7)
+- `xhigh` → **quorum** (§4): 3-refuter majority for CRITICAL, 2 for HIGH; a kill that would drop
+  a CRITICAL from the report requires explicit user confirmation (§7)
+
+## Isolation note
+
+Refuters are ALWAYS standalone `Agent(...)` Task spawns with **no `team_name`**, fed only the
+serialized claim (category + `file:line`, NO producer severity/prose). audit-full has no mesh
+to leak into, but the rule holds: delivery is prompt/`additionalContext`-only (engine §9).

--- a/src/skills/review-pr/SKILL.md
+++ b/src/skills/review-pr/SKILL.md
@@ -384,6 +384,25 @@ Set `ORK_DISABLE_ULTRAREVIEW=1` or `.claude/settings.json` → `"ork.disableUltr
 
 Load validation commands: `Read("${CLAUDE_SKILL_DIR}/references/validation-commands.md")`
 
+## Phase 4.5: Adversarial Refutation (effort-gated)
+
+A separate **blind refuter** verifies decision-bearing findings before they reach the
+Phase 5 verdict — the structural fix for self-preferential bias (the agent that raised a
+finding can't be its own fair judge). `low`/`medium` skip this phase; `high` runs single
+advisory refuters (no auto-flip); `xhigh` runs the engine's quorum (3 for a request-changes
+blocker, 2 for HIGH).
+
+Load the protocol + review-pr bindings: `Read("${CLAUDE_SKILL_DIR}/references/adversarial-refutation.md")`
+(which loads the shared engine `${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md`).
+
+Runs after Phase 3 findings (and any Phase 3.5 ultrareview merge) and Phase 4 validation,
+before the Phase 5 synthesis and Phase 6 verdict. Refuters are ALWAYS isolated `Agent(...)`
+spawns with no `team_name`. Refutation alone may demote a finding's bucket but may **NOT**
+flip `request-changes`→`approve` without explicit user confirmation, and ground truth
+(failing CI/tests/lint, npm-audit/CVSS) is never refuted. The ledger
+(`refutation-ledger.json`) records survived/killed/downgraded so wrong calls — wrong KEEPs
+and wrong KILLs — are auditable cross-session.
+
 ## Phase 5: Synthesize Review
 
 Combine all agent feedback into a structured report. Load template: `Read("${CLAUDE_SKILL_DIR}/references/review-report-template.md")`
@@ -493,6 +512,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 |------|---------|
 | `review-template.md` | Review checklist template |
 | `review-report-template.md` | Structured review report |
+| `adversarial-refutation.md` | Blind-refuter bindings (Phase 4.5) — loads the shared engine |
 | `orchestration-mode-selection.md` | Task tool vs Agent Teams |
 | `validation-commands.md` | Build/test/lint commands |
 | `task-metrics-template.md` | Task metrics format |

--- a/src/skills/review-pr/references/adversarial-refutation.md
+++ b/src/skills/review-pr/references/adversarial-refutation.md
@@ -1,0 +1,55 @@
+# Adversarial Refutation — review-pr bindings
+
+Thin adapter. Loads the shared engine, then binds it to review-pr's finding + verdict model.
+
+**Load the engine first:** `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/adversarial-refutation.md")`
+— the blindness contract, independent-score-first, citation-verify, quorum, cross-file
+UPHELD-default, deterministic-exemption, no-auto-flip, spawn-ceiling, ledger schema, and
+isolated-spawn rules. This file only supplies what's review-pr-specific.
+
+## Bindings
+
+| Engine concept | review-pr binding |
+|----------------|-------------------|
+| "finding" | a Phase 3 conventional comment classified `issue` (especially a **request-changes blocker**) or a decision-bearing `suggestion`, from the 6-agent JSON |
+| rubric | `code-review-playbook` + the producing agent's domain rubric (security→OWASP, perf→Core Web Vitals, tests→coverage-gap) |
+| refuter agent | the **same** `subagent_type` that produced the finding (code-quality-reviewer / security-auditor / test-generator / backend-system-architect / frontend-performance-engineer / accessibility-specialist), spawned blind |
+| code artifact | the `CHANGED_FILES` diff slice for the cited `file:line` (Phase 1 scope) — the refuter re-reads the diff itself, never the producer's quoted snippet |
+| ledger | `refutation-ledger.json` in the review job dir (`$CLAUDE_JOB_DIR`) |
+| revised output | a `refuted` + `original_severity` field on each finding object + a "Refuted?" note in the Phase 5 report; the Phase 6 verdict honors **no-auto-flip** (§7) |
+
+## Scope filter (which findings get a refuter)
+
+A finding qualifies only if decision-bearing — ANY of:
+- it is a **request-changes blocker** (the verdict flips on it)
+- **CRITICAL or HIGH** severity (security / correctness / data-loss)
+- it is the **sole** blocker standing between the PR and `approve`
+- a finding `/ork:implement` or the author will act on immediately (concrete code change demanded)
+
+Skip: `praise`, `nitpick`, and low/style `suggestion` comments; mid-severity advisory notes
+that cannot change the merge verdict. Dedup duplicate findings to root-cause BEFORE counting
+(engine §8). Bounds spawns to ~2-6 per review.
+
+## Effort gate (review-pr-specific)
+
+- `low` / `medium` → **skip Phase 4.5 entirely**
+- `high` → up-to-6 **single** refuters, **advisory only** — an `OVERTURNED`-with-verified-citation
+  is surfaced for the user (engine §7 no-auto-flip; a single refuter never demotes a blocker on
+  its own)
+- `xhigh` → **quorum** per engine §4: 3-refuter majority for a request-changes blocker, 2 for a
+  HIGH finding; a kill that would remove a blocker still requires explicit user confirmation
+  before the verdict changes (§7)
+
+## Verdict guardrail (review-pr-specific)
+
+Refutation MAY demote a finding's display bucket and drop its confidence, but it may **NOT**
+by itself flip the human-facing verdict from `request-changes` → `approve` (engine §7). Keep
+the producer-basis verdict AND a labeled "post-refutation" view; surface every killed
+CRITICAL/HIGH prominently. Ground truth (failing CI/tests/lint, npm-audit/CVSS matches) is
+exempt — never refuted (engine §6); only a *reachability claim* layered on a CVE is refutable.
+
+## Isolation note
+
+Even when Phase 3 ran in Agent Teams mode, Phase 4.5 refuters are ALWAYS standalone
+`Agent(...)` Task spawns with **no `team_name`** — fed only the serialized claim + diff slice.
+Joining the mesh would leak producer reasoning via `SendMessage` history (engine §9).


### PR DESCRIPTION
Completes the **#2231** rollout — extends the adversarial-refutation engine (shipped for `assess` in #2235) to the other two evaluative skills. A **blind refuter** verifies each skill's own decision-bearing findings before the human-facing verdict, the structural fix for self-preferential bias (a producer can't be its own fair judge).

## What changed
One shared engine + a thin per-skill adapter (no engine duplication):

| Skill | Phase | Finding refuted | Key guardrail |
|-------|-------|-----------------|---------------|
| `assess` | 2.5 | per-dimension score | ✅ shipped #2235 |
| `review-pr` | **4.5** | Phase-3 conventional comments (esp. request-changes blockers) | refutation may **not** flip request-changes→approve without user confirm |
| `audit-full` | **STEP 3.5** | CRITICAL/HIGH findings | deterministic CVE/build/test **exempt**; cross-file the refuter can't reproduce stays UPHELD |

Each new `references/adversarial-refutation.md` adapter loads `shared/rules/adversarial-refutation.md` and binds it (finding type, refuter agent, rubric, ledger, scope filter, effort gate). `_sections.md` already named all three skills (pre-wired in #2235) — no shared-rule change.

For `audit-full` (single-context producer), the refuters are its **only** sub-agent spawns — always isolated `Agent()`, no `team_name`.

## Validation
- `test:skills` ✅ — rule-validation (634 rules, 0 failed), `_sections.md` presence, AskUserQuestion schema, tool-call signatures all pass.
- `plugins/` rebuilt from src; docs reference pages regenerated for the two skills. Ungated docs/`lib/generated` churn + a worktree-only hook-count artifact (211→173, unbuilt hooks) reverted per repo convention.

## Playground
Interactive rollout playground (per-skill bindings, effort-gate matrix, the engine's 10 guardrails):
`docs/feat--adversarial-verify-review-audit/adversarial-refutation-rollout-playground.html`

Closes #2231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)