### PR TITLE
fix(deps): bump hono to 4.12.25 (5 high CVEs)

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -2570,9 +2570,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2588,9 +2585,6 @@
 			"integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2608,9 +2602,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2626,9 +2617,6 @@
 			"integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2646,9 +2634,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2664,9 +2649,6 @@
 			"integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -5773,9 +5755,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.23",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-			"integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+			"version": "4.12.25",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orchestkit",
-  "version": "8.47.1",
+  "version": "8.47.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orchestkit",
-      "version": "8.47.1",
+      "version": "8.47.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -1398,9 +1398,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

`hono` (root + docs/site dependency) ≤4.12.24 carries **5 new high-severity advisories** — main's Security Tests + Dependency-Audit gate has been red on these, blocking **all open PRs** (#2485, #2486, #2477, #2484).

| Advisory | Impact |
|---|---|
| GHSA-wwfh-h76j-fc44 | `serve-static` path traversal on Windows via encoded backslash |
| GHSA-88fw-hqm2-52qc | CORS middleware reflects any Origin with credentials on wildcard default |
| GHSA-rv63-4mwf-qqc2 | Body-Limit bypass on AWS Lambda |
| GHSA-j6c9-x7qj-28xf / GHSA-wgpf-jwqj-8h8p | Set-Cookie / repeated-header drops on Lambda adapters |

## Fix
`npm audit fix --package-lock-only` → **hono 4.12.23 → 4.12.25**, within the existing `^4.12.18` range (non-major), root + docs/site lockfiles only.

```
npm audit (root + docs/site): 0 findings
test-npm-audit.sh: root/src/hooks/docs-site → 3/3 pass
```

Follows #2208 (which bumped the earlier *moderate* hono CVEs). Once merged, the 4 blocked PRs rebase onto green main.

**Durable note:** hono is a recurring CVE source and has **no direct root import** (`git grep "from 'hono'"` in src/ is empty) — worth a follow-up to confirm it's still needed as a root dependency vs docs/site-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
