### PR TITLE
feat(docs): add Glama ownership claim files (server + connector)

### DIFF
--- a/docs/feat--glama-claim/index.html
+++ b/docs/feat--glama-claim/index.html
@@ -1,0 +1,78 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Glama Claim Playground — OrchestKit</title>
+<style>
+  :root { color-scheme: dark; }
+  body { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #0d1117; color: #e6edf3; max-width: 880px; margin: 2rem auto; padding: 0 1rem; }
+  h1 { font-size: 1.3rem; } h2 { font-size: 1.05rem; margin-top: 2rem; }
+  .card { border: 1px solid #30363d; border-radius: 8px; padding: 1rem; margin: 1rem 0; background: #161b22; }
+  .ok { color: #3fb950; } .fail { color: #f85149; } .pending { color: #d29922; }
+  pre { background: #0d1117; border: 1px solid #30363d; border-radius: 6px; padding: .75rem; overflow-x: auto; }
+  button { background: #238636; color: #fff; border: 0; border-radius: 6px; padding: .5rem 1rem; cursor: pointer; font: inherit; }
+  button:hover { background: #2ea043; }
+  a { color: #58a6ff; }
+  .muted { color: #8b949e; }
+</style>
+</head>
+<body>
+<h1>Glama Claim Playground</h1>
+<p class="muted">
+  This change publishes two ownership-claim files for the Glama MCP registry:
+  a repo-root <code>glama.json</code> (claims the <em>Server</em> listing, keyed by GitHub repo)
+  and <code>/.well-known/glama.json</code> on orchestkit.yonyon.ai (claims the
+  <em>Connector</em> listing for the remote endpoint). This playground probes the
+  live deployment so a reviewer can verify both surfaces.
+</p>
+
+<div class="card">
+  <h2 style="margin-top:0">1. Connector claim — <code>/.well-known/glama.json</code></h2>
+  <p class="muted">Served from <code>docs/site/public/.well-known/glama.json</code> once this PR deploys.</p>
+  <button onclick="probe('https://orchestkit.yonyon.ai/.well-known/glama.json', 'wk')">Probe live</button>
+  <pre id="wk" class="pending">not probed yet</pre>
+</div>
+
+<div class="card">
+  <h2 style="margin-top:0">2. MCP endpoint health (what Glama checks)</h2>
+  <p class="muted">The connector listing re-tests this endpoint; it should answer an MCP <code>initialize</code>.</p>
+  <button onclick="probeMcp()">Probe /api/mcp</button>
+  <pre id="mcp" class="pending">not probed yet</pre>
+</div>
+
+<div class="card">
+  <h2 style="margin-top:0">3. Registry listings</h2>
+  <ul>
+    <li><a href="https://glama.ai/mcp/connectors/io.github.yonatangross/orchestkit" target="_blank" rel="noopener">Connector listing (live, tool quality 4.2/5.0)</a></li>
+    <li><a href="https://glama.ai/mcp/servers/yonatangross/orchestkit" target="_blank" rel="noopener">Server listing (pending submission + Dockerfile checks)</a></li>
+  </ul>
+</div>
+
+<script>
+async function probe(url, id) {
+  const el = document.getElementById(id);
+  el.textContent = 'probing ' + url + ' …'; el.className = 'pending';
+  try {
+    const r = await fetch(url, { cache: 'no-store' });
+    const body = await r.text();
+    el.textContent = 'HTTP ' + r.status + '\n' + body.slice(0, 500);
+    el.className = r.ok ? 'ok' : 'fail';
+  } catch (e) { el.textContent = 'fetch failed: ' + e; el.className = 'fail'; }
+}
+async function probeMcp() {
+  const el = document.getElementById('mcp');
+  el.textContent = 'probing …'; el.className = 'pending';
+  try {
+    const r = await fetch('https://orchestkit.yonyon.ai/api/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json, text/event-stream' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'playground', version: '1.0' } } }),
+    });
+    el.textContent = 'HTTP ' + r.status + '\n' + (await r.text()).slice(0, 500);
+    el.className = r.ok ? 'ok' : 'fail';
+  } catch (e) { el.textContent = 'fetch failed: ' + e; el.className = 'fail'; }
+}
+</script>
+</body>
+</html>

--- a/docs/site/public/.well-known/glama.json
+++ b/docs/site/public/.well-known/glama.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://glama.ai/mcp/schemas/connector.json",
+	"maintainers": [{ "email": "yonatan2gross@gmail.com" }]
+}

--- a/docs/site/public/.well-known/glama.json
+++ b/docs/site/public/.well-known/glama.json
@@ -1,4 +1,4 @@
 {
 	"$schema": "https://glama.ai/mcp/schemas/connector.json",
-	"maintainers": [{ "email": "yonatan2gross@gmail.com" }]
+	"maintainers": [{ "email": "yonaigross@gmail.com" }]
 }

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://glama.ai/mcp/schemas/server.json",
+	"maintainers": ["yonatangross"]
+}


### PR DESCRIPTION
## Summary

Adds the two Glama MCP registry ownership-claim files:

- `glama.json` (repo root) — claims the Glama **Server** listing (GitHub-keyed), maintainer `yonatangross`. Required before the Dockerfile checks + score badge that punkpeye/awesome-mcp-servers#7611 needs.
- `docs/site/public/.well-known/glama.json` — claims the live **Connector** listing at https://glama.ai/mcp/connectors/io.github.yonatangross/orchestkit (remote Streamable-HTTP endpoint). Glama auto-verifies this file within minutes of deploy; the email must match the Glama account email.

No source, hook, or skill changes — static JSON additions only.

## Interactive Playground

[docs/feat--glama-claim/index.html](../blob/feat/glama-claim/docs/feat--glama-claim/index.html) — playground that probes the deployed `/.well-known/glama.json` and the `/api/mcp` initialize round-trip so a reviewer can verify both claim surfaces live.

## Verification

- `https://orchestkit.yonyon.ai/api/mcp` answers MCP `initialize` (protocol 2025-06-18, v8.33.0) — tested via curl and via `mcp-remote --transport http-only` stdio bridge.
- Connector listing is live and healthy (tool definition quality 4.2/5.0).
