### PR TITLE
fix(docs-site): open CORS for cross-origin agents + MCP paths

### DIFF
--- a/docs/feat--agent-readiness-cors/cors-agent-access.html
+++ b/docs/feat--agent-readiness-cors/cors-agent-access.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OrchestKit · Cross-Origin Agent Access</title>
+<style>
+  :root{--bg:#0b1120;--panel:#111a2e;--panel2:#0e1626;--border:#1e2b45;--fg:#e6edf7;--muted:#93a4c0;--emerald:#34d399;--red:#f87171;--mono:ui-monospace,Menlo,monospace}
+  *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--fg);font-family:system-ui,sans-serif;line-height:1.55}
+  .wrap{max-width:880px;margin:0 auto;padding:32px 20px 72px}
+  h1{font-size:1.7rem;margin:0 0 6px;letter-spacing:-.02em}.sub{color:var(--muted);margin:0 0 26px}
+  h2{font-size:1.1rem;margin:30px 0 10px}
+  .grid{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin:0 0 18px}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:12px;padding:16px}
+  .card.bad{border-color:#3a1d22}.card.good{border-color:#103b30}
+  .tag{font-family:var(--mono);font-size:.72rem;padding:2px 8px;border-radius:5px}
+  .tag.bad{background:#2a1318;color:var(--red)}.tag.good{background:#0f3b30;color:var(--emerald)}
+  pre{background:var(--panel2);border:1px solid var(--border);border-radius:8px;padding:12px;overflow:auto;font-family:var(--mono);font-size:.78rem;margin:10px 0 0}
+  table{width:100%;border-collapse:collapse;font-size:.85rem;margin-top:8px}
+  th,td{text-align:left;padding:8px;border-bottom:1px solid var(--border)}th{color:var(--muted);font-weight:600}
+  td.path{font-family:var(--mono);color:var(--emerald)}
+  .curl{display:flex;gap:8px;margin-top:12px}.curl code{flex:1;font-family:var(--mono);font-size:.76rem;background:var(--panel2);border:1px solid var(--border);border-radius:6px;padding:8px 10px;overflow:auto;white-space:nowrap;color:var(--muted)}
+  button{background:var(--emerald);color:var(--bg);border:0;border-radius:6px;padding:8px 12px;font-weight:600;cursor:pointer;font-size:.78rem}
+  .foot{color:var(--muted);font-size:.8rem;margin-top:28px;border-top:1px solid var(--border);padding-top:14px}
+  code.k{font-family:var(--mono);color:var(--fg)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>Cross-Origin Agent Access</h1>
+  <p class="sub">Follow-up to the agent-readiness work: the discovery endpoints were live and spec-correct, but a same-origin CORS lock stopped cross-origin agents (and the orank probe) from <em>reading</em> them. This playground shows the fix.</p>
+
+  <h2>The bug</h2>
+  <div class="grid">
+    <div class="card bad">
+      <span class="tag bad">BEFORE</span>
+      <p>Every response carried:</p>
+      <pre>Access-Control-Allow-Origin:
+  https://orchestkit.yonyon.ai</pre>
+      <p>A browser-based agent on any other origin → <b>blocked</b> from reading <code class="k">/ask</code>, <code class="k">/api/mcp</code>, the cards, llms feeds.</p>
+    </div>
+    <div class="card good">
+      <span class="tag good">AFTER</span>
+      <p>Public, read-only site → open:</p>
+      <pre>Access-Control-Allow-Origin: *
+Access-Control-Allow-Methods:
+  GET, POST, OPTIONS
+Access-Control-Allow-Headers:
+  Content-Type, Accept</pre>
+      <p>Plus <code class="k">OPTIONS</code> preflight handlers on <code class="k">/ask</code> and <code class="k">/api/mcp</code>.</p>
+    </div>
+  </div>
+
+  <h2>New MCP discovery paths</h2>
+  <p class="sub" style="margin:0 0 8px">orank's methodology probes several well-known filenames — all now resolve to the server card.</p>
+  <table>
+    <thead><tr><th>Path</th><th>Resolves to</th></tr></thead>
+    <tbody>
+      <tr><td class="path">/.well-known/mcp</td><td>server card</td></tr>
+      <tr><td class="path">/.well-known/mcp/server-card.json</td><td>server card</td></tr>
+      <tr><td class="path">/.well-known/mcp.json</td><td>server card (new)</td></tr>
+      <tr><td class="path">/.well-known/mcp/manifest.json</td><td>server card (new)</td></tr>
+      <tr><td class="path">/mcp.json</td><td>server card (new)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Verify the CORS header yourself</h2>
+  <div class="curl"><code id="c">curl -s -D- -o /dev/null https://orchestkit.yonyon.ai/.well-known/agent-card.json | grep -i access-control</code><button onclick="navigator.clipboard.writeText(document.getElementById('c').textContent);this.textContent='Copied';setTimeout(()=>this.textContent='Copy',1200)">Copy</button></div>
+  <button id="live" style="margin-top:14px">Try a live cross-origin fetch from this page →</button>
+  <pre id="out">(click above — once deployed, this cross-origin fetch succeeds; before the fix it threw a CORS error)</pre>
+
+  <p class="foot">PR branch <code class="k">feat/agent-readiness-cors</code>. The playground itself is a cross-origin client — after deploy, the live fetch below proves agents can read the endpoint.</p>
+</div>
+<script>
+document.getElementById('live').onclick=async()=>{
+  const o=document.getElementById('out');o.textContent='fetching https://orchestkit.yonyon.ai/.well-known/agent-card.json …';
+  try{const r=await fetch('https://orchestkit.yonyon.ai/.well-known/agent-card.json');const j=await r.json();
+    o.textContent='✓ cross-origin read OK\n\nname: '+j.name+'\nskills: '+(j.skills||[]).map(s=>s.id).join(', ')+'\nurl: '+j.url;}
+  catch(e){o.textContent='✗ '+e+'\n(if this is a CORS error, the deploy with ACAO:* has not propagated yet)';}
+};
+</script>
+</body>
+</html>

--- a/docs/site/app/api/ask/route.ts
+++ b/docs/site/app/api/ask/route.ts
@@ -103,3 +103,9 @@ export async function POST(req: Request) {
 export async function GET(req: Request) {
 	return handle(req);
 }
+
+// CORS preflight for cross-origin (browser-based) agents. CORS headers are
+// attached globally in next.config.mjs; this just returns a 2xx for OPTIONS.
+export function OPTIONS() {
+	return new Response(null, { status: 204 });
+}

--- a/docs/site/app/api/mcp/route.ts
+++ b/docs/site/app/api/mcp/route.ts
@@ -152,3 +152,9 @@ export function GET() {
 		headers: { Allow: "POST" },
 	});
 }
+
+// CORS preflight so browser-based agents can open the transport cross-origin.
+// CORS headers are attached globally in next.config.mjs.
+export function OPTIONS() {
+	return new Response(null, { status: 204 });
+}

--- a/docs/site/next.config.mjs
+++ b/docs/site/next.config.mjs
@@ -45,6 +45,19 @@ const config = {
 			destination: "/api/well-known/mcp-server-card",
 		},
 		{
+			// Alternate well-known filenames agents probe for the server card.
+			source: "/.well-known/mcp.json",
+			destination: "/api/well-known/mcp-server-card",
+		},
+		{
+			source: "/.well-known/mcp/manifest.json",
+			destination: "/api/well-known/mcp-server-card",
+		},
+		{
+			source: "/mcp.json",
+			destination: "/api/well-known/mcp-server-card",
+		},
+		{
 			// NLWeb natural-language query endpoint.
 			source: "/ask",
 			destination: "/api/ask",
@@ -70,9 +83,18 @@ const config = {
 		{
 			source: "/(.*)",
 			headers: [
+				// Public, read-only site + agent API: allow any origin so
+				// cross-origin (incl. browser-based) AI agents can actually read
+				// /ask, /api/mcp, the well-known cards, and the markdown/llms feeds.
+				// Locking this to the apex blocked every cross-origin agent.
+				{ key: "Access-Control-Allow-Origin", value: "*" },
 				{
-					key: "Access-Control-Allow-Origin",
-					value: "https://orchestkit.yonyon.ai",
+					key: "Access-Control-Allow-Methods",
+					value: "GET, POST, OPTIONS",
+				},
+				{
+					key: "Access-Control-Allow-Headers",
+					value: "Content-Type, Accept",
 				},
 				// RFC 8288 Link headers — advertise agent-discovery resources so agents
 				// can find the API catalog and machine-readable docs from any response.


### PR DESCRIPTION
## What

Follow-up to #2279. The agent-discovery endpoints were live and matched orank's published criteria, but several still scored `fail` — because a **same-origin CORS lock** stopped cross-origin agents (and orank's browser-based probe) from *reading* the responses.

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/agent-readiness-cors/docs/feat--agent-readiness-cors/cors-agent-access.html)** — before/after + a live cross-origin fetch test.

## Root cause

Every response carried `Access-Control-Allow-Origin: https://orchestkit.yonyon.ai`. For a public, read-only docs/agent API this is wrong — it blocks any cross-origin (browser-based) AI agent from reading `/ask`, `/api/mcp`, the well-known cards, and the markdown/llms feeds. That's the most likely reason live, spec-correct endpoints read `fail` on the orank scan.

## Changes

- **CORS opened** (`next.config.mjs`): `Access-Control-Allow-Origin: *` + `Access-Control-Allow-Methods: GET, POST, OPTIONS` + `Access-Control-Allow-Headers: Content-Type, Accept` on all responses. Safe — the site is fully public with no auth/cookies.
- **OPTIONS preflight handlers** on `/api/ask` and `/api/mcp` so browser-based agents pass preflight for the POST + `application/json` calls.
- **Broader MCP discovery paths**: `/.well-known/mcp.json`, `/.well-known/mcp/manifest.json`, and `/mcp.json` now resolve to the server card (orank's methodology probes these filenames).

## Verification

- ✅ Production `next build` (exit 0) · `tsc --noEmit` clean
- ✅ `Access-Control-Allow-Origin: *` on `/ask`, `/api/mcp`, `/.well-known/*`, `/llms*.txt`, `/*.md`
- ✅ `OPTIONS /api/ask` and `OPTIONS /api/mcp` → 204
- ✅ All new MCP `.json` paths return the server card

## Expected impact

This should let orank's probe read the agent endpoints it currently can't, recovering the NLWeb `/ask`, MCP discovery, multi-surface MCP, and JSON-error checks. I will re-scan after deploy and report the actual delta — not claiming the points until the scan confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
