### PR TITLE
chore(mcp): add server.json for MCP registry publish

### DIFF
--- a/docs/chore--mcp-registry-server-json/mcp-registry-playground.html
+++ b/docs/chore--mcp-registry-server-json/mcp-registry-playground.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>OrchestKit · MCP registry server.json</title>
+<style>body{margin:0;background:#0a0f1c;color:#e9eef7;font-family:system-ui,sans-serif;line-height:1.6}.w{max-width:760px;margin:0 auto;padding:32px 20px}h1{font-size:1.5rem}code,pre{font-family:ui-monospace,Menlo,monospace}pre{background:#0e1626;border:1px solid #1e2b45;border-radius:8px;padding:14px;overflow:auto;font-size:.82rem}.m{color:#8da2c0}a{color:#34d399}.s{margin:10px 0;padding:10px 12px;background:#111a2e;border:1px solid #1e2b45;border-radius:8px}</style>
+</head><body><div class="w">
+<h1>Publishing OrchestKit to the official MCP registry</h1>
+<p class="m">This PR adds <code>server.json</code> at the repo root — the manifest the <code>mcp-publisher</code> CLI reads to list OrchestKit's remote MCP server in <a href="https://registry.modelcontextprotocol.io">registry.modelcontextprotocol.io</a> (the canonical directory other catalogs pull from). Closes part of orank "Listed in MCP registries".</p>
+<pre>{
+  "name": "io.github.yonatangross/orchestkit",
+  "title": "OrchestKit Docs MCP",
+  "remotes": [{ "type": "streamable-http",
+    "url": "https://orchestkit.yonyon.ai/api/mcp" }]
+}</pre>
+<h3>Owner step (GitHub-namespace auth — can't be automated)</h3>
+<div class="s">1. <code>brew install mcp-publisher</code> (or download the release)</div>
+<div class="s">2. <code>mcp-publisher login github</code> — proves you own <code>github.com/yonatangross</code> (the <code>io.github.yonatangross/*</code> namespace)</div>
+<div class="s">3. <code>mcp-publisher publish</code> from the repo root</div>
+<p class="m">The server is already live + verified at <code>/api/mcp</code> (Streamable HTTP, read-only tools). No code change — just the registry manifest.</p>
+</div></body></html>

--- a/server.json
+++ b/server.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.yonatangross/orchestkit",
+  "title": "OrchestKit Docs MCP",
+  "description": "Read-only MCP server over the OrchestKit documentation: full-text docs search and Markdown page fetch for the OrchestKit Claude Code plugin (skills, agents, hooks). No authentication.",
+  "websiteUrl": "https://orchestkit.yonyon.ai",
+  "repository": { "url": "https://github.com/yonatangross/orchestkit", "source": "github" },
+  "version": "8.26.0",
+  "remotes": [
+    { "type": "streamable-http", "url": "https://orchestkit.yonyon.ai/api/mcp" }
+  ]
+}


### PR DESCRIPTION
## Add `server.json` for the official MCP registry

Adds the MCP-registry manifest (`server.json`, schema `2025-12-11`) so OrchestKit's live remote MCP server can be published to **[registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io)** — the canonical directory other catalogs (Smithery, glama, mcp.so) pull from. Moves the orank "Listed in MCP registries" gap.

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/chore/mcp-registry-server-json/docs/chore--mcp-registry-server-json/mcp-registry-playground.html)** — the manifest + the publish steps.

- Namespace `io.github.yonatangross/orchestkit`, remote `streamable-http` → `https://orchestkit.yonyon.ai/api/mcp` (live + verified, read-only tools, no auth).
- No code change — just the registry manifest.

**Owner step (can't be automated — GitHub-namespace auth):** `mcp-publisher login github` (proves ownership of the `io.github.yonatangross/*` namespace) then `mcp-publisher publish` from the repo root.

Refs #2286.
