### PR TITLE
fix(ci): remediate 6 Scorecard Token-Permissions alerts (fix #212, filter #207-211)

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -18,6 +18,10 @@
 # pattern for granting Dependabot PRs a privileged token without exposing it to
 # untrusted PR code. Dependabot-controlled metadata is passed via env, never
 # interpolated into a run-step shell body.
+#
+# Least privilege: top-level grants nothing (contents: read); the write token
+# the automerge job needs is scoped to that job only (Scorecard Token-Permissions
+# #212 — top-level write leaks to every future job added to this workflow).
 
 name: Dependabot auto-merge
 
@@ -26,8 +30,7 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   automerge:
@@ -35,6 +38,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     timeout-minutes: 5
+    permissions:
+      contents: write       # gh pr merge --auto
+      pull-requests: write  # enable auto-merge, label/comment held majors
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,15 +43,27 @@ jobs:
           retention-days: 5
 
   # Unrestricted job (no scorecard-action present) — free to run `run:` steps.
-  # Hybrid de-noise: drop the irreducible npm/pip "not pinned by hash" findings.
-  # npm global installs and `pip install -e .` cannot be hash-pinned the way
-  # GitHub Actions / container images can, so they are permanent noise that
-  # masks genuinely actionable findings. GitHubAction / containerImage /
-  # downloadThenRun findings are KEPT, so a future unpinned-action regression
-  # (cf. ci-sentinel.yml slipping the org-wide SHA-pin sweep) still raises an
-  # alert. This affects ONLY the code-scanning view — `publish_results: true`
-  # already sent the unfiltered result to the public OpenSSF score upstream, so
-  # the score is not gamed.
+  # Hybrid de-noise: drop the irreducible findings that mask actionable ones.
+  #
+  # 1. npm/pip "not pinned by hash" (PinnedDependenciesID): npm global installs
+  #    and `pip install -e .` cannot be hash-pinned the way GitHub Actions /
+  #    container images can — permanent noise. GitHubAction / containerImage /
+  #    downloadThenRun findings are KEPT so a future unpinned-action regression
+  #    (cf. ci-sentinel.yml slipping the org-wide SHA-pin sweep) still alerts.
+  #
+  # 2. Token-Permissions (TokenPermissionsID) on five publish/watch workflows
+  #    (#207–211): each already runs default-deny at the top level with write
+  #    scoped to the single job whose entire purpose is to push a branch, open a
+  #    PR, or `gh release create`. The write is irreducible — a release cannot
+  #    be cut with `contents: read`. The filter is keyed to an explicit FILE
+  #    ALLOWLIST (not the generic message), so a NEW workflow with a bad
+  #    top-level write still raises an alert. dependabot-automerge.yml is
+  #    deliberately NOT in the allowlist — #212 was a genuine top-level-write
+  #    violation and was fixed at the source, not filtered.
+  #
+  # This affects ONLY the code-scanning view — `publish_results: true` already
+  # sent the unfiltered result to the public OpenSSF score upstream, so the
+  # score is not gamed.
   upload:
     name: Filter & Upload SARIF
     needs: analysis
@@ -67,12 +79,18 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v6.0.0
         with:
           name: scorecard-sarif
-      - name: Drop unfixable npm/pip pinned-deps findings from SARIF
+      - name: Drop irreducible pinned-deps + scoped-write findings from SARIF
         run: |
           jq '.runs |= map(.results |= ((. // []) | map(
             select(
-              ((.ruleId == "PinnedDependenciesID")
-                and (.message.text | test("(npmCommand|pipCommand) not pinned by hash")))
+              (
+                ((.ruleId == "PinnedDependenciesID")
+                  and (.message.text | test("(npmCommand|pipCommand) not pinned by hash")))
+                or
+                ((.ruleId == "TokenPermissionsID")
+                  and ([.locations[]?.physicalLocation.artifactLocation.uri // ""]
+                    | any(test("\\.github/workflows/(publish-hook-contract-py|publish-hook-contract-npm|labs-version-watch|claude-release-watch|cc-support-window-bump)\\.yml$"))))
+              )
               | not
             )
           )))' results.sarif > results.filtered.sarif


### PR DESCRIPTION
## Summary

Triage + remediation of the 6 open Scorecard **Token-Permissions** (High) code-scanning alerts. One was a genuine least-privilege violation (fixed at source); the other five are already best-practice and irreducible (SARIF-filtered, matching the existing pinned-deps precedent #2155).

## Triage

| # | Workflow | Top-level perm | Verdict |
|---|----------|----------------|---------|
| 212 | `dependabot-automerge.yml` | `contents: write` ← leaked to all jobs | **Fixed** — top-level → `contents: read`, write scoped to the `automerge` job |
| 211 | `publish-hook-contract-py.yml` | `contents: read` | Irreducible — `gh release create` |
| 210 | `publish-hook-contract-npm.yml` | `contents: read` | Irreducible — `gh release create` |
| 209 | `labs-version-watch.yml` | `contents: read` | Irreducible — push branch + open PR |
| 208 | `claude-release-watch.yml` | `contents: read` | Irreducible — commit snapshot + issue/PR |
| 207 | `cc-support-window-bump.yml` | `contents: read` | Irreducible — push branch + open PR |

The five already run default-deny at the top level with write scoped to the single job whose purpose *is* to push/PR/release. The write cannot be removed without breaking the workflow — same class as the npm/pip pinned-deps findings filtered in #2155.

## Changes

1. **`dependabot-automerge.yml`** — top-level `permissions:` set to `contents: read`; the `contents: write` + `pull-requests: write` the automerge job needs moved into the job. No behavior change.
2. **`scorecard.yml`** — extended the existing `upload`-job jq de-noise step to also drop `TokenPermissionsID` findings for an explicit **file allowlist** of the 5 write-legit workflows. Keyed to file path (not the generic message), so a *new* workflow with a bad top-level write still alerts; `dependabot-automerge.yml` is deliberately not in the allowlist (fixed at source).

## Verification

- `actionlint` clean on both files.
- jq filter unit-tested against synthetic SARIF: drops the 5 allowlisted findings, **keeps** a non-allowlisted top-level-write finding and action-pin findings (safety net intact).
- `publish_results: true` already sent the unfiltered result upstream, so the public OpenSSF score is not affected — this only de-noises the code-scanning view.

## Notes

- `ci/` branch: config-only (`.github/workflows/`), nothing user-facing to playground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
