### PR TITLE
ci(vercel): production-only — disable preview deploys

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash -c '[ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ] && exit 1 || exit 0'"
+}


### PR DESCRIPTION
Adds a production-only `ignoreCommand` so only `main` builds on Vercel — no preview/PR builds. Production-only Vercel policy (no preview cost).