### PR TITLE
chore(infra): migrate stale yonatangross.dev refs to yonyon.ai

### DIFF
--- a/docs/site/lib/generated/pipeline-gallery-data.ts
+++ b/docs/site/lib/generated/pipeline-gallery-data.ts
@@ -37,7 +37,7 @@ export const PIPELINE_ENTRIES: PipelineEntry[] = [
     description: "Transformed a static portfolio hero into an animated component with badge, gradient text, and dual CTAs.",
     input: {
       type: "url",
-      value: "https://yonatangross.dev",
+      value: "https://yonyon.ai",
     },
     stages: {
       extract: "Extracted 8 colors (oklch), Geist font family, 4xl-6xl type scale, gradient mesh + orb background pattern, dual CTA layout",


### PR DESCRIPTION
## What

Migrate the last stale `yonatangross.dev` reference in the repo to the canonical `yonyon.ai` domain.

`yonatangross.dev` is **fully decommissioned** (verified 2026-06-17); canonical domain is `yonyon.ai` with a 1:1 subdomain mapping (`foo.yonatangross.dev` → `foo.yonyon.ai`).

## Changes

| File | Change |
|------|--------|
| `docs/site/lib/generated/pipeline-gallery-data.ts` | Sample input URL `https://yonatangross.dev` → `https://yonyon.ai` in the design-to-code pipeline gallery showcase data |

## Verification

`git grep yonatangross.dev` over tracked files returns **no remaining references** after this change. Artifacts (`*.jsonl`, `.claude/`, `playgrounds/`, `memory/`) were excluded from scope per the sweep policy; none contained matching refs anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)