### PR TITLE
docs(readme): add Ask DeepWiki documentation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/yonatangross/orchestkit?style=for-the-badge&logo=github)](https://github.com/yonatangross/orchestkit)
 [![Community](https://img.shields.io/badge/Community-WhatsApp-25D366?style=for-the-badge&logo=whatsapp)](https://chat.whatsapp.com/IKgu1xuvKNXHikJ4Qeotpk)
+[![Ask DeepWiki](https://img.shields.io/badge/Ask-DeepWiki-1A1A2E?style=for-the-badge&logo=bookstack&logoColor=4F9CF9)](https://deepwiki.com/yonatangross/orchestkit)
 
 </div>
 


### PR DESCRIPTION
## Summary

Adds an **Ask DeepWiki** badge to the README badge row, linking to the auto-generated conversational docs at https://deepwiki.com/yonatangross/orchestkit.

Styled with `style=for-the-badge` so it matches the existing Claude Code / License / Stars / Community badges (the native DeepWiki flat badge would have clashed visually).

## Changes

- `README.md` — one badge line added under the Community badge.

## Notes

- `ci/` branch prefix: no version bump, no playground (nothing user-facing to render), pre-push version gate skipped by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
