### PR TITLE
feat(docs-site): discovery on-site gaps — density, brand tie, dev hub

### DIFF
--- a/docs/feat--discovery-onsite-gaps/discovery-playground.html
+++ b/docs/feat--discovery-onsite-gaps/discovery-playground.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Discovery On-Site Gaps — Playground</title>
+<style>body{background:#0d1117;color:#e6edf3;font-family:ui-monospace,Menlo,monospace;padding:2rem;line-height:1.6;max-width:980px;margin:0 auto}.ok{color:#3fb950}.bad{color:#f85149}.warn{color:#d29922}.dim{color:#8b949e}pre{background:#161b22;border:1px solid #30363d;border-radius:8px;padding:1rem;font-size:.8rem;white-space:pre-wrap}td,th{padding:.35rem .5rem;border-bottom:1px solid #30363d;text-align:left;font-size:.84rem;vertical-align:top}table{width:100%;border-collapse:collapse}</style>
+</head>
+<body>
+<h1>🔎 Discovery on-site gaps — the touchable half of 16/41</h1>
+<p class="dim">Probe-verified before coding: density 4.47% (bar 5%), "Yonyon" appeared ZERO times as text on the site, Wikidata entity existed but the checker searched the apex brand.</p>
+<table>
+<tr><th>Gap (check)</th><th>Evidence</th><th>Fix in this PR</th></tr>
+<tr><td>Semantic indexability 1/2 + content-efficiency 1/2</td><td>5,306 text chars / 118,610 HTML bytes = <span class="bad">4.47%</span></td><td class="ok">"What is OrchestKit?" SSR prose section (~1.1K chars of honest, name-rich text) → crosses the 5% bar; feeds BOTH checks</td></tr>
+<tr><td>Developer resource discoverability 0/6</td><td>checker web-searches "yonyon developer resources"; brand word absent from all page text</td><td class="ok">title "OrchestKit by Yonyon — AI Development Toolkit for Claude Code" · Organization alternateName ["Yonyon", …] · footer "built by Yonyon" · NEW /developers hub (12 resources at the literal query term) · llms.txt link</td></tr>
+<tr><td>Wikipedia/Wikidata 0/4</td><td>Q140128295 EXISTS (P856 = orchestkit.yonyon.ai, 8 claims) — checker searched "yonyon", entity is named "OrchestKit"</td><td class="ok">en aliases added on Wikidata (rev 2504696812): "Yonyon OrchestKit", "OrchestKit by Yonyon" · feedback #73 filed citing the QID · sameAs already bi-directional</td></tr>
+</table>
+<pre><span class="dim"># density math</span>
+before: 5,306 / 118,610        = 4.47% ❌
+added : ~+1,100 SSR text chars (What-is section + footer + hub links on home)
+after : ~6,400 / ~120,000      ≈ <span class="ok">5.3% ✅</span> (verified against the production build)</pre>
+<p class="dim">Deliberately NOT done here: Wikipedia article (notability needs press first — premature = deletion + salted title), hidden-text stuffing (cloaking), share-of-voice content batch + launch-kit drafts (separate PR; human posting gates apply).</p>
+</body>
+</html>

--- a/docs/site/app/(home)/developers/page.tsx
+++ b/docs/site/app/(home)/developers/page.tsx
@@ -1,0 +1,119 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ContentPage } from "@/components/content-page";
+import { COUNTS, SITE } from "@/lib/constants";
+
+// /developers — the developer-resource hub at a predictable, name-based URL.
+// Everything listed here already exists; this page is the single index that
+// search engines and agents can find for "<brand> developer resources".
+export const metadata: Metadata = {
+	title: "Developer Resources",
+	description: `OrchestKit by Yonyon developer resources: API docs, OpenAPI spec, MCP server (hosted + Docker), SDK packages on npm and PyPI, auth and API policy.`,
+	alternates: { canonical: `${SITE.domain}/developers` },
+};
+
+const RESOURCES: ReadonlyArray<{
+	title: string;
+	desc: string;
+	href: string;
+	external?: boolean;
+}> = [
+	{
+		title: "Documentation",
+		desc: `Install guides, concepts, and reference for all ${COUNTS.skills} skills, ${COUNTS.agents} agents, and ${COUNTS.hooks} hooks.`,
+		href: "/docs/getting-started/installation",
+	},
+	{
+		title: "OpenAPI specification",
+		desc: "OpenAPI 3.1 description of the public, read-only docs API — search, Markdown fetch, batch, async jobs.",
+		href: "/api/openapi",
+	},
+	{
+		title: "MCP server (hosted, Streamable HTTP)",
+		desc: "Connect AI agents to the docs natively. No auth. Server card at /.well-known/mcp/server-card.json.",
+		href: "/api/mcp",
+	},
+	{
+		title: "MCP server (stdio, Docker image)",
+		desc: "Run locally: docker run -i --rm ghcr.io/yonatangross/orchestkit-docs-mcp — multi-arch (amd64 + arm64).",
+		href: "https://github.com/yonatangross/orchestkit/pkgs/container/orchestkit-docs-mcp",
+		external: true,
+	},
+	{
+		title: "NLWeb natural-language endpoint",
+		desc: "POST or GET /ask with a question; JSON or SSE streaming responses (NLWeb protocol).",
+		href: "/ask?query=what+is+orchestkit",
+	},
+	{
+		title: "Python package (PyPI)",
+		desc: "orchestkit-hook-contract — typed hook I/O contract for building OrchestKit-compatible tooling in Python.",
+		href: "https://pypi.org/project/orchestkit-hook-contract/",
+		external: true,
+	},
+	{
+		title: "Authentication policy",
+		desc: "The API is public and anonymous-only — auth.md states it in the WorkOS auth.md shape, with RFC 9728 PRM.",
+		href: "/auth.md",
+	},
+	{
+		title: "API versioning & deprecation policy",
+		desc: "Versioning scheme, RFC 8594 Deprecation/Sunset headers, and the 6-month sunset guarantee.",
+		href: "/api-policy.md",
+	},
+	{
+		title: "llms.txt",
+		desc: "Machine-readable site index for AI agents — canonical description, use cases, and resource map.",
+		href: "/llms.txt",
+	},
+	{
+		title: "API catalog (RFC 9727)",
+		desc: "Linkset of every discoverable API surface at /.well-known/api-catalog.",
+		href: "/.well-known/api-catalog",
+	},
+	{
+		title: "Source code (GitHub)",
+		desc: "MIT-licensed monorepo: plugin source, hooks, MCP server, docs site, and CI.",
+		href: "https://github.com/yonatangross/orchestkit",
+		external: true,
+	},
+	{
+		title: "MCP registry entry",
+		desc: "io.github.yonatangross/orchestkit on the official Model Context Protocol registry — republished every release.",
+		href: "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.yonatangross/orchestkit",
+		external: true,
+	},
+];
+
+export default function DevelopersPage() {
+	return (
+		<ContentPage
+			title="OrchestKit developer resources"
+			path="/developers"
+			lead="Every developer-facing surface of OrchestKit by Yonyon in one place: documentation, OpenAPI spec, MCP servers, SDK packages, and the auth and API policies. All public, all free, no account required."
+		>
+			<h2>Resources</h2>
+			<ul>
+				{RESOURCES.map((r) => (
+					<li key={r.href}>
+						{r.external ? (
+							<a href={r.href} target="_blank" rel="noopener noreferrer">
+								{r.title}
+							</a>
+						) : (
+							<Link href={r.href}>{r.title}</Link>
+						)}
+						{" — "}
+						{r.desc}
+					</li>
+				))}
+			</ul>
+			<h2>For AI agents</h2>
+			<p>
+				Agents should start at the RFC 9727 API catalog or llms.txt above. The
+				docs API needs no credentials; errors use RFC 9457 Problem Details; rate
+				limits are communicated via standard RateLimit headers. The same docs are
+				reachable as Markdown by appending .md to any page URL.
+			</p>
+		</ContentPage>
+	);
+}

--- a/docs/site/app/(home)/page.tsx
+++ b/docs/site/app/(home)/page.tsx
@@ -460,10 +460,48 @@ export default async function HomePage() {
       {/* ============ FOR AI AGENTS (SSR, text-dense) ============ */}
       <AgentReadinessSection />
 
+      {/* ============ WHAT IS ORCHESTKIT (SSR prose — semantic indexability) ============
+          Server-rendered plain-text answers; RAG indexers and search engines read raw
+          HTML, so this section carries the canonical name-based descriptions. */}
+      <section className="border-t border-fd-border">
+        <div className="mx-auto max-w-[1200px] px-7 py-12">
+          <h2 className="text-lg font-semibold">What is OrchestKit?</h2>
+          <div className="mt-4 grid gap-6 text-sm leading-relaxed text-fd-muted-foreground md:grid-cols-2">
+            <p>
+              OrchestKit is a free, MIT-licensed plugin for Claude Code, Anthropic&apos;s
+              agentic coding CLI. It packages {COUNTS.skills} reusable skills,{" "}
+              {COUNTS.agents} specialist agents, and {COUNTS.hooks} lifecycle hooks into a
+              single install, so the agent applies proven auth, migration, API-design,
+              testing, and security patterns to your codebase without being re-taught
+              every session. It runs entirely inside Claude Code — there is no hosted
+              service, no account, and no telemetry requirement.
+            </p>
+            <p>
+              OrchestKit is built and maintained by Yonyon, the software studio of
+              Yonatan Gross. Developer resources live at predictable URLs: the{" "}
+              <Link href="/docs/getting-started/installation" className="underline decoration-fd-border underline-offset-4 hover:text-fd-primary">
+                documentation
+              </Link>
+              , the{" "}
+              <Link href="/developers" className="underline decoration-fd-border underline-offset-4 hover:text-fd-primary">
+                developer resource hub
+              </Link>{" "}
+              (OpenAPI spec, MCP server, SDK packages, auth and API policy), and the{" "}
+              <a href={SITE.github} target="_blank" rel="noopener noreferrer" className="underline decoration-fd-border underline-offset-4 hover:text-fd-primary">
+                open-source repository on GitHub
+              </a>
+              . AI agents can query the docs through the NLWeb /ask endpoint or the
+              OrchestKit Docs MCP server, hosted and as a Docker image.
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* ============ FOOTER ============ */}
       <footer>
         <div className="mx-auto flex max-w-[1200px] items-center justify-between px-7 py-5 text-[13px] text-fd-muted-foreground">
           <span>
+            OrchestKit is built by Yonyon{" · "}
             Built with{" "}
             <a
               href="https://fumadocs.dev"

--- a/docs/site/app/layout.tsx
+++ b/docs/site/app/layout.tsx
@@ -19,7 +19,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
 	title: {
 		template: `%s | ${SITE.name}`,
-		default: `${SITE.name} — AI Development Toolkit`,
+		// "by Yonyon" ties the studio brand to the product for name-based search
+		// queries — the word appeared nowhere as text on the site before this.
+		default: `${SITE.name} by Yonyon — AI Development Toolkit for Claude Code`,
 	},
 	description: `${COUNTS.skills} skills, ${COUNTS.agents} agents, ${COUNTS.hooks} hooks for Claude Code. Stop explaining your stack. Start shipping.`,
 	icons: { icon: "/favicon.svg" },

--- a/docs/site/app/llms.txt/route.ts
+++ b/docs/site/app/llms.txt/route.ts
@@ -95,6 +95,7 @@ export function GET() {
 		"- [OpenAPI spec](/api/openapi)",
 		"- [NLWeb natural-language query endpoint](/ask)",
 		"- [Agent skills on skills.sh (official, self-published)](https://www.skills.sh/yonatangross/orchestkit)",
+		"- [Developer resource hub](/developers)",
 		"- [MCP server](/api/mcp) · [server card](/.well-known/mcp/server-card.json) · [MCP well-known](/.well-known/mcp)",
 		"- [API catalog (RFC 9727)](/.well-known/api-catalog)",
 		"- [Pricing](/pricing.md)",

--- a/docs/site/components/structured-data.tsx
+++ b/docs/site/components/structured-data.tsx
@@ -33,6 +33,10 @@ export function organizationNode(): JsonLdNode {
 		"@type": "Organization",
 		"@id": ORG_ID,
 		name: SITE.name,
+		// Brand disambiguation: the apex brand "Yonyon" collides with an unrelated
+		// music artist in search/training corpora; alternateName ties the studio
+		// name to THIS entity so name-based queries resolve here.
+		alternateName: ["Yonyon", "OrchestKit by Yonyon"],
 		legalName: ORG.legalName,
 		url: SITE.domain,
 		logo: `${SITE.domain}/favicon.svg`,

--- a/docs/site/lib/agent-404.ts
+++ b/docs/site/lib/agent-404.ts
@@ -22,6 +22,7 @@ export const SERVED_EXACT: ReadonlySet<string> = new Set([
 	"/alternatives",
 	"/compare",
 	"/contact",
+	"/developers",
 	"/pricing",
 	"/privacy",
 	"/status",


### PR DESCRIPTION
## Summary

The touchable half of orank's Discovery layer (16/41). Probe-verified before any code: homepage density **4.47%** vs the checker's 5% bar; the word "Yonyon" appeared **zero times as page text** anywhere on the site (URL only), so the dev-resource checker's literal query — "yonyon developer resources" — could never tie brand to site; and the Wikidata entity the wikipedia-presence check demands **already exists** (Q140128295, P856 = orchestkit.yonyon.ai) but is named "OrchestKit" while the checker searched "yonyon".

## Changes

- **Semantic indexability / content efficiency** — server-rendered "What is OrchestKit?" prose section on the homepage: honest, name-rich text that lifts density **4.47% → 5.23%** (measured on the production build, not estimated). One fix feeds two checks (Discovery `semantic-indexing` + Identity `content-efficiency`, both warning at 1/2).
- **Brand tie (dev-resource discoverability)** — default title is now "OrchestKit by Yonyon — AI Development Toolkit for Claude Code"; Organization JSON-LD gains `alternateName: ["Yonyon", "OrchestKit by Yonyon"]`; footer states "OrchestKit is built by Yonyon".
- **`/developers` hub (new page)** — 12 developer resources (docs, OpenAPI, hosted + Docker MCP surfaces, PyPI package, auth.md, api-policy.md, llms.txt, RFC 9727 catalog, GitHub, MCP registry entry) at the predictable, name-based URL the checker queries. Wired into `SERVED_EXACT` (the drift-guard test enforces it) and `llms.txt`.

## Off-repo, same round

- **Wikidata Q140128295** gained en aliases "Yonyon OrchestKit" / "OrchestKit by Yonyon" (rev 2504696812) so apex-brand searches resolve to the product entity; site `sameAs` already links the QID bi-directionally.
- **ora feedback #73** filed on `wikipedia-presence`: the entity + exact P856 the fix text asks for exist; the finding searched the apex word and missed it.

## Deliberately NOT done

- Wikipedia article — notability needs third-party press first; premature attempts get deleted and the title salted
- Hidden-text density stuffing — cloaking, honest-posture violation
- Category-content batch + HN/Reddit/Dev.to launch drafts — separate round; community posts must be authentically human-posted

## Verification

- `tsc --noEmit` clean · docs-site vitest **242/242** · `next build` green
- Density + brand strings measured on the **built** HTML (5.23%, both strings present); `/developers` prerenders with 2,153 text chars

## Playground

`docs/feat--discovery-onsite-gaps/discovery-playground.html` (full audit playground from the brainstorm: `/tmp/orank-discovery-gaps-playground-2026-06-11.html`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
