### PR TITLE
docs(multimodal-llm): clarify Opus 4.6 pixel-budget comparison

### DIFF
--- a/docs/site/content/docs/reference/skills/multimodal-llm.mdx
+++ b/docs/site/content/docs/reference/skills/multimodal-llm.mdx
@@ -119,7 +119,7 @@ Generate multi-scene videos with consistent characters using storyboarding and c
 
 | Decision | Recommendation |
 |----------|----------------|
-| High accuracy vision | `claude-opus-4-8` (2,576 px, 3× Opus 4.6 — production default). `claude-fable-5` is SOTA (screenshot→source) but entitlement-gated and credit-consuming; pin only on explicit owner decision |
+| High accuracy vision | `claude-opus-4-8` (production default — 2,576 px vision budget, 3× what Opus 4.6 allotted). `claude-fable-5` is SOTA (screenshot→source) but entitlement-gated and credit-consuming; pin only on explicit owner decision |
 | Long documents | `gemini-3.1-pro-preview` (1M+ context) |
 | Cost-efficient vision | `gemini-3.1-flash-lite-preview` (**replaces Gemini 2.5 Flash**, deprecates Oct 2026) |
 | Video analysis | `gemini-3.1-pro-preview` (native video, supersedes 2.5 Pro) |

--- a/plugins/ork/skills/multimodal-llm/SKILL.md
+++ b/plugins/ork/skills/multimodal-llm/SKILL.md
@@ -129,7 +129,7 @@ Generate multi-scene videos with consistent characters using storyboarding and c
 
 | Decision | Recommendation |
 |----------|----------------|
-| High accuracy vision | `claude-opus-4-8` (2,576 px, 3× Opus 4.6 — production default). `claude-fable-5` is SOTA (screenshot→source) but entitlement-gated and credit-consuming; pin only on explicit owner decision |
+| High accuracy vision | `claude-opus-4-8` (production default — 2,576 px vision budget, 3× what Opus 4.6 allotted). `claude-fable-5` is SOTA (screenshot→source) but entitlement-gated and credit-consuming; pin only on explicit owner decision |
 | Long documents | `gemini-3.1-pro-preview` (1M+ context) |
 | Cost-efficient vision | `gemini-3.1-flash-lite-preview` (**replaces Gemini 2.5 Flash**, deprecates Oct 2026) |
 | Video analysis | `gemini-3.1-pro-preview` (native video, supersedes 2.5 Pro) |

--- a/src/skills/multimodal-llm/SKILL.md
+++ b/src/skills/multimodal-llm/SKILL.md
@@ -129,7 +129,7 @@ Generate multi-scene videos with consistent characters using storyboarding and c
 
 | Decision | Recommendation |
 |----------|----------------|
-| High accuracy vision | `claude-opus-4-8` (2,576 px, 3× Opus 4.6 — production default). `claude-fable-5` is SOTA (screenshot→source) but entitlement-gated and credit-consuming; pin only on explicit owner decision |
+| High accuracy vision | `claude-opus-4-8` (production default — 2,576 px vision budget, 3× what Opus 4.6 allotted). `claude-fable-5` is SOTA (screenshot→source) but entitlement-gated and credit-consuming; pin only on explicit owner decision |
 | Long documents | `gemini-3.1-pro-preview` (1M+ context) |
 | Cost-efficient vision | `gemini-3.1-flash-lite-preview` (**replaces Gemini 2.5 Flash**, deprecates Oct 2026) |
 | Video analysis | `gemini-3.1-pro-preview` (native video, supersedes 2.5 Pro) |


### PR DESCRIPTION
## Summary

Follow-up to #2420 (raced its auto-merge by seconds). The high-accuracy-vision row read `claude-opus-4-8 (2,576 px, 3× Opus 4.6 — production default)` — the carried-over `3× Opus 4.6` parenthetical looked like it modified the recommendation. Reworded to make it unambiguous that 2,576 px is the vision budget and the 3× is a comparison to Opus 4.6's allotment.

## Testing

Content-only reword; `npm run build` regenerated plugins/ + docs reference cleanly.

## Playground

Covered by the existing `docs/fix--cc-adoption-ws2-model-resilience/availability-simulator.html` playground (same branch slug, merged in #2420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)