### PR TITLE
fix(docker): pin base images by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,11 @@
 #
 # Tool listing works offline; tool calls fetch from the public docs API.
 
-FROM node:22-alpine AS build
+# Digest-pinned (Scorecard Pinned-Dependencies; alerts #204/#206). The digest is
+# the multi-arch manifest list for node:22-alpine — covers amd64 + arm64.
+# Renovate/Dependabot bump it; to refresh manually:
+#   docker buildx imagetools inspect node:22-alpine
+FROM node:22-alpine@sha256:9385cd9f3001dfc3431e8ead12c43e9e1f87cc1b9b5c6cfd0f73865d405b27c4 AS build
 WORKDIR /app
 COPY src/mcp-server/package.json src/mcp-server/package-lock.json ./
 RUN npm ci
@@ -16,7 +20,7 @@ COPY src/mcp-server/tsconfig.json src/mcp-server/esbuild.config.mjs ./
 COPY src/mcp-server/src ./src
 RUN npm run build
 
-FROM node:22-alpine
+FROM node:22-alpine@sha256:9385cd9f3001dfc3431e8ead12c43e9e1f87cc1b9b5c6cfd0f73865d405b27c4
 # MCP registry ownership validation — must match server.json "name"
 LABEL io.modelcontextprotocol.server.name="io.github.yonatangross/orchestkit"
 # Auto-links the GHCR package to this repo (grants Actions GITHUB_TOKEN write

--- a/docs/fix--pin-dockerfile-base/pin-playground.html
+++ b/docs/fix--pin-dockerfile-base/pin-playground.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Digest Pin — Playground</title>
+<style>body{background:#0d1117;color:#e6edf3;font-family:ui-monospace,Menlo,monospace;padding:2rem;line-height:1.6}.ok{color:#3fb950}.bad{color:#f85149}pre{background:#161b22;border:1px solid #30363d;border-radius:8px;padding:1rem;font-size:.85rem}</style>
+</head>
+<body>
+<h1>📌 Scorecard Pinned-Dependencies fix (#204, #206)</h1>
+<pre><span class="bad">- FROM node:22-alpine AS build</span>
+<span class="ok">+ FROM node:22-alpine@sha256:9385cd9f3001dfc3431e8ead12c43e9e1f87cc1b9b5c6cfd0f73865d405b27c4 AS build</span>
+
+<span class="bad">- FROM node:22-alpine</span>
+<span class="ok">+ FROM node:22-alpine@sha256:9385cd9f3001dfc3431e8ead12c43e9e1f87cc1b9b5c6cfd0f73865d405b27c4</span></pre>
+<p>Digest = multi-arch manifest list (amd64 + arm64). Refresh: <code>docker buildx imagetools inspect node:22-alpine</code>. Renovate/Dependabot bump it from here.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Fixes Scorecard code-scanning alerts **#204** and **#206** (Pinned-Dependencies, Medium): both `FROM node:22-alpine` lines in the Dockerfile now pin the multi-arch manifest-list digest (`sha256:9385cd9f…b27c4`, covers linux/amd64 + linux/arm64). A comment documents the manual refresh command (`docker buildx imagetools inspect node:22-alpine`); Renovate/Dependabot handle bumps.

These are container findings — the kept category per the repo's Scorecard policy (npm/pip pinned-deps are the irreducible ones).

## Verification

- `docker build` with the pinned digest: succeeds locally
- `tests/manifests/test-server-json.sh`: all checks pass (label invariant intact)
- The `Docker Smoke` PR gate (path-filtered on Dockerfile) runs the build + label check in CI

## Playground

N/A — two-line digest pin; see the diff. (playground exemption: dependency pin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
