### PR TITLE
feat(playground): Arieh-grade visual standard + decision boards

### DIFF
--- a/docs/feat--playground-visual-standard/decision-board.html
+++ b/docs/feat--playground-visual-standard/decision-board.html
@@ -135,6 +135,10 @@
   .card .meta { margin-top: 7px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
   .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); }
   .chip.rice { background: hsl(248 84% 68% / 0.16); color: hsl(248 84% 82%); font-family: var(--pg-mono); }
+  .chip.q-qw { background: hsl(160 68% 45% / 0.18); color: hsl(160 68% 72%); }
+  .chip.q-bb { background: hsl(248 84% 68% / 0.18); color: hsl(248 84% 82%); }
+  .chip.q-fi { background: hsl(206 85% 62% / 0.16); color: hsl(206 85% 76%); }
+  .chip.q-ts { background: hsl(345 76% 63% / 0.16); color: hsl(345 76% 78%); }
   .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
 
   /* dragging states */
@@ -220,7 +224,7 @@
       <h1>Decision Board</h1>
       <p>The decision-making parts of a playground should let you <b>act on the decision</b>, not just read it.
          Drag a card to set its impact &amp; effort, reorder the backlog, or sort it into buckets — the
-         <b>RICE score</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
+         <b>scores</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
          (<span class="kbd">Tab</span> a card, then <span class="kbd">← ↑ ↓ →</span>).</p>
     </div>
     <div class="right">
@@ -253,14 +257,14 @@
    Swap ITEMS for your own to reuse the template.
    ═══════════════════════════════════════════════════════════════════════ */
 const ITEMS = [
-  { id:"a", title:"One-click onboarding wizard",      reach:900, impact:3,   confidence:0.8,  effort:3 },
-  { id:"b", title:"Dark mode",                          reach:1200,impact:1,   confidence:0.95, effort:1 },
-  { id:"c", title:"SSO / SAML for enterprise",          reach:140, impact:3,   confidence:0.7,  effort:5 },
-  { id:"d", title:"Inline AI code review",              reach:600, impact:3,   confidence:0.6,  effort:4 },
-  { id:"e", title:"Mobile app",                         reach:2000,impact:2,   confidence:0.4,  effort:5 },
-  { id:"f", title:"Keyboard shortcuts",                 reach:500, impact:1,   confidence:0.9,  effort:1 },
-  { id:"g", title:"Usage analytics dashboard",          reach:350, impact:2,   confidence:0.8,  effort:3 },
-  { id:"h", title:"Slack notifications",                reach:700, impact:1,   confidence:0.85, effort:2 },
+  { id:"i2475", title:"#2475 Re-architect InstructionsLoaded hooks", reach:800, impact:5, confidence:0.7,  effort:3 }, // quick win
+  { id:"i2353", title:"#2353 Auto-inject prior-decision search",     reach:600, impact:4, confidence:0.7,  effort:2 }, // quick win
+  { id:"i2430", title:"#2430 ORK_NO_NOTIFY flag (disable banners)",  reach:300, impact:2, confidence:0.9,  effort:1 }, // fill-in
+  { id:"i2375", title:"#2375 Glama listing + score badge",           reach:150, impact:2, confidence:0.8,  effort:2 }, // fill-in
+  { id:"i2192", title:"#2192 Walk-all auto-eval coverage",           reach:500, impact:5, confidence:0.6,  effort:4 }, // big bet
+  { id:"i2195", title:"#2195 DeepEval/RAGAS eval pipeline",          reach:450, impact:4, confidence:0.6,  effort:5 }, // big bet
+  { id:"i2011", title:"#2011 M168 skill recommender",               reach:700, impact:4, confidence:0.65, effort:4 }, // big bet
+  { id:"i2264", title:"#2264 Reversible output compression",         reach:400, impact:2, confidence:0.5,  effort:4 }, // time sink
 ];
 
 const BUCKET_SCHEMES = {
@@ -298,19 +302,40 @@ const live  = document.getElementById("live");
 const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
 
 /* ── card markup ─────────────────────────────────────────────────────── */
+// Impact×Effort quadrant (split at the plane midpoint, impact/effort = 3).
+function quadrant(it) {
+  const hiI = it.impact > 3, hiE = it.effort > 3;
+  if (hiI && !hiE) return { key: "qw", label: "Quick win" };
+  if (hiI && hiE)  return { key: "bb", label: "Big bet" };
+  if (!hiI && !hiE) return { key: "fi", label: "Fill-in" };
+  return { key: "ts", label: "Time sink" };
+}
+// Chips are VIEW-AWARE: the matrix shows quadrant (position-consistent, no RICE),
+// the ranked list shows the full RICE breakdown (where reach/confidence are visible).
+function cardChips(it) {
+  if (state.view === "matrix") {
+    const q = quadrant(it);
+    return `<span class="chip q-${q.key}">${q.label}</span><span class="chip">I ${it.impact} · E ${it.effort}</span>`;
+  }
+  if (state.view === "list") {
+    return `<span class="chip rice">RICE ${rice(it)}</span><span class="chip">reach ${it.reach}</span>`
+         + `<span class="chip">impact ${it.impact}</span><span class="chip">conf ${Math.round(it.confidence * 100)}%</span><span class="chip">effort ${it.effort}</span>`;
+  }
+  return `<span class="chip">I ${it.impact} · E ${it.effort}</span>`;
+}
+function cardLabel(it) {
+  if (state.view === "matrix") return `${esc(it.title)}. ${quadrant(it).label}, impact ${it.impact}, effort ${it.effort}.`;
+  if (state.view === "list")   return `${esc(it.title)}. RICE ${rice(it)}.`;
+  return `${esc(it.title)}.`;
+}
 function cardHTML(it, extra = "") {
   return `<div class="card" data-id="${it.id}" tabindex="0" role="button"
             aria-roledescription="draggable card"
-            aria-label="${esc(it.title)}. RICE ${rice(it)}. ${kbdHint()}">
+            aria-label="${cardLabel(it)} ${kbdHint()}">
       <span class="grip" aria-hidden="true">⠿</span>
       ${extra}
       <div class="ct">${esc(it.title)}</div>
-      <div class="meta">
-        <span class="chip rice">RICE ${rice(it)}</span>
-        <span class="chip">reach ${it.reach}</span>
-        <span class="chip">impact ${it.impact}</span>
-        <span class="chip">effort ${it.effort}</span>
-      </div>
+      <div class="meta">${cardChips(it)}</div>
     </div>`;
 }
 function kbdHint() {
@@ -340,8 +365,9 @@ function renderList() {
 function renderMatrix() {
   const pct = v => 12 + ((v - 1) / 4) * 76;    // 1..5 → 12..88 (padded so cards never clip the edge)
   stage.innerHTML = `
-    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and RICE recomputes.
-       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.</p>
+    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and its quadrant updates.
+       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.
+       <span style="color:var(--pg-faint)">(full RICE score lives in the Ranked-list view)</span></p>
     <div class="matrix-wrap">
       <div class="axis-y" aria-hidden="true">Impact →</div>
       <div class="plane" id="plane">
@@ -454,7 +480,7 @@ function commitDrop(under, e) {
       const it = byId(drag.id);
       it.effort = clamp15(Math.round(fx * 4 + 1));
       it.impact = clamp15(Math.round(fy * 4 + 1));
-      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort} — ${quadrant(it).label}.`);
     }
   } else if (state.view === "list") {
     const list = document.getElementById("v-list");
@@ -491,7 +517,7 @@ stage.addEventListener("keydown", e => {
     const dir = state.rtl ? -1 : 1;
     if (e.key === "ArrowRight") it.effort = clamp15(it.effort + dir);
     if (e.key === "ArrowLeft")  it.effort = clamp15(it.effort - dir);
-    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort} — ${quadrant(it).label}.`);
   } else {
     const sch = BUCKET_SCHEMES[state.bucketScheme], order = sch.defs.map(d => d.key);
     const cur = order.indexOf(state.bucket[id]);
@@ -514,11 +540,11 @@ function refocus(id, msg) {
 function updatePrompt() {
   let txt = "";
   if (state.view === "matrix") {
-    const sorted = [...ITEMS].sort((a,b) => rice(b) - rice(a));
-    const top = sorted.slice(0,3).map(i => i.title);
-    const sink = sorted[sorted.length-1];
-    txt = `Prioritize the backlog by <b>RICE</b>. Top: <b>${esc(top.join(", "))}</b>. `
-        + `Deprioritize <span class="warm">${esc(sink.title)}</span> (RICE ${rice(sink)} — low impact for the effort).`;
+    const g = k => ITEMS.filter(i => quadrant(i).key === k).map(i => i.title);
+    const seg = (label, names) => `${label}: ${names.length ? esc(names.join(", ")) : "—"}`;
+    txt = `Prioritize by impact vs effort. `
+        + `<b>${seg("Do first (quick wins)", g("qw"))}</b>  ·  ${seg("Plan (big bets)", g("bb"))}  ·  `
+        + `${seg("Maybe (fill-ins)", g("fi"))}  ·  <span class="warm">${seg("Avoid (time sinks)", g("ts"))}</span>.`;
   } else if (state.view === "list") {
     const o = state.order.map((id,i) => `${i+1}. ${byId(id).title}`);
     txt = `Work the backlog in this <b>explicit order</b>: ${esc(o.join("  ·  "))}.`;

--- a/docs/feat--playground-visual-standard/decision-board.html
+++ b/docs/feat--playground-visual-standard/decision-board.html
@@ -1,0 +1,561 @@
+<!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  DECISION BOARD · drag-and-drop prioritization toolkit
+  OrchestKit playground exemplar — the "decision-board" archetype.
+
+  Conforms to: skills/shared/rules/playground-visual-standard.md
+  Persona: cool-glass ("technical precision", indigo). Zero dependencies. Single file.
+
+  WHAT THIS IS
+  ------------
+  The visual playgrounds OrchestKit generates should let you *make the
+  decision*, not just read a dashboard. This is the reusable template for
+  the decision-making parts: drag cards to prioritize and to manage. One
+  shared item set, four lenses:
+
+    1. Impact × Effort 2×2  — drop a card on the plane → sets its impact/effort
+    2. Ranked list          — drag to reorder 1..N (explicit priority override)
+    3. Buckets / columns    — drag between MoSCoW or Now / Next / Later
+    4. Live score + prompt   — RICE recomputes as you drag; copy the decision
+
+  ACCESSIBILITY (the part most drag-drop demos skip)
+  --------------------------------------------------
+  Native HTML5 drag-and-drop is mouse-only and inaccessible. This uses
+  vanilla Pointer Events (mouse + touch + pen) PLUS full keyboard control:
+  Tab to a card, arrow keys move it, every move is announced via aria-live.
+  Honors prefers-reduced-motion. RTL via CSS logical properties + a toggle.
+
+  TO REUSE: replace ITEMS below with your own; keep the engine.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Decision Board · Prioritization Playground</title>
+<style>
+  /* ── §2 Design tokens (HSL so shades are derivable) ─────────────────── */
+  :root {
+    --pg-bg:            hsl(232 26% 7%);
+    --pg-ink:           hsl(220 18% 93%);
+    --pg-muted:         hsl(220 12% 64%);
+    --pg-faint:         hsl(220 10% 46%);
+    --pg-line:          hsl(0 0% 100% / 0.10);
+    --pg-glass:         hsl(0 0% 100% / 0.05);
+    --pg-glass-2:       hsl(0 0% 100% / 0.08);
+    --pg-glass-edge:    hsl(0 0% 100% / 0.18);
+
+    --pg-accent:        hsl(248 84% 68%);   /* indigo — primary action / active */
+    --pg-accent-deep:   hsl(248 60% 52%);
+    --pg-warm:          hsl(38 95% 60%);    /* amber — secondary accent */
+    --pg-emerald:       hsl(160 68% 45%);   /* quick wins / success */
+    --pg-sky:           hsl(206 85% 62%);   /* fill-ins / could */
+    --pg-rose:          hsl(345 76% 63%);   /* time sinks / must */
+
+    /* two-part shadow (§5) — ambient + tight */
+    --pg-shadow: 0 20px 60px -22px hsl(232 40% 2% / 0.7), 0 4px 12px -6px hsl(232 40% 2% / 0.5);
+
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+
+    /* §6 motion budget — four tiers, nothing else animates */
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 88% -8%, hsl(248 84% 68% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 4% 110%, hsl(38 95% 60% / 0.12), transparent 58%),
+      radial-gradient(700px 520px at 50% 50%, hsl(160 68% 45% / 0.05), transparent 70%),
+      var(--pg-bg);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased; min-height: 100vh;
+  }
+
+  .wrap { max-width: 1120px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+
+  /* ── header / explainer ─────────────────────────────────────────────── */
+  .head { display: flex; align-items: flex-start; gap: 14px; flex-wrap: wrap; }
+  .logo {
+    width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 22px -8px hsl(248 84% 60% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4);
+  }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; display: flex; gap: 8px; align-items: center; }
+
+  .toggle {
+    cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px;
+    transition: color var(--pg-dur-fast), border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); background: var(--pg-glass-2); border-color: var(--pg-glass-edge); }
+
+  /* ── glass panel ────────────────────────────────────────────────────── */
+  .panel {
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow);
+  }
+
+  /* ── §7 segmented view switch ───────────────────────────────────────── */
+  .views { display: flex; gap: 4px; padding: 5px; background: hsl(0 0% 0% / 0.28); border: 1px solid var(--pg-line); border-radius: 13px; flex-wrap: wrap; }
+  .views button {
+    flex: 1 1 auto; min-width: 140px; border: 0; background: transparent; color: var(--pg-muted); cursor: pointer;
+    font: inherit; font-size: 13px; font-weight: 600; padding: 10px 12px; border-radius: 9px; letter-spacing: -.1px;
+    transition: color var(--pg-dur-fast), background var(--pg-dur-fast); display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  }
+  .views button:hover { color: var(--pg-ink); }
+  .views button[aria-pressed="true"] {
+    color: var(--pg-ink); background: linear-gradient(180deg, var(--pg-glass-2), hsl(0 0% 100% / 0.03));
+    box-shadow: 0 2px 10px -4px hsl(232 40% 2% / 0.6), inset 0 1px 0 hsl(0 0% 100% / 0.12);
+  }
+
+  .stage { padding: 20px; min-height: 440px; position: relative; }
+  .scheme-note { font-size: 12px; color: var(--pg-faint); margin: 0 0 14px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .scheme-note b { color: var(--pg-muted); font-weight: 650; }
+  .kbd { font-family: var(--pg-mono); font-size: 10.5px; color: var(--pg-muted); background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); border-radius: 6px; padding: 1px 6px; }
+
+  /* ── card (shared across views) ─────────────────────────────────────── */
+  .card {
+    background: hsl(0 0% 100% / 0.045); border: 1px solid var(--pg-line); border-radius: var(--pg-r-md);
+    padding: 11px 12px; cursor: grab; user-select: none; touch-action: none; position: relative;
+    transition: transform var(--pg-dur-fast) var(--pg-ease), border-color var(--pg-dur-fast), box-shadow var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .card:hover { border-color: var(--pg-glass-edge); background: hsl(0 0% 100% / 0.07); }
+  .card:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .card .ct { font-size: 13.5px; font-weight: 600; letter-spacing: -.1px; line-height: 1.3; }
+  .card .meta { margin-top: 7px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
+  .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); }
+  .chip.rice { background: hsl(248 84% 68% / 0.16); color: hsl(248 84% 82%); font-family: var(--pg-mono); }
+  .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
+
+  /* dragging states */
+  .card.source { opacity: .35; }
+  .ghost {
+    position: fixed; z-index: 999; pointer-events: none; width: var(--ghost-w, 220px);
+    transform: rotate(1.5deg) scale(1.03); box-shadow: 0 26px 60px -18px hsl(232 60% 2% / 0.8); cursor: grabbing;
+  }
+  .card.lifted { border-color: var(--pg-accent); box-shadow: 0 0 0 2px hsl(248 84% 68% / 0.4); }
+
+  /* ── view: ranked list ──────────────────────────────────────────────── */
+  #v-list { display: flex; flex-direction: column; gap: 9px; max-width: 660px; margin: 0 auto; }
+  #v-list .card { display: grid; grid-template-columns: 30px 1fr auto; align-items: center; gap: 12px; padding-inline-end: 26px; }
+  #v-list .rank { font-family: var(--pg-mono); font-size: 17px; font-weight: 800; color: var(--pg-accent); width: 30px; text-align: center; }
+  .drop-line { height: 2px; background: var(--pg-accent); border-radius: 2px; margin: -5px 0; box-shadow: 0 0 8px hsl(248 84% 68% / 0.7); }
+
+  /* ── view: impact × effort matrix ───────────────────────────────────── */
+  .matrix-wrap { display: grid; grid-template-columns: 26px 1fr; grid-template-rows: 1fr 26px; gap: 8px; height: 460px; }
+  .axis-y { writing-mode: vertical-rl; transform: rotate(180deg); text-align: center; font-size: 11px; letter-spacing: 1px; color: var(--pg-faint); text-transform: uppercase; }
+  .axis-x { grid-column: 2; text-align: center; font-size: 11px; letter-spacing: 1px; color: var(--pg-faint); text-transform: uppercase; }
+  .plane {
+    position: relative; border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); overflow: hidden;
+    background:
+      linear-gradient(hsl(0 0% 100% / 0.05), hsl(0 0% 100% / 0.05)) 0 0 / 100% 1px no-repeat,
+      linear-gradient(hsl(0 0% 100% / 0.05), hsl(0 0% 100% / 0.05)) 50% 0 / 1px 100% no-repeat,
+      hsl(0 0% 100% / 0.015);
+  }
+  .quad { position: absolute; width: 50%; height: 50%; padding: 10px 12px; font-size: 11px; font-weight: 700; letter-spacing: .3px; text-transform: uppercase; pointer-events: none; }
+  .quad.q-qw { inset-block-start: 0; inset-inline-start: 0;  color: hsl(160 68% 62%); background: radial-gradient(120% 120% at 0 0, hsl(160 68% 45% / 0.14), transparent 70%); }
+  .quad.q-bb { inset-block-start: 0; inset-inline-end: 0;  color: hsl(248 84% 80%); background: radial-gradient(120% 120% at 100% 0, hsl(248 84% 68% / 0.14), transparent 70%); text-align: end; }
+  .quad.q-fi { inset-block-end: 0; inset-inline-start: 0;  color: hsl(206 85% 74%); background: radial-gradient(120% 120% at 0 100%, hsl(206 85% 62% / 0.12), transparent 70%); }
+  .quad.q-ts { inset-block-end: 0; inset-inline-end: 0;  color: hsl(345 76% 76%); background: radial-gradient(120% 120% at 100% 100%, hsl(345 76% 63% / 0.13), transparent 70%); text-align: end; }
+  .plane .card { position: absolute; width: 150px; transform: translate(-50%, -50%); cursor: grab; }
+  .plane.hot { box-shadow: inset 0 0 0 2px hsl(248 84% 68% / 0.45); }
+
+  /* ── view: buckets ──────────────────────────────────────────────────── */
+  .buckets { display: grid; grid-template-columns: repeat(var(--cols, 4), 1fr); gap: 14px; }
+  .bucket { display: flex; flex-direction: column; min-height: 320px; }
+  .bucket-h { display: flex; align-items: center; gap: 8px; margin-bottom: 11px; font-size: 13px; font-weight: 700; }
+  .bucket-h .dot { width: 9px; height: 9px; border-radius: 999px; flex: none; }
+  .bucket-h .n { margin-inline-start: auto; font-size: 11px; color: var(--pg-faint); background: hsl(0 0% 0% / 0.25); border-radius: 999px; padding: 1px 8px; font-family: var(--pg-mono); }
+  .drop {
+    flex: 1; display: flex; flex-direction: column; gap: 9px; padding: 10px; border-radius: var(--pg-r-md);
+    background: hsl(0 0% 100% / 0.02); border: 1px dashed var(--pg-line);
+    transition: border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .drop.hot { border-color: var(--pg-accent); border-style: solid; background: hsl(248 84% 68% / 0.07); }
+  .drop:empty::after { content: "drop here"; color: var(--pg-faint); font-size: 11px; margin: auto; opacity: .6; }
+
+  /* ── §7 score + copy-prompt bar ─────────────────────────────────────── */
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(220 16% 80%); max-height: 92px; overflow-y: auto; }
+  .promptbar .pt b { color: var(--pg-accent); font-weight: 600; }
+  .promptbar .pt .warm { color: var(--pg-warm); }
+  .copy {
+    flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(248 30% 12%);
+    border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 10px 26px -12px hsl(248 84% 60% / 0.8); transition: transform var(--pg-dur-instant);
+  }
+  .copy:hover { transform: translateY(-1px); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+
+  /* ── §6 reduced motion ──────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    .ghost { transform: none; }
+  }
+  @media (max-width: 720px) {
+    .buckets { grid-template-columns: repeat(2, 1fr); }
+    .matrix-wrap { height: 520px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="head">
+    <div class="logo">🎚️</div>
+    <div>
+      <h1>Decision Board</h1>
+      <p>The decision-making parts of a playground should let you <b>act on the decision</b>, not just read it.
+         Drag a card to set its impact &amp; effort, reorder the backlog, or sort it into buckets — the
+         <b>RICE score</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
+         (<span class="kbd">Tab</span> a card, then <span class="kbd">← ↑ ↓ →</span>).</p>
+    </div>
+    <div class="right">
+      <button class="toggle" id="dirToggle" aria-pressed="false" title="Toggle text direction">⇄ RTL</button>
+    </div>
+  </header>
+
+  <div class="panel" style="padding:6px">
+    <div class="views" id="views" role="tablist" aria-label="Decision view">
+      <button data-view="matrix" aria-pressed="true">📊 Impact × Effort</button>
+      <button data-view="list"   aria-pressed="false">🔢 Ranked list</button>
+      <button data-view="buckets" aria-pressed="false">🗂️ Buckets</button>
+    </div>
+  </div>
+
+  <main class="panel stage" id="stage" aria-live="off"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">📋 Copy decision</button>
+  </div>
+
+  <div class="sr-only" id="live" role="status" aria-live="polite"></div>
+</div>
+
+<script>
+/* ═══════════════════════════════════════════════════════════════════════
+   DATA MODEL — one shared item set. Each view is a lens that edits or
+   orders these fields. RICE = round(reach × impact × confidence / effort).
+   Swap ITEMS for your own to reuse the template.
+   ═══════════════════════════════════════════════════════════════════════ */
+const ITEMS = [
+  { id:"a", title:"One-click onboarding wizard",      reach:900, impact:3,   confidence:0.8,  effort:3 },
+  { id:"b", title:"Dark mode",                          reach:1200,impact:1,   confidence:0.95, effort:1 },
+  { id:"c", title:"SSO / SAML for enterprise",          reach:140, impact:3,   confidence:0.7,  effort:5 },
+  { id:"d", title:"Inline AI code review",              reach:600, impact:3,   confidence:0.6,  effort:4 },
+  { id:"e", title:"Mobile app",                         reach:2000,impact:2,   confidence:0.4,  effort:5 },
+  { id:"f", title:"Keyboard shortcuts",                 reach:500, impact:1,   confidence:0.9,  effort:1 },
+  { id:"g", title:"Usage analytics dashboard",          reach:350, impact:2,   confidence:0.8,  effort:3 },
+  { id:"h", title:"Slack notifications",                reach:700, impact:1,   confidence:0.85, effort:2 },
+];
+
+const BUCKET_SCHEMES = {
+  moscow: { cols: 4, defs: [
+    { key:"must",   label:"Must",   dot:"var(--pg-rose)" },
+    { key:"should", label:"Should", dot:"var(--pg-warm)" },
+    { key:"could",  label:"Could",  dot:"var(--pg-sky)" },
+    { key:"wont",   label:"Won't",  dot:"var(--pg-faint)" },
+  ]},
+  nnl: { cols: 3, defs: [
+    { key:"now",   label:"Now",   dot:"var(--pg-emerald)" },
+    { key:"next",  label:"Next",  dot:"var(--pg-warm)" },
+    { key:"later", label:"Later", dot:"var(--pg-faint)" },
+  ]},
+};
+
+/* per-item view state, derived/seeded from the model */
+const state = {
+  view: "matrix",
+  rtl: false,
+  bucketScheme: "moscow",
+  // matrix position: impact & effort already on items (1..5)
+  order: ITEMS.map(i => i.id),           // ranked-list order
+  bucket: {},                            // id -> bucket key
+};
+ITEMS.forEach((it, idx) => {
+  state.bucket[it.id] = ["must","must","should","could","should","could","should","could"][idx] || "could";
+});
+
+const byId = id => ITEMS.find(i => i.id === id);
+const rice = it => Math.round((it.reach * it.impact * it.confidence) / it.effort);
+const esc = s => String(s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+const stage = document.getElementById("stage");
+const live  = document.getElementById("live");
+const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
+
+/* ── card markup ─────────────────────────────────────────────────────── */
+function cardHTML(it, extra = "") {
+  return `<div class="card" data-id="${it.id}" tabindex="0" role="button"
+            aria-roledescription="draggable card"
+            aria-label="${esc(it.title)}. RICE ${rice(it)}. ${kbdHint()}">
+      <span class="grip" aria-hidden="true">⠿</span>
+      ${extra}
+      <div class="ct">${esc(it.title)}</div>
+      <div class="meta">
+        <span class="chip rice">RICE ${rice(it)}</span>
+        <span class="chip">reach ${it.reach}</span>
+        <span class="chip">impact ${it.impact}</span>
+        <span class="chip">effort ${it.effort}</span>
+      </div>
+    </div>`;
+}
+function kbdHint() {
+  if (state.view === "list")   return "Use arrow up and down to reorder.";
+  if (state.view === "matrix") return "Arrows change impact and effort.";
+  return "Arrow left and right move between buckets.";
+}
+
+/* ═══════════════════════════ RENDERERS ════════════════════════════════ */
+function render() {
+  if (state.view === "matrix") renderMatrix();
+  else if (state.view === "list") renderList();
+  else renderBuckets();
+  updatePrompt();
+}
+
+function renderList() {
+  const items = state.order.map(byId);
+  stage.innerHTML = `
+    <p class="scheme-note">Drag to reorder — this is your <b>explicit priority</b>, overriding the computed score.
+       <span class="kbd">↑</span><span class="kbd">↓</span> move the focused card.</p>
+    <div id="v-list">
+      ${items.map((it, i) => cardHTML(it, `<span class="rank" aria-hidden="true">${i+1}</span>`)).join("")}
+    </div>`;
+}
+
+function renderMatrix() {
+  const pct = v => 12 + ((v - 1) / 4) * 76;    // 1..5 → 12..88 (padded so cards never clip the edge)
+  stage.innerHTML = `
+    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and RICE recomputes.
+       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.</p>
+    <div class="matrix-wrap">
+      <div class="axis-y" aria-hidden="true">Impact →</div>
+      <div class="plane" id="plane">
+        <div class="quad q-qw">Quick wins</div>
+        <div class="quad q-bb">Big bets</div>
+        <div class="quad q-fi">Fill-ins</div>
+        <div class="quad q-ts">Time sinks</div>
+        ${ITEMS.map(it => `${cardWrapMatrix(it, pct)}`).join("")}
+      </div>
+      <div class="axis-x" aria-hidden="true">Effort →</div>
+    </div>`;
+}
+function cardWrapMatrix(it, pct) {
+  // inset-inline-start auto-mirrors in RTL; center-anchored (translate -50%,-50%)
+  // high impact → near top, so top% = 100 - impact%
+  const x = pct(it.effort), y = pct(it.impact);
+  const el = cardHTML(it);
+  return el.replace('class="card"', `class="card" style="inset-inline-start:${x}%; inset-block-start:${100 - y}%;"`);
+}
+
+function renderBuckets() {
+  const sch = BUCKET_SCHEMES[state.bucketScheme];
+  stage.style.setProperty("--cols", sch.cols);
+  const other = state.bucketScheme === "moscow" ? "nnl" : "moscow";
+  stage.innerHTML = `
+    <p class="scheme-note">Drag cards between buckets to manage scope.
+       <button class="toggle" id="schemeToggle" aria-pressed="false">↔ ${other === "moscow" ? "MoSCoW" : "Now / Next / Later"}</button>
+       <span class="kbd">←</span><span class="kbd">→</span> move the focused card.</p>
+    <div class="buckets">
+      ${sch.defs.map(b => `
+        <div class="bucket">
+          <div class="bucket-h"><span class="dot" style="background:${b.dot}"></span>${b.label}
+            <span class="n">${ITEMS.filter(i => state.bucket[i.id] === b.key).length}</span></div>
+          <div class="drop" data-bucket="${b.key}">
+            ${ITEMS.filter(i => state.bucket[i.id] === b.key).map(i => cardHTML(i)).join("")}
+          </div>
+        </div>`).join("")}
+    </div>`;
+  const st = document.getElementById("schemeToggle");
+  if (st) st.addEventListener("click", () => { state.bucketScheme = other; render(); });
+}
+
+/* ═══════════════════════ POINTER DRAG ENGINE ══════════════════════════ */
+let drag = null;
+stage.addEventListener("pointerdown", e => {
+  const card = e.target.closest(".card");
+  if (!card || e.button !== 0) return;
+  e.preventDefault();
+  const rect = card.getBoundingClientRect();
+  const ghost = card.cloneNode(true);
+  ghost.classList.add("ghost"); ghost.classList.remove("source");
+  ghost.style.setProperty("--ghost-w", rect.width + "px");
+  ghost.style.left = rect.left + "px"; ghost.style.top = rect.top + "px";
+  document.body.appendChild(ghost);
+  card.classList.add("source");
+  drag = { id: card.dataset.id, ghost, card, dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp, { once: true });
+});
+function onMove(e) {
+  if (!drag) return;
+  drag.ghost.style.left = (e.clientX - drag.dx) + "px";
+  drag.ghost.style.top  = (e.clientY - drag.dy) + "px";
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  drag.ghost.style.display = "";
+  hover(under, e);
+}
+function onUp(e) {
+  if (!drag) return;
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  commitDrop(under, e);
+  drag.ghost.remove();
+  document.querySelectorAll(".hot").forEach(x => x.classList.remove("hot"));
+  document.querySelectorAll(".drop-line").forEach(x => x.remove());
+  drag = null;
+  window.removeEventListener("pointermove", onMove);
+}
+
+function hover(under, e) {
+  document.querySelectorAll(".drop-line").forEach(x => x.remove());
+  if (state.view === "buckets") {
+    document.querySelectorAll(".drop").forEach(d => d.classList.remove("hot"));
+    const drop = under && under.closest(".drop"); if (drop) drop.classList.add("hot");
+  } else if (state.view === "matrix") {
+    const plane = document.getElementById("plane"); if (plane) plane.classList.toggle("hot", !!(under && under.closest(".plane")));
+  } else if (state.view === "list") {
+    const list = document.getElementById("v-list");
+    const over = under && under.closest(".card");
+    if (over && over !== drag.card) {
+      const r = over.getBoundingClientRect();
+      const after = e.clientY > r.top + r.height / 2;
+      const line = document.createElement("div"); line.className = "drop-line";
+      list.insertBefore(line, after ? over.nextSibling : over);
+    }
+  }
+}
+function commitDrop(under, e) {
+  if (state.view === "buckets") {
+    const drop = under && under.closest(".drop");
+    if (drop) { state.bucket[drag.id] = drop.dataset.bucket; render();
+      announce(`${byId(drag.id).title} moved to ${drop.dataset.bucket}.`); }
+  } else if (state.view === "matrix") {
+    const plane = document.getElementById("plane");
+    if (plane && under && under.closest(".plane")) {
+      const r = plane.getBoundingClientRect();
+      let fx = (e.clientX - r.left) / r.width; if (state.rtl) fx = 1 - fx;
+      const fy = 1 - (e.clientY - r.top) / r.height;          // bottom = low impact
+      const it = byId(drag.id);
+      it.effort = clamp15(Math.round(fx * 4 + 1));
+      it.impact = clamp15(Math.round(fy * 4 + 1));
+      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+    }
+  } else if (state.view === "list") {
+    const list = document.getElementById("v-list");
+    const cards = [...list.querySelectorAll(".card")];
+    const over = under && under.closest(".card");
+    let to = over ? cards.indexOf(over) : cards.length - 1;
+    const from = state.order.indexOf(drag.id);
+    if (over) { const r = over.getBoundingClientRect(); if (e.clientY > r.top + r.height/2) to++; }
+    if (to > from) to--;
+    state.order.splice(from, 1);
+    state.order.splice(Math.max(0, Math.min(to, state.order.length)), 0, drag.id);
+    render(); announce(`${byId(drag.id).title} moved to position ${state.order.indexOf(drag.id)+1}.`);
+  }
+}
+const clamp15 = v => Math.max(1, Math.min(5, v));
+
+/* ═══════════════════════ KEYBOARD ENGINE ══════════════════════════════ */
+stage.addEventListener("keydown", e => {
+  const card = e.target.closest(".card"); if (!card) return;
+  const id = card.dataset.id, it = byId(id);
+  const keys = ["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"];
+  if (!keys.includes(e.key)) return;
+  e.preventDefault();
+  if (state.view === "list") {
+    const i = state.order.indexOf(id);
+    const j = e.key === "ArrowUp" ? i - 1 : e.key === "ArrowDown" ? i + 1 : i;
+    if (j !== i && j >= 0 && j < state.order.length) {
+      state.order.splice(i, 1); state.order.splice(j, 0, id);
+      refocus(id, `${it.title} now position ${j+1}.`);
+    }
+  } else if (state.view === "matrix") {
+    if (e.key === "ArrowUp")    it.impact = clamp15(it.impact + 1);
+    if (e.key === "ArrowDown")  it.impact = clamp15(it.impact - 1);
+    const dir = state.rtl ? -1 : 1;
+    if (e.key === "ArrowRight") it.effort = clamp15(it.effort + dir);
+    if (e.key === "ArrowLeft")  it.effort = clamp15(it.effort - dir);
+    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+  } else {
+    const sch = BUCKET_SCHEMES[state.bucketScheme], order = sch.defs.map(d => d.key);
+    const cur = order.indexOf(state.bucket[id]);
+    const step = (e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0) * (state.rtl ? -1 : 1);
+    const nx = cur + step;
+    if (step && nx >= 0 && nx < order.length) {
+      state.bucket[id] = order[nx];
+      refocus(id, `${it.title} moved to ${sch.defs[nx].label}.`);
+    }
+  }
+});
+function refocus(id, msg) {
+  render();
+  const el = stage.querySelector(`.card[data-id="${id}"]`);
+  if (el) el.focus();
+  announce(msg);
+}
+
+/* ═══════════════════════ COPY-PROMPT BAR ══════════════════════════════ */
+function updatePrompt() {
+  let txt = "";
+  if (state.view === "matrix") {
+    const sorted = [...ITEMS].sort((a,b) => rice(b) - rice(a));
+    const top = sorted.slice(0,3).map(i => i.title);
+    const sink = sorted[sorted.length-1];
+    txt = `Prioritize the backlog by <b>RICE</b>. Top: <b>${esc(top.join(", "))}</b>. `
+        + `Deprioritize <span class="warm">${esc(sink.title)}</span> (RICE ${rice(sink)} — low impact for the effort).`;
+  } else if (state.view === "list") {
+    const o = state.order.map((id,i) => `${i+1}. ${byId(id).title}`);
+    txt = `Work the backlog in this <b>explicit order</b>: ${esc(o.join("  ·  "))}.`;
+  } else {
+    const sch = BUCKET_SCHEMES[state.bucketScheme];
+    txt = sch.defs.map(b => {
+      const names = ITEMS.filter(i => state.bucket[i.id] === b.key).map(i => i.title);
+      return `<b>${b.label}:</b> ${names.length ? esc(names.join(", ")) : "—"}`;
+    }).join("  ·  ");
+    txt = `Scope decision (${state.bucketScheme === "moscow" ? "MoSCoW" : "Now/Next/Later"}). ${txt}.`;
+  }
+  document.getElementById("promptOut").innerHTML = txt;
+}
+document.getElementById("copyBtn").addEventListener("click", () => {
+  const txt = document.getElementById("promptOut").textContent;
+  navigator.clipboard.writeText(txt).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "✓ Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 Copy decision"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+/* ═══════════════════════ CHROME / EVENTS ══════════════════════════════ */
+document.getElementById("views").addEventListener("click", e => {
+  const b = e.target.closest("[data-view]"); if (!b) return;
+  state.view = b.dataset.view;
+  document.querySelectorAll("#views button").forEach(x => x.setAttribute("aria-pressed", x.dataset.view === state.view));
+  render();
+});
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl;
+  document.documentElement.dir = state.rtl ? "rtl" : "ltr";
+  e.currentTarget.setAttribute("aria-pressed", state.rtl);
+  render();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/create-pr.mdx
+++ b/docs/site/content/docs/reference/skills/create-pr.mdx
@@ -246,16 +246,29 @@ Generate an interactive HTML playground visualizing the PR's changes. CI validat
 
 > **Requires** the `playground` plugin (external): `/plugin marketplace add anthropics/claude-plugins-official && /plugin install playground`
 
+**First classify the archetype** — a feature PR must not ship as a flat dashboard.
+`Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/playground-visual-standard.md")` and apply its §0 routing rule:
+
+- **Visual PR** (adds/changes a user-facing feature, flow, or a prioritization/decision surface) →
+  **USER-STORY PLAYER** or **DECISION BOARD**. Build to the standard: adapt the matching exemplar at
+  `$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/assets/playground-exemplars/` (`user-story-player.template.html`
+  or `decision-board.template.html`), and bring full design firepower (the `frontend-design` skill /
+  the `ork:frontend-ui-developer` agent). When delegating to `playground:playground`, brief it with the
+  **archetype + persona + tokens** — never hand it a pre-built HTML blob.
+- **Non-visual PR** (infra/CI/refactor/config/docs) → **DASHBOARD** — the default summary below is fine.
+
 ```python
 BRANCH=$(git branch --show-current)
 BRANCH_DIR = BRANCH.replace("/", "--")  # feat/foo → feat--foo
 
-# Invoke the playground skill with a summary of the PR changes
+# Invoke the playground skill with a summary of the PR changes.
+# For a VISUAL PR, set archetype/persona/exemplar per playground-visual-standard.md instead of this default.
 Skill("playground:playground", args=f"""
   {PR_TITLE} — visualize the key changes in this PR.
-  Show: architecture/data flow, before/after, key components changed.
-  Include presets for the main change areas.
-  Dark theme with purple/violet OrchestKit brand colors.
+  Archetype: <user-story-player | decision-board | dashboard> per playground-visual-standard.md §0.
+  For visual archetypes: follow that standard's tokens/glass/motion and adapt the matching exemplar.
+  Show: architecture/data flow, before/after, key components changed; presets for the main change areas.
+  Dark glass theme, OrchestKit brand accents.
 """)
 
 # The playground skill writes to a temp path — move it to the correct location

--- a/docs/site/content/docs/reference/skills/visualize-plan.mdx
+++ b/docs/site/content/docs/reference/skills/visualize-plan.mdx
@@ -221,11 +221,17 @@ Render the selected sections into the `FORMATS` chosen in STEP 0.5. **ASCII alwa
 | Format | Action |
 |--------|--------|
 | ASCII | Native render (above) — always, the floor |
-| Playground | Hand the plan brief to the `playground` skill → write `docs/&lt;branch-dir&gt;/plan-viz.html`, link it |
+| Playground | Classify the archetype (below), then hand the plan brief to the `playground` skill → write `docs/&lt;branch-dir&gt;/plan-viz.html`, link it |
 | Infographic | Run the `notebooklm` `studio_create(artifact_type=infographic\|slides)` flow — **fire-and-notify**, poll `studio_status`, never await |
 | All | ASCII inline now + the rest linked as they finish |
 
 `&lt;branch-dir&gt;` = branch with `/` → `--` (same path the PR Playground gate checks).
+
+> **Playground archetype:** a plan visualization is usually a **DASHBOARD** (current behavior — fine).
+> But if the plan demonstrates a *user-facing flow* or a *prioritization/decision*, route to the
+> **user-story-player** or **decision-board** archetype instead of a flat card grid. Apply the §0 routing
+> rule in `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/playground-visual-standard.md")` and adapt the
+> matching exemplar under `skills/shared/assets/playground-exemplars/`.
 
 ---
 
@@ -1022,11 +1028,17 @@ Hide unavailable options from the AskUserQuestion list and add a one-line instal
 | Format | How | Output | Blocks? |
 |--------|-----|--------|---------|
 | ASCII + emojis | Native — render sections per `rules/section-rendering.md` | In chat | n/a (always first) |
-| Interactive playground | Build the plan brief, hand to the `playground` skill | `docs/&lt;branch-dir&gt;/plan-viz.html` | No — write then link |
+| Interactive playground | Classify archetype (§0 of the visual standard), build the plan brief, hand to the `playground` skill | `docs/&lt;branch-dir&gt;/plan-viz.html` | No — write then link |
 | NotebookLM infographic/slides | Build a source doc, run the notebooklm `studio_create(artifact_type=infographic\|slides)` flow | `.png`/slides artifact | **No — fire-and-notify** |
 | All available | Fan out: ASCII inline now + the others as they finish | all of the above | No |
 
 `&lt;branch-dir&gt;` = current branch with `/` → `--` (matches the PR Playground CI gate path, so the playground also satisfies that gate for free).
+
+> **Archetype before generation.** Most plan visualizations are a **DASHBOARD** (the default card grid).
+> But a plan that demonstrates a *user-facing flow* or a *prioritization/decision* should be a
+> **user-story-player** or **decision-board** — `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/shared/rules/playground-visual-standard.md")`
+> for the §0 routing rule, the token/glass/motion spec, and the exemplars to adapt
+> (`skills/shared/assets/playground-exemplars/`). Brief the `playground` skill with archetype + persona, not raw HTML.
 
 ## The plan brief (shared interchange, v1)
 

--- a/plugins/ork/commands/create-pr.md
+++ b/plugins/ork/commands/create-pr.md
@@ -234,16 +234,29 @@ Generate an interactive HTML playground visualizing the PR's changes. CI validat
 
 > **Requires** the `playground` plugin (external): `/plugin marketplace add anthropics/claude-plugins-official && /plugin install playground`
 
+**First classify the archetype** — a feature PR must not ship as a flat dashboard.
+`Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")` and apply its §0 routing rule:
+
+- **Visual PR** (adds/changes a user-facing feature, flow, or a prioritization/decision surface) →
+  **USER-STORY PLAYER** or **DECISION BOARD**. Build to the standard: adapt the matching exemplar at
+  `${CLAUDE_PLUGIN_ROOT}/skills/shared/assets/playground-exemplars/` (`user-story-player.template.html`
+  or `decision-board.template.html`), and bring full design firepower (the `frontend-design` skill /
+  the `ork:frontend-ui-developer` agent). When delegating to `playground:playground`, brief it with the
+  **archetype + persona + tokens** — never hand it a pre-built HTML blob.
+- **Non-visual PR** (infra/CI/refactor/config/docs) → **DASHBOARD** — the default summary below is fine.
+
 ```python
 BRANCH=$(git branch --show-current)
 BRANCH_DIR = BRANCH.replace("/", "--")  # feat/foo → feat--foo
 
-# Invoke the playground skill with a summary of the PR changes
+# Invoke the playground skill with a summary of the PR changes.
+# For a VISUAL PR, set archetype/persona/exemplar per playground-visual-standard.md instead of this default.
 Skill("playground:playground", args=f"""
   {PR_TITLE} — visualize the key changes in this PR.
-  Show: architecture/data flow, before/after, key components changed.
-  Include presets for the main change areas.
-  Dark theme with purple/violet OrchestKit brand colors.
+  Archetype: <user-story-player | decision-board | dashboard> per playground-visual-standard.md §0.
+  For visual archetypes: follow that standard's tokens/glass/motion and adapt the matching exemplar.
+  Show: architecture/data flow, before/after, key components changed; presets for the main change areas.
+  Dark glass theme, OrchestKit brand accents.
 """)
 
 # The playground skill writes to a temp path — move it to the correct location

--- a/plugins/ork/commands/visualize-plan.md
+++ b/plugins/ork/commands/visualize-plan.md
@@ -207,11 +207,17 @@ Render the selected sections into the `FORMATS` chosen in STEP 0.5. **ASCII alwa
 | Format | Action |
 |--------|--------|
 | ASCII | Native render (above) — always, the floor |
-| Playground | Hand the plan brief to the `playground` skill → write `docs/<branch-dir>/plan-viz.html`, link it |
+| Playground | Classify the archetype (below), then hand the plan brief to the `playground` skill → write `docs/<branch-dir>/plan-viz.html`, link it |
 | Infographic | Run the `notebooklm` `studio_create(artifact_type=infographic\|slides)` flow — **fire-and-notify**, poll `studio_status`, never await |
 | All | ASCII inline now + the rest linked as they finish |
 
 `<branch-dir>` = branch with `/` → `--` (same path the PR Playground gate checks).
+
+> **Playground archetype:** a plan visualization is usually a **DASHBOARD** (current behavior — fine).
+> But if the plan demonstrates a *user-facing flow* or a *prioritization/decision*, route to the
+> **user-story-player** or **decision-board** archetype instead of a flat card grid. Apply the §0 routing
+> rule in `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")` and adapt the
+> matching exemplar under `skills/shared/assets/playground-exemplars/`.
 
 
 ## STEP 5: Offer Actions

--- a/plugins/ork/skills/create-pr/SKILL.md
+++ b/plugins/ork/skills/create-pr/SKILL.md
@@ -258,16 +258,29 @@ Generate an interactive HTML playground visualizing the PR's changes. CI validat
 
 > **Requires** the `playground` plugin (external): `/plugin marketplace add anthropics/claude-plugins-official && /plugin install playground`
 
+**First classify the archetype** — a feature PR must not ship as a flat dashboard.
+`Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")` and apply its §0 routing rule:
+
+- **Visual PR** (adds/changes a user-facing feature, flow, or a prioritization/decision surface) →
+  **USER-STORY PLAYER** or **DECISION BOARD**. Build to the standard: adapt the matching exemplar at
+  `${CLAUDE_PLUGIN_ROOT}/skills/shared/assets/playground-exemplars/` (`user-story-player.template.html`
+  or `decision-board.template.html`), and bring full design firepower (the `frontend-design` skill /
+  the `ork:frontend-ui-developer` agent). When delegating to `playground:playground`, brief it with the
+  **archetype + persona + tokens** — never hand it a pre-built HTML blob.
+- **Non-visual PR** (infra/CI/refactor/config/docs) → **DASHBOARD** — the default summary below is fine.
+
 ```python
 BRANCH=$(git branch --show-current)
 BRANCH_DIR = BRANCH.replace("/", "--")  # feat/foo → feat--foo
 
-# Invoke the playground skill with a summary of the PR changes
+# Invoke the playground skill with a summary of the PR changes.
+# For a VISUAL PR, set archetype/persona/exemplar per playground-visual-standard.md instead of this default.
 Skill("playground:playground", args=f"""
   {PR_TITLE} — visualize the key changes in this PR.
-  Show: architecture/data flow, before/after, key components changed.
-  Include presets for the main change areas.
-  Dark theme with purple/violet OrchestKit brand colors.
+  Archetype: <user-story-player | decision-board | dashboard> per playground-visual-standard.md §0.
+  For visual archetypes: follow that standard's tokens/glass/motion and adapt the matching exemplar.
+  Show: architecture/data flow, before/after, key components changed; presets for the main change areas.
+  Dark glass theme, OrchestKit brand accents.
 """)
 
 # The playground skill writes to a temp path — move it to the correct location

--- a/plugins/ork/skills/shared/assets/playground-exemplars/README.md
+++ b/plugins/ork/skills/shared/assets/playground-exemplars/README.md
@@ -1,0 +1,35 @@
+# Playground exemplars
+
+Gold-standard, single-file HTML playgrounds for the **visual** playground archetypes. They are the
+copyable starting points enforced by
+[`../../rules/playground-visual-standard.md`](../../rules/playground-visual-standard.md).
+
+> **Edit discipline (colocation):** if you change a token, component, or rule in the standard, update
+> the matching exemplar in the **same PR** — and vice versa. They are one unit of change.
+
+| File | Archetype | Persona | Use it when… |
+|---|---|---|---|
+| `homeos-arieh.html` | User-story player | warm-glass | …you want to see the bar. Designed by **Arieh**; committed verbatim — study, don't edit. |
+| `user-story-player.template.html` | User-story player | warm-glass | …the playground demonstrates a **feature or flow** (message→card, action→result). Swap `STORY`. |
+| `decision-board.template.html` | Decision board | cool-glass | …the playground is for **prioritization / management** via drag-and-drop. Swap `ITEMS`. |
+
+## What makes these different from a dashboard
+
+A dashboard *shows* state; these let the viewer **operate** something:
+
+- **Player** — a device mockup + a transport (▶ play / ‹ prev / next ›) + a cause→effect flow arrow.
+- **Decision board** — drag-and-drop across an Impact×Effort matrix, a ranked list, or buckets, with
+  a live RICE/WSJF score and a 1-click copy-prompt.
+
+Both are zero-dependency, single-file, dark warm/cool **glass** aesthetic, RTL-ready via CSS logical
+properties, accessible (the decision board has full keyboard control + `aria-live` announcements),
+and honor `prefers-reduced-motion`.
+
+## Reuse
+
+1. Copy the template matching your archetype.
+2. Replace the data block (`STORY` / `ITEMS`) — keep the engine.
+3. Run the §10 self-audit checklist in the standard before shipping.
+
+For the routing rule (player vs decision-board vs plain dashboard) and the full token/glass/motion
+spec, read the standard.

--- a/plugins/ork/skills/shared/assets/playground-exemplars/decision-board.template.html
+++ b/plugins/ork/skills/shared/assets/playground-exemplars/decision-board.template.html
@@ -135,6 +135,10 @@
   .card .meta { margin-top: 7px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
   .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); }
   .chip.rice { background: hsl(248 84% 68% / 0.16); color: hsl(248 84% 82%); font-family: var(--pg-mono); }
+  .chip.q-qw { background: hsl(160 68% 45% / 0.18); color: hsl(160 68% 72%); }
+  .chip.q-bb { background: hsl(248 84% 68% / 0.18); color: hsl(248 84% 82%); }
+  .chip.q-fi { background: hsl(206 85% 62% / 0.16); color: hsl(206 85% 76%); }
+  .chip.q-ts { background: hsl(345 76% 63% / 0.16); color: hsl(345 76% 78%); }
   .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
 
   /* dragging states */
@@ -220,7 +224,7 @@
       <h1>Decision Board</h1>
       <p>The decision-making parts of a playground should let you <b>act on the decision</b>, not just read it.
          Drag a card to set its impact &amp; effort, reorder the backlog, or sort it into buckets — the
-         <b>RICE score</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
+         <b>scores</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
          (<span class="kbd">Tab</span> a card, then <span class="kbd">← ↑ ↓ →</span>).</p>
     </div>
     <div class="right">
@@ -253,14 +257,14 @@
    Swap ITEMS for your own to reuse the template.
    ═══════════════════════════════════════════════════════════════════════ */
 const ITEMS = [
-  { id:"a", title:"One-click onboarding wizard",      reach:900, impact:3,   confidence:0.8,  effort:3 },
-  { id:"b", title:"Dark mode",                          reach:1200,impact:1,   confidence:0.95, effort:1 },
-  { id:"c", title:"SSO / SAML for enterprise",          reach:140, impact:3,   confidence:0.7,  effort:5 },
-  { id:"d", title:"Inline AI code review",              reach:600, impact:3,   confidence:0.6,  effort:4 },
-  { id:"e", title:"Mobile app",                         reach:2000,impact:2,   confidence:0.4,  effort:5 },
-  { id:"f", title:"Keyboard shortcuts",                 reach:500, impact:1,   confidence:0.9,  effort:1 },
-  { id:"g", title:"Usage analytics dashboard",          reach:350, impact:2,   confidence:0.8,  effort:3 },
-  { id:"h", title:"Slack notifications",                reach:700, impact:1,   confidence:0.85, effort:2 },
+  { id:"a", title:"One-click onboarding wizard", reach:900,  impact:4, confidence:0.8,  effort:2 }, // quick win
+  { id:"b", title:"Usage analytics dashboard",   reach:350,  impact:5, confidence:0.8,  effort:2 }, // quick win
+  { id:"c", title:"Keyboard shortcuts",          reach:500,  impact:2, confidence:0.9,  effort:1 }, // fill-in
+  { id:"d", title:"Dark mode",                   reach:1200, impact:2, confidence:0.95, effort:2 }, // fill-in
+  { id:"e", title:"SSO / SAML for enterprise",   reach:140,  impact:5, confidence:0.7,  effort:5 }, // big bet
+  { id:"f", title:"Inline AI code review",       reach:600,  impact:5, confidence:0.6,  effort:4 }, // big bet
+  { id:"g", title:"Mobile app",                  reach:2000, impact:4, confidence:0.4,  effort:5 }, // big bet
+  { id:"h", title:"Slack notifications",         reach:700,  impact:2, confidence:0.85, effort:4 }, // time sink
 ];
 
 const BUCKET_SCHEMES = {
@@ -298,19 +302,40 @@ const live  = document.getElementById("live");
 const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
 
 /* ── card markup ─────────────────────────────────────────────────────── */
+// Impact×Effort quadrant (split at the plane midpoint, impact/effort = 3).
+function quadrant(it) {
+  const hiI = it.impact > 3, hiE = it.effort > 3;
+  if (hiI && !hiE) return { key: "qw", label: "Quick win" };
+  if (hiI && hiE)  return { key: "bb", label: "Big bet" };
+  if (!hiI && !hiE) return { key: "fi", label: "Fill-in" };
+  return { key: "ts", label: "Time sink" };
+}
+// Chips are VIEW-AWARE: the matrix shows quadrant (position-consistent, no RICE),
+// the ranked list shows the full RICE breakdown (where reach/confidence are visible).
+function cardChips(it) {
+  if (state.view === "matrix") {
+    const q = quadrant(it);
+    return `<span class="chip q-${q.key}">${q.label}</span><span class="chip">I ${it.impact} · E ${it.effort}</span>`;
+  }
+  if (state.view === "list") {
+    return `<span class="chip rice">RICE ${rice(it)}</span><span class="chip">reach ${it.reach}</span>`
+         + `<span class="chip">impact ${it.impact}</span><span class="chip">conf ${Math.round(it.confidence * 100)}%</span><span class="chip">effort ${it.effort}</span>`;
+  }
+  return `<span class="chip">I ${it.impact} · E ${it.effort}</span>`;
+}
+function cardLabel(it) {
+  if (state.view === "matrix") return `${esc(it.title)}. ${quadrant(it).label}, impact ${it.impact}, effort ${it.effort}.`;
+  if (state.view === "list")   return `${esc(it.title)}. RICE ${rice(it)}.`;
+  return `${esc(it.title)}.`;
+}
 function cardHTML(it, extra = "") {
   return `<div class="card" data-id="${it.id}" tabindex="0" role="button"
             aria-roledescription="draggable card"
-            aria-label="${esc(it.title)}. RICE ${rice(it)}. ${kbdHint()}">
+            aria-label="${cardLabel(it)} ${kbdHint()}">
       <span class="grip" aria-hidden="true">⠿</span>
       ${extra}
       <div class="ct">${esc(it.title)}</div>
-      <div class="meta">
-        <span class="chip rice">RICE ${rice(it)}</span>
-        <span class="chip">reach ${it.reach}</span>
-        <span class="chip">impact ${it.impact}</span>
-        <span class="chip">effort ${it.effort}</span>
-      </div>
+      <div class="meta">${cardChips(it)}</div>
     </div>`;
 }
 function kbdHint() {
@@ -340,8 +365,9 @@ function renderList() {
 function renderMatrix() {
   const pct = v => 12 + ((v - 1) / 4) * 76;    // 1..5 → 12..88 (padded so cards never clip the edge)
   stage.innerHTML = `
-    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and RICE recomputes.
-       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.</p>
+    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and its quadrant updates.
+       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.
+       <span style="color:var(--pg-faint)">(full RICE score lives in the Ranked-list view)</span></p>
     <div class="matrix-wrap">
       <div class="axis-y" aria-hidden="true">Impact →</div>
       <div class="plane" id="plane">
@@ -454,7 +480,7 @@ function commitDrop(under, e) {
       const it = byId(drag.id);
       it.effort = clamp15(Math.round(fx * 4 + 1));
       it.impact = clamp15(Math.round(fy * 4 + 1));
-      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort} — ${quadrant(it).label}.`);
     }
   } else if (state.view === "list") {
     const list = document.getElementById("v-list");
@@ -491,7 +517,7 @@ stage.addEventListener("keydown", e => {
     const dir = state.rtl ? -1 : 1;
     if (e.key === "ArrowRight") it.effort = clamp15(it.effort + dir);
     if (e.key === "ArrowLeft")  it.effort = clamp15(it.effort - dir);
-    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort} — ${quadrant(it).label}.`);
   } else {
     const sch = BUCKET_SCHEMES[state.bucketScheme], order = sch.defs.map(d => d.key);
     const cur = order.indexOf(state.bucket[id]);
@@ -514,11 +540,11 @@ function refocus(id, msg) {
 function updatePrompt() {
   let txt = "";
   if (state.view === "matrix") {
-    const sorted = [...ITEMS].sort((a,b) => rice(b) - rice(a));
-    const top = sorted.slice(0,3).map(i => i.title);
-    const sink = sorted[sorted.length-1];
-    txt = `Prioritize the backlog by <b>RICE</b>. Top: <b>${esc(top.join(", "))}</b>. `
-        + `Deprioritize <span class="warm">${esc(sink.title)}</span> (RICE ${rice(sink)} — low impact for the effort).`;
+    const g = k => ITEMS.filter(i => quadrant(i).key === k).map(i => i.title);
+    const seg = (label, names) => `${label}: ${names.length ? esc(names.join(", ")) : "—"}`;
+    txt = `Prioritize by impact vs effort. `
+        + `<b>${seg("Do first (quick wins)", g("qw"))}</b>  ·  ${seg("Plan (big bets)", g("bb"))}  ·  `
+        + `${seg("Maybe (fill-ins)", g("fi"))}  ·  <span class="warm">${seg("Avoid (time sinks)", g("ts"))}</span>.`;
   } else if (state.view === "list") {
     const o = state.order.map((id,i) => `${i+1}. ${byId(id).title}`);
     txt = `Work the backlog in this <b>explicit order</b>: ${esc(o.join("  ·  "))}.`;

--- a/plugins/ork/skills/shared/assets/playground-exemplars/decision-board.template.html
+++ b/plugins/ork/skills/shared/assets/playground-exemplars/decision-board.template.html
@@ -1,0 +1,561 @@
+<!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  DECISION BOARD · drag-and-drop prioritization toolkit
+  OrchestKit playground exemplar — the "decision-board" archetype.
+
+  Conforms to: skills/shared/rules/playground-visual-standard.md
+  Persona: cool-glass ("technical precision", indigo). Zero dependencies. Single file.
+
+  WHAT THIS IS
+  ------------
+  The visual playgrounds OrchestKit generates should let you *make the
+  decision*, not just read a dashboard. This is the reusable template for
+  the decision-making parts: drag cards to prioritize and to manage. One
+  shared item set, four lenses:
+
+    1. Impact × Effort 2×2  — drop a card on the plane → sets its impact/effort
+    2. Ranked list          — drag to reorder 1..N (explicit priority override)
+    3. Buckets / columns    — drag between MoSCoW or Now / Next / Later
+    4. Live score + prompt   — RICE recomputes as you drag; copy the decision
+
+  ACCESSIBILITY (the part most drag-drop demos skip)
+  --------------------------------------------------
+  Native HTML5 drag-and-drop is mouse-only and inaccessible. This uses
+  vanilla Pointer Events (mouse + touch + pen) PLUS full keyboard control:
+  Tab to a card, arrow keys move it, every move is announced via aria-live.
+  Honors prefers-reduced-motion. RTL via CSS logical properties + a toggle.
+
+  TO REUSE: replace ITEMS below with your own; keep the engine.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Decision Board · Prioritization Playground</title>
+<style>
+  /* ── §2 Design tokens (HSL so shades are derivable) ─────────────────── */
+  :root {
+    --pg-bg:            hsl(232 26% 7%);
+    --pg-ink:           hsl(220 18% 93%);
+    --pg-muted:         hsl(220 12% 64%);
+    --pg-faint:         hsl(220 10% 46%);
+    --pg-line:          hsl(0 0% 100% / 0.10);
+    --pg-glass:         hsl(0 0% 100% / 0.05);
+    --pg-glass-2:       hsl(0 0% 100% / 0.08);
+    --pg-glass-edge:    hsl(0 0% 100% / 0.18);
+
+    --pg-accent:        hsl(248 84% 68%);   /* indigo — primary action / active */
+    --pg-accent-deep:   hsl(248 60% 52%);
+    --pg-warm:          hsl(38 95% 60%);    /* amber — secondary accent */
+    --pg-emerald:       hsl(160 68% 45%);   /* quick wins / success */
+    --pg-sky:           hsl(206 85% 62%);   /* fill-ins / could */
+    --pg-rose:          hsl(345 76% 63%);   /* time sinks / must */
+
+    /* two-part shadow (§5) — ambient + tight */
+    --pg-shadow: 0 20px 60px -22px hsl(232 40% 2% / 0.7), 0 4px 12px -6px hsl(232 40% 2% / 0.5);
+
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+
+    /* §6 motion budget — four tiers, nothing else animates */
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 88% -8%, hsl(248 84% 68% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 4% 110%, hsl(38 95% 60% / 0.12), transparent 58%),
+      radial-gradient(700px 520px at 50% 50%, hsl(160 68% 45% / 0.05), transparent 70%),
+      var(--pg-bg);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased; min-height: 100vh;
+  }
+
+  .wrap { max-width: 1120px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+
+  /* ── header / explainer ─────────────────────────────────────────────── */
+  .head { display: flex; align-items: flex-start; gap: 14px; flex-wrap: wrap; }
+  .logo {
+    width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 22px -8px hsl(248 84% 60% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4);
+  }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; display: flex; gap: 8px; align-items: center; }
+
+  .toggle {
+    cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px;
+    transition: color var(--pg-dur-fast), border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); background: var(--pg-glass-2); border-color: var(--pg-glass-edge); }
+
+  /* ── glass panel ────────────────────────────────────────────────────── */
+  .panel {
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow);
+  }
+
+  /* ── §7 segmented view switch ───────────────────────────────────────── */
+  .views { display: flex; gap: 4px; padding: 5px; background: hsl(0 0% 0% / 0.28); border: 1px solid var(--pg-line); border-radius: 13px; flex-wrap: wrap; }
+  .views button {
+    flex: 1 1 auto; min-width: 140px; border: 0; background: transparent; color: var(--pg-muted); cursor: pointer;
+    font: inherit; font-size: 13px; font-weight: 600; padding: 10px 12px; border-radius: 9px; letter-spacing: -.1px;
+    transition: color var(--pg-dur-fast), background var(--pg-dur-fast); display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  }
+  .views button:hover { color: var(--pg-ink); }
+  .views button[aria-pressed="true"] {
+    color: var(--pg-ink); background: linear-gradient(180deg, var(--pg-glass-2), hsl(0 0% 100% / 0.03));
+    box-shadow: 0 2px 10px -4px hsl(232 40% 2% / 0.6), inset 0 1px 0 hsl(0 0% 100% / 0.12);
+  }
+
+  .stage { padding: 20px; min-height: 440px; position: relative; }
+  .scheme-note { font-size: 12px; color: var(--pg-faint); margin: 0 0 14px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .scheme-note b { color: var(--pg-muted); font-weight: 650; }
+  .kbd { font-family: var(--pg-mono); font-size: 10.5px; color: var(--pg-muted); background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); border-radius: 6px; padding: 1px 6px; }
+
+  /* ── card (shared across views) ─────────────────────────────────────── */
+  .card {
+    background: hsl(0 0% 100% / 0.045); border: 1px solid var(--pg-line); border-radius: var(--pg-r-md);
+    padding: 11px 12px; cursor: grab; user-select: none; touch-action: none; position: relative;
+    transition: transform var(--pg-dur-fast) var(--pg-ease), border-color var(--pg-dur-fast), box-shadow var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .card:hover { border-color: var(--pg-glass-edge); background: hsl(0 0% 100% / 0.07); }
+  .card:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .card .ct { font-size: 13.5px; font-weight: 600; letter-spacing: -.1px; line-height: 1.3; }
+  .card .meta { margin-top: 7px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
+  .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); }
+  .chip.rice { background: hsl(248 84% 68% / 0.16); color: hsl(248 84% 82%); font-family: var(--pg-mono); }
+  .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
+
+  /* dragging states */
+  .card.source { opacity: .35; }
+  .ghost {
+    position: fixed; z-index: 999; pointer-events: none; width: var(--ghost-w, 220px);
+    transform: rotate(1.5deg) scale(1.03); box-shadow: 0 26px 60px -18px hsl(232 60% 2% / 0.8); cursor: grabbing;
+  }
+  .card.lifted { border-color: var(--pg-accent); box-shadow: 0 0 0 2px hsl(248 84% 68% / 0.4); }
+
+  /* ── view: ranked list ──────────────────────────────────────────────── */
+  #v-list { display: flex; flex-direction: column; gap: 9px; max-width: 660px; margin: 0 auto; }
+  #v-list .card { display: grid; grid-template-columns: 30px 1fr auto; align-items: center; gap: 12px; padding-inline-end: 26px; }
+  #v-list .rank { font-family: var(--pg-mono); font-size: 17px; font-weight: 800; color: var(--pg-accent); width: 30px; text-align: center; }
+  .drop-line { height: 2px; background: var(--pg-accent); border-radius: 2px; margin: -5px 0; box-shadow: 0 0 8px hsl(248 84% 68% / 0.7); }
+
+  /* ── view: impact × effort matrix ───────────────────────────────────── */
+  .matrix-wrap { display: grid; grid-template-columns: 26px 1fr; grid-template-rows: 1fr 26px; gap: 8px; height: 460px; }
+  .axis-y { writing-mode: vertical-rl; transform: rotate(180deg); text-align: center; font-size: 11px; letter-spacing: 1px; color: var(--pg-faint); text-transform: uppercase; }
+  .axis-x { grid-column: 2; text-align: center; font-size: 11px; letter-spacing: 1px; color: var(--pg-faint); text-transform: uppercase; }
+  .plane {
+    position: relative; border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); overflow: hidden;
+    background:
+      linear-gradient(hsl(0 0% 100% / 0.05), hsl(0 0% 100% / 0.05)) 0 0 / 100% 1px no-repeat,
+      linear-gradient(hsl(0 0% 100% / 0.05), hsl(0 0% 100% / 0.05)) 50% 0 / 1px 100% no-repeat,
+      hsl(0 0% 100% / 0.015);
+  }
+  .quad { position: absolute; width: 50%; height: 50%; padding: 10px 12px; font-size: 11px; font-weight: 700; letter-spacing: .3px; text-transform: uppercase; pointer-events: none; }
+  .quad.q-qw { inset-block-start: 0; inset-inline-start: 0;  color: hsl(160 68% 62%); background: radial-gradient(120% 120% at 0 0, hsl(160 68% 45% / 0.14), transparent 70%); }
+  .quad.q-bb { inset-block-start: 0; inset-inline-end: 0;  color: hsl(248 84% 80%); background: radial-gradient(120% 120% at 100% 0, hsl(248 84% 68% / 0.14), transparent 70%); text-align: end; }
+  .quad.q-fi { inset-block-end: 0; inset-inline-start: 0;  color: hsl(206 85% 74%); background: radial-gradient(120% 120% at 0 100%, hsl(206 85% 62% / 0.12), transparent 70%); }
+  .quad.q-ts { inset-block-end: 0; inset-inline-end: 0;  color: hsl(345 76% 76%); background: radial-gradient(120% 120% at 100% 100%, hsl(345 76% 63% / 0.13), transparent 70%); text-align: end; }
+  .plane .card { position: absolute; width: 150px; transform: translate(-50%, -50%); cursor: grab; }
+  .plane.hot { box-shadow: inset 0 0 0 2px hsl(248 84% 68% / 0.45); }
+
+  /* ── view: buckets ──────────────────────────────────────────────────── */
+  .buckets { display: grid; grid-template-columns: repeat(var(--cols, 4), 1fr); gap: 14px; }
+  .bucket { display: flex; flex-direction: column; min-height: 320px; }
+  .bucket-h { display: flex; align-items: center; gap: 8px; margin-bottom: 11px; font-size: 13px; font-weight: 700; }
+  .bucket-h .dot { width: 9px; height: 9px; border-radius: 999px; flex: none; }
+  .bucket-h .n { margin-inline-start: auto; font-size: 11px; color: var(--pg-faint); background: hsl(0 0% 0% / 0.25); border-radius: 999px; padding: 1px 8px; font-family: var(--pg-mono); }
+  .drop {
+    flex: 1; display: flex; flex-direction: column; gap: 9px; padding: 10px; border-radius: var(--pg-r-md);
+    background: hsl(0 0% 100% / 0.02); border: 1px dashed var(--pg-line);
+    transition: border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .drop.hot { border-color: var(--pg-accent); border-style: solid; background: hsl(248 84% 68% / 0.07); }
+  .drop:empty::after { content: "drop here"; color: var(--pg-faint); font-size: 11px; margin: auto; opacity: .6; }
+
+  /* ── §7 score + copy-prompt bar ─────────────────────────────────────── */
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(220 16% 80%); max-height: 92px; overflow-y: auto; }
+  .promptbar .pt b { color: var(--pg-accent); font-weight: 600; }
+  .promptbar .pt .warm { color: var(--pg-warm); }
+  .copy {
+    flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(248 30% 12%);
+    border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 10px 26px -12px hsl(248 84% 60% / 0.8); transition: transform var(--pg-dur-instant);
+  }
+  .copy:hover { transform: translateY(-1px); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+
+  /* ── §6 reduced motion ──────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    .ghost { transform: none; }
+  }
+  @media (max-width: 720px) {
+    .buckets { grid-template-columns: repeat(2, 1fr); }
+    .matrix-wrap { height: 520px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="head">
+    <div class="logo">🎚️</div>
+    <div>
+      <h1>Decision Board</h1>
+      <p>The decision-making parts of a playground should let you <b>act on the decision</b>, not just read it.
+         Drag a card to set its impact &amp; effort, reorder the backlog, or sort it into buckets — the
+         <b>RICE score</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
+         (<span class="kbd">Tab</span> a card, then <span class="kbd">← ↑ ↓ →</span>).</p>
+    </div>
+    <div class="right">
+      <button class="toggle" id="dirToggle" aria-pressed="false" title="Toggle text direction">⇄ RTL</button>
+    </div>
+  </header>
+
+  <div class="panel" style="padding:6px">
+    <div class="views" id="views" role="tablist" aria-label="Decision view">
+      <button data-view="matrix" aria-pressed="true">📊 Impact × Effort</button>
+      <button data-view="list"   aria-pressed="false">🔢 Ranked list</button>
+      <button data-view="buckets" aria-pressed="false">🗂️ Buckets</button>
+    </div>
+  </div>
+
+  <main class="panel stage" id="stage" aria-live="off"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">📋 Copy decision</button>
+  </div>
+
+  <div class="sr-only" id="live" role="status" aria-live="polite"></div>
+</div>
+
+<script>
+/* ═══════════════════════════════════════════════════════════════════════
+   DATA MODEL — one shared item set. Each view is a lens that edits or
+   orders these fields. RICE = round(reach × impact × confidence / effort).
+   Swap ITEMS for your own to reuse the template.
+   ═══════════════════════════════════════════════════════════════════════ */
+const ITEMS = [
+  { id:"a", title:"One-click onboarding wizard",      reach:900, impact:3,   confidence:0.8,  effort:3 },
+  { id:"b", title:"Dark mode",                          reach:1200,impact:1,   confidence:0.95, effort:1 },
+  { id:"c", title:"SSO / SAML for enterprise",          reach:140, impact:3,   confidence:0.7,  effort:5 },
+  { id:"d", title:"Inline AI code review",              reach:600, impact:3,   confidence:0.6,  effort:4 },
+  { id:"e", title:"Mobile app",                         reach:2000,impact:2,   confidence:0.4,  effort:5 },
+  { id:"f", title:"Keyboard shortcuts",                 reach:500, impact:1,   confidence:0.9,  effort:1 },
+  { id:"g", title:"Usage analytics dashboard",          reach:350, impact:2,   confidence:0.8,  effort:3 },
+  { id:"h", title:"Slack notifications",                reach:700, impact:1,   confidence:0.85, effort:2 },
+];
+
+const BUCKET_SCHEMES = {
+  moscow: { cols: 4, defs: [
+    { key:"must",   label:"Must",   dot:"var(--pg-rose)" },
+    { key:"should", label:"Should", dot:"var(--pg-warm)" },
+    { key:"could",  label:"Could",  dot:"var(--pg-sky)" },
+    { key:"wont",   label:"Won't",  dot:"var(--pg-faint)" },
+  ]},
+  nnl: { cols: 3, defs: [
+    { key:"now",   label:"Now",   dot:"var(--pg-emerald)" },
+    { key:"next",  label:"Next",  dot:"var(--pg-warm)" },
+    { key:"later", label:"Later", dot:"var(--pg-faint)" },
+  ]},
+};
+
+/* per-item view state, derived/seeded from the model */
+const state = {
+  view: "matrix",
+  rtl: false,
+  bucketScheme: "moscow",
+  // matrix position: impact & effort already on items (1..5)
+  order: ITEMS.map(i => i.id),           // ranked-list order
+  bucket: {},                            // id -> bucket key
+};
+ITEMS.forEach((it, idx) => {
+  state.bucket[it.id] = ["must","must","should","could","should","could","should","could"][idx] || "could";
+});
+
+const byId = id => ITEMS.find(i => i.id === id);
+const rice = it => Math.round((it.reach * it.impact * it.confidence) / it.effort);
+const esc = s => String(s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+const stage = document.getElementById("stage");
+const live  = document.getElementById("live");
+const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
+
+/* ── card markup ─────────────────────────────────────────────────────── */
+function cardHTML(it, extra = "") {
+  return `<div class="card" data-id="${it.id}" tabindex="0" role="button"
+            aria-roledescription="draggable card"
+            aria-label="${esc(it.title)}. RICE ${rice(it)}. ${kbdHint()}">
+      <span class="grip" aria-hidden="true">⠿</span>
+      ${extra}
+      <div class="ct">${esc(it.title)}</div>
+      <div class="meta">
+        <span class="chip rice">RICE ${rice(it)}</span>
+        <span class="chip">reach ${it.reach}</span>
+        <span class="chip">impact ${it.impact}</span>
+        <span class="chip">effort ${it.effort}</span>
+      </div>
+    </div>`;
+}
+function kbdHint() {
+  if (state.view === "list")   return "Use arrow up and down to reorder.";
+  if (state.view === "matrix") return "Arrows change impact and effort.";
+  return "Arrow left and right move between buckets.";
+}
+
+/* ═══════════════════════════ RENDERERS ════════════════════════════════ */
+function render() {
+  if (state.view === "matrix") renderMatrix();
+  else if (state.view === "list") renderList();
+  else renderBuckets();
+  updatePrompt();
+}
+
+function renderList() {
+  const items = state.order.map(byId);
+  stage.innerHTML = `
+    <p class="scheme-note">Drag to reorder — this is your <b>explicit priority</b>, overriding the computed score.
+       <span class="kbd">↑</span><span class="kbd">↓</span> move the focused card.</p>
+    <div id="v-list">
+      ${items.map((it, i) => cardHTML(it, `<span class="rank" aria-hidden="true">${i+1}</span>`)).join("")}
+    </div>`;
+}
+
+function renderMatrix() {
+  const pct = v => 12 + ((v - 1) / 4) * 76;    // 1..5 → 12..88 (padded so cards never clip the edge)
+  stage.innerHTML = `
+    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and RICE recomputes.
+       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.</p>
+    <div class="matrix-wrap">
+      <div class="axis-y" aria-hidden="true">Impact →</div>
+      <div class="plane" id="plane">
+        <div class="quad q-qw">Quick wins</div>
+        <div class="quad q-bb">Big bets</div>
+        <div class="quad q-fi">Fill-ins</div>
+        <div class="quad q-ts">Time sinks</div>
+        ${ITEMS.map(it => `${cardWrapMatrix(it, pct)}`).join("")}
+      </div>
+      <div class="axis-x" aria-hidden="true">Effort →</div>
+    </div>`;
+}
+function cardWrapMatrix(it, pct) {
+  // inset-inline-start auto-mirrors in RTL; center-anchored (translate -50%,-50%)
+  // high impact → near top, so top% = 100 - impact%
+  const x = pct(it.effort), y = pct(it.impact);
+  const el = cardHTML(it);
+  return el.replace('class="card"', `class="card" style="inset-inline-start:${x}%; inset-block-start:${100 - y}%;"`);
+}
+
+function renderBuckets() {
+  const sch = BUCKET_SCHEMES[state.bucketScheme];
+  stage.style.setProperty("--cols", sch.cols);
+  const other = state.bucketScheme === "moscow" ? "nnl" : "moscow";
+  stage.innerHTML = `
+    <p class="scheme-note">Drag cards between buckets to manage scope.
+       <button class="toggle" id="schemeToggle" aria-pressed="false">↔ ${other === "moscow" ? "MoSCoW" : "Now / Next / Later"}</button>
+       <span class="kbd">←</span><span class="kbd">→</span> move the focused card.</p>
+    <div class="buckets">
+      ${sch.defs.map(b => `
+        <div class="bucket">
+          <div class="bucket-h"><span class="dot" style="background:${b.dot}"></span>${b.label}
+            <span class="n">${ITEMS.filter(i => state.bucket[i.id] === b.key).length}</span></div>
+          <div class="drop" data-bucket="${b.key}">
+            ${ITEMS.filter(i => state.bucket[i.id] === b.key).map(i => cardHTML(i)).join("")}
+          </div>
+        </div>`).join("")}
+    </div>`;
+  const st = document.getElementById("schemeToggle");
+  if (st) st.addEventListener("click", () => { state.bucketScheme = other; render(); });
+}
+
+/* ═══════════════════════ POINTER DRAG ENGINE ══════════════════════════ */
+let drag = null;
+stage.addEventListener("pointerdown", e => {
+  const card = e.target.closest(".card");
+  if (!card || e.button !== 0) return;
+  e.preventDefault();
+  const rect = card.getBoundingClientRect();
+  const ghost = card.cloneNode(true);
+  ghost.classList.add("ghost"); ghost.classList.remove("source");
+  ghost.style.setProperty("--ghost-w", rect.width + "px");
+  ghost.style.left = rect.left + "px"; ghost.style.top = rect.top + "px";
+  document.body.appendChild(ghost);
+  card.classList.add("source");
+  drag = { id: card.dataset.id, ghost, card, dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp, { once: true });
+});
+function onMove(e) {
+  if (!drag) return;
+  drag.ghost.style.left = (e.clientX - drag.dx) + "px";
+  drag.ghost.style.top  = (e.clientY - drag.dy) + "px";
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  drag.ghost.style.display = "";
+  hover(under, e);
+}
+function onUp(e) {
+  if (!drag) return;
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  commitDrop(under, e);
+  drag.ghost.remove();
+  document.querySelectorAll(".hot").forEach(x => x.classList.remove("hot"));
+  document.querySelectorAll(".drop-line").forEach(x => x.remove());
+  drag = null;
+  window.removeEventListener("pointermove", onMove);
+}
+
+function hover(under, e) {
+  document.querySelectorAll(".drop-line").forEach(x => x.remove());
+  if (state.view === "buckets") {
+    document.querySelectorAll(".drop").forEach(d => d.classList.remove("hot"));
+    const drop = under && under.closest(".drop"); if (drop) drop.classList.add("hot");
+  } else if (state.view === "matrix") {
+    const plane = document.getElementById("plane"); if (plane) plane.classList.toggle("hot", !!(under && under.closest(".plane")));
+  } else if (state.view === "list") {
+    const list = document.getElementById("v-list");
+    const over = under && under.closest(".card");
+    if (over && over !== drag.card) {
+      const r = over.getBoundingClientRect();
+      const after = e.clientY > r.top + r.height / 2;
+      const line = document.createElement("div"); line.className = "drop-line";
+      list.insertBefore(line, after ? over.nextSibling : over);
+    }
+  }
+}
+function commitDrop(under, e) {
+  if (state.view === "buckets") {
+    const drop = under && under.closest(".drop");
+    if (drop) { state.bucket[drag.id] = drop.dataset.bucket; render();
+      announce(`${byId(drag.id).title} moved to ${drop.dataset.bucket}.`); }
+  } else if (state.view === "matrix") {
+    const plane = document.getElementById("plane");
+    if (plane && under && under.closest(".plane")) {
+      const r = plane.getBoundingClientRect();
+      let fx = (e.clientX - r.left) / r.width; if (state.rtl) fx = 1 - fx;
+      const fy = 1 - (e.clientY - r.top) / r.height;          // bottom = low impact
+      const it = byId(drag.id);
+      it.effort = clamp15(Math.round(fx * 4 + 1));
+      it.impact = clamp15(Math.round(fy * 4 + 1));
+      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+    }
+  } else if (state.view === "list") {
+    const list = document.getElementById("v-list");
+    const cards = [...list.querySelectorAll(".card")];
+    const over = under && under.closest(".card");
+    let to = over ? cards.indexOf(over) : cards.length - 1;
+    const from = state.order.indexOf(drag.id);
+    if (over) { const r = over.getBoundingClientRect(); if (e.clientY > r.top + r.height/2) to++; }
+    if (to > from) to--;
+    state.order.splice(from, 1);
+    state.order.splice(Math.max(0, Math.min(to, state.order.length)), 0, drag.id);
+    render(); announce(`${byId(drag.id).title} moved to position ${state.order.indexOf(drag.id)+1}.`);
+  }
+}
+const clamp15 = v => Math.max(1, Math.min(5, v));
+
+/* ═══════════════════════ KEYBOARD ENGINE ══════════════════════════════ */
+stage.addEventListener("keydown", e => {
+  const card = e.target.closest(".card"); if (!card) return;
+  const id = card.dataset.id, it = byId(id);
+  const keys = ["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"];
+  if (!keys.includes(e.key)) return;
+  e.preventDefault();
+  if (state.view === "list") {
+    const i = state.order.indexOf(id);
+    const j = e.key === "ArrowUp" ? i - 1 : e.key === "ArrowDown" ? i + 1 : i;
+    if (j !== i && j >= 0 && j < state.order.length) {
+      state.order.splice(i, 1); state.order.splice(j, 0, id);
+      refocus(id, `${it.title} now position ${j+1}.`);
+    }
+  } else if (state.view === "matrix") {
+    if (e.key === "ArrowUp")    it.impact = clamp15(it.impact + 1);
+    if (e.key === "ArrowDown")  it.impact = clamp15(it.impact - 1);
+    const dir = state.rtl ? -1 : 1;
+    if (e.key === "ArrowRight") it.effort = clamp15(it.effort + dir);
+    if (e.key === "ArrowLeft")  it.effort = clamp15(it.effort - dir);
+    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+  } else {
+    const sch = BUCKET_SCHEMES[state.bucketScheme], order = sch.defs.map(d => d.key);
+    const cur = order.indexOf(state.bucket[id]);
+    const step = (e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0) * (state.rtl ? -1 : 1);
+    const nx = cur + step;
+    if (step && nx >= 0 && nx < order.length) {
+      state.bucket[id] = order[nx];
+      refocus(id, `${it.title} moved to ${sch.defs[nx].label}.`);
+    }
+  }
+});
+function refocus(id, msg) {
+  render();
+  const el = stage.querySelector(`.card[data-id="${id}"]`);
+  if (el) el.focus();
+  announce(msg);
+}
+
+/* ═══════════════════════ COPY-PROMPT BAR ══════════════════════════════ */
+function updatePrompt() {
+  let txt = "";
+  if (state.view === "matrix") {
+    const sorted = [...ITEMS].sort((a,b) => rice(b) - rice(a));
+    const top = sorted.slice(0,3).map(i => i.title);
+    const sink = sorted[sorted.length-1];
+    txt = `Prioritize the backlog by <b>RICE</b>. Top: <b>${esc(top.join(", "))}</b>. `
+        + `Deprioritize <span class="warm">${esc(sink.title)}</span> (RICE ${rice(sink)} — low impact for the effort).`;
+  } else if (state.view === "list") {
+    const o = state.order.map((id,i) => `${i+1}. ${byId(id).title}`);
+    txt = `Work the backlog in this <b>explicit order</b>: ${esc(o.join("  ·  "))}.`;
+  } else {
+    const sch = BUCKET_SCHEMES[state.bucketScheme];
+    txt = sch.defs.map(b => {
+      const names = ITEMS.filter(i => state.bucket[i.id] === b.key).map(i => i.title);
+      return `<b>${b.label}:</b> ${names.length ? esc(names.join(", ")) : "—"}`;
+    }).join("  ·  ");
+    txt = `Scope decision (${state.bucketScheme === "moscow" ? "MoSCoW" : "Now/Next/Later"}). ${txt}.`;
+  }
+  document.getElementById("promptOut").innerHTML = txt;
+}
+document.getElementById("copyBtn").addEventListener("click", () => {
+  const txt = document.getElementById("promptOut").textContent;
+  navigator.clipboard.writeText(txt).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "✓ Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 Copy decision"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+/* ═══════════════════════ CHROME / EVENTS ══════════════════════════════ */
+document.getElementById("views").addEventListener("click", e => {
+  const b = e.target.closest("[data-view]"); if (!b) return;
+  state.view = b.dataset.view;
+  document.querySelectorAll("#views button").forEach(x => x.setAttribute("aria-pressed", x.dataset.view === state.view));
+  render();
+});
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl;
+  document.documentElement.dir = state.rtl ? "rtl" : "ltr";
+  e.currentTarget.setAttribute("aria-pressed", state.rtl);
+  render();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/plugins/ork/skills/shared/assets/playground-exemplars/homeos-arieh.html
+++ b/plugins/ork/skills/shared/assets/playground-exemplars/homeos-arieh.html
@@ -1,0 +1,830 @@
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  CANONICAL GOLD-STANDARD REFERENCE — "HomeOS · App UI Explorer"
+  Designed by Arieh. Committed verbatim as the quality bar for OrchestKit
+  visual playgrounds. Do not edit — study it.
+
+  Why it is the bar (see skills/shared/rules/playground-visual-standard.md):
+   • USER-STORY PLAYER archetype: high-fidelity device mockups (WhatsApp phone
+     w/ notch + chat bubbles + typing dots, kitchen tablet, kanban).
+   • Plays a user story with a transport (play / prev / next).
+   • Cause→effect flow arrow: a forwarded message becomes a calendar-event card.
+   • Warm-glass persona: gradient mesh, backdrop-filter, two-part shadows.
+   • RTL Hebrew first-class via logical properties. 1-click copy-prompt bar.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<!doctype html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HomeOS · App UI Explorer</title>
+<style>
+  /* ───────────────────────────────────────────────────────────────
+     HomeOS — App UI & User-Story Explorer
+     Single-file, no external deps. RTL Hebrew first-class.
+     Aesthetic: warm "family tech" — emerald (WhatsApp nod) + amber,
+     glass chrome over a gradient mesh, parchment kitchen-tablet surface.
+     ─────────────────────────────────────────────────────────────── */
+  :root {
+    --bg: #0c1014;
+    --ink: #e9eef1;
+    --muted: #93a1ab;
+    --faint: #66727c;
+    --line: rgba(255,255,255,.09);
+    --glass: rgba(255,255,255,.045);
+    --glass-2: rgba(255,255,255,.07);
+    --emerald: #25d366;       /* WhatsApp green */
+    --emerald-deep: #0e7c66;
+    --amber: #f5a623;
+    --rose: #e8748a;
+    --sky: #5aa9e6;
+    --teal: #2dd4bf;
+    --radius: 18px;
+    --shadow: 0 20px 50px -20px rgba(0,0,0,.7);
+    --font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI",
+            "Assistant", "Heebo", "Rubik", system-ui, sans-serif;
+    --mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--ink);
+    background:
+      radial-gradient(900px 600px at 88% -8%, rgba(37,211,102,.16), transparent 60%),
+      radial-gradient(800px 620px at 6% 108%, rgba(245,166,35,.13), transparent 58%),
+      radial-gradient(700px 500px at 50% 50%, rgba(45,212,191,.06), transparent 70%),
+      var(--bg);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased;
+    overflow: hidden;
+  }
+
+  .app {
+    height: 100vh;
+    display: grid;
+    grid-template-columns: 350px 1fr;
+    gap: 18px;
+    padding: 18px;
+  }
+
+  /* ── Controls panel ───────────────────────────────────────────── */
+  .panel {
+    background: var(--glass);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
+  .controls {
+    padding: 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+  .brand { display: flex; align-items: center; gap: 12px; }
+  .brand .logo {
+    width: 42px; height: 42px; border-radius: 13px; flex: none;
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep));
+    display: grid; place-items: center;
+    box-shadow: 0 8px 22px -8px rgba(37,211,102,.7), inset 0 1px 0 rgba(255,255,255,.4);
+    font-size: 22px;
+  }
+  .brand h1 { margin: 0; font-size: 18px; letter-spacing: -.2px; }
+  .brand p { margin: 2px 0 0; font-size: 11.5px; color: var(--muted); letter-spacing: .2px; }
+
+  .group { display: flex; flex-direction: column; gap: 10px; }
+  .group > .label {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 1.4px;
+    color: var(--faint); font-weight: 600; display:flex; justify-content:space-between; align-items:center;
+  }
+
+  /* scenario cards */
+  .scn {
+    text-align: start; width: 100%; cursor: pointer;
+    background: var(--glass); border: 1px solid var(--line);
+    border-radius: 14px; padding: 12px 13px; color: var(--ink);
+    display: flex; gap: 11px; align-items: flex-start;
+    transition: transform .18s ease, border-color .18s, background .18s, box-shadow .18s;
+    font-family: inherit;
+  }
+  .scn:hover { transform: translateY(-2px); background: var(--glass-2); border-color: rgba(255,255,255,.18); }
+  .scn[aria-pressed="true"] {
+    border-color: rgba(37,211,102,.6);
+    background: linear-gradient(180deg, rgba(37,211,102,.14), rgba(37,211,102,.04));
+    box-shadow: 0 10px 30px -16px rgba(37,211,102,.6);
+  }
+  .scn .ico { font-size: 20px; line-height: 1; margin-top: 1px; }
+  .scn .tt { font-size: 13.5px; font-weight: 650; letter-spacing: -.1px; }
+  .scn .sb { font-size: 11.5px; color: var(--muted); margin-top: 3px; line-height: 1.45; }
+  .scn .soon {
+    font-size: 9.5px; font-weight: 700; letter-spacing: .5px; color: #0c1014;
+    background: var(--amber); border-radius: 999px; padding: 2px 7px; margin-inline-start: auto; align-self:center;
+  }
+
+  /* segmented control */
+  .seg { display: flex; background: rgba(0,0,0,.28); border: 1px solid var(--line); border-radius: 12px; padding: 4px; gap: 4px; }
+  .seg button {
+    flex: 1; border: 0; background: transparent; color: var(--muted);
+    font-family: inherit; font-size: 12.5px; font-weight: 600; padding: 9px 6px; border-radius: 9px;
+    cursor: pointer; transition: .16s; letter-spacing: -.1px;
+  }
+  .seg button:hover { color: var(--ink); }
+  .seg button[aria-pressed="true"] {
+    background: linear-gradient(180deg, var(--glass-2), rgba(255,255,255,.03));
+    color: var(--ink); box-shadow: 0 2px 10px -4px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.12);
+  }
+
+  /* family chips */
+  .fam { display: flex; gap: 8px; flex-wrap: wrap; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    background: var(--glass); border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 11px 5px 6px; font-size: 12.5px; color: var(--ink); transition: .16s; font-family: inherit;
+  }
+  .chip[aria-pressed="false"] { opacity: .4; filter: grayscale(.6); }
+  .chip:hover { border-color: rgba(255,255,255,.22); }
+  .av {
+    width: 22px; height: 22px; border-radius: 999px; display: grid; place-items: center;
+    font-size: 11px; font-weight: 800; color: #0c1014;
+  }
+
+  /* transport */
+  .transport { display: flex; gap: 8px; }
+  .btn {
+    flex: 1; cursor: pointer; font-family: inherit; font-size: 13px; font-weight: 650;
+    border-radius: 11px; padding: 11px; border: 1px solid var(--line);
+    background: var(--glass); color: var(--ink); transition: .16s;
+    display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  }
+  .btn:hover { background: var(--glass-2); transform: translateY(-1px); }
+  .btn.primary {
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep));
+    border-color: transparent; color: #05140d;
+    box-shadow: 0 10px 26px -12px rgba(37,211,102,.8);
+  }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+
+  .hint { font-size: 11.5px; color: var(--faint); line-height: 1.5; }
+  .hint b { color: var(--muted); font-weight: 650; }
+
+  /* ── Stage ────────────────────────────────────────────────────── */
+  .stage { display: grid; grid-template-rows: auto 1fr auto; gap: 16px; min-width: 0; }
+  .stage-head {
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  }
+  .stage-title { min-width: 0; }
+  .stage-title h2 { margin: 0; font-size: 19px; letter-spacing: -.3px; }
+  .stage-title p { margin: 3px 0 0; font-size: 12.5px; color: var(--muted); }
+  .view-switch { flex: none; width: 360px; max-width: 42vw; }
+
+  .stage-body {
+    background: var(--glass); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 26px; overflow: auto; display: grid; place-items: center; position: relative;
+  }
+  .stage-body::before {
+    content: ""; position: absolute; inset: 0; border-radius: var(--radius); pointer-events: none;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+  }
+
+  /* ── WhatsApp phone view ──────────────────────────────────────── */
+  .wa-wrap { display: flex; gap: 34px; align-items: center; flex-wrap: wrap; justify-content: center; }
+
+  .phone {
+    width: 330px; height: 660px; border-radius: 42px; padding: 12px;
+    background: linear-gradient(160deg, #1c2530, #0b0f14);
+    box-shadow: var(--shadow), inset 0 0 0 2px rgba(255,255,255,.06);
+    flex: none; position: relative;
+  }
+  .phone::after { /* notch */
+    content: ""; position: absolute; top: 18px; left: 50%; transform: translateX(-50%);
+    width: 120px; height: 26px; background: #05080b; border-radius: 0 0 16px 16px; z-index: 5;
+  }
+  .screen {
+    height: 100%; border-radius: 31px; overflow: hidden; display: flex; flex-direction: column;
+    background: #0b141a;
+  }
+  .wa-head {
+    background: #1f2c34; padding: 16px 14px 12px; display: flex; align-items: center; gap: 11px;
+    border-bottom: 1px solid rgba(0,0,0,.4);
+  }
+  .wa-head .bot-av {
+    width: 38px; height: 38px; border-radius: 999px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep)); font-size: 19px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.4);
+  }
+  .wa-head .nm { font-size: 14.5px; font-weight: 650; color: #e9eef1; }
+  .wa-head .st { font-size: 11px; color: #8aa0ad; margin-top: 1px; }
+  .wa-head .dots { margin-inline-start: auto; color: #8aa0ad; font-size: 18px; letter-spacing: 1px; }
+
+  .wa-body {
+    flex: 1; overflow-y: auto; padding: 16px 12px; display: flex; flex-direction: column; gap: 8px;
+    background-color: #0b141a;
+    background-image:
+      radial-gradient(rgba(255,255,255,.022) 1px, transparent 1px),
+      radial-gradient(rgba(255,255,255,.022) 1px, transparent 1px);
+    background-size: 26px 26px, 26px 26px;
+    background-position: 0 0, 13px 13px;
+  }
+  .wa-body::-webkit-scrollbar { width: 0; }
+  .day-pill {
+    align-self: center; font-size: 10.5px; color: #c9d6dd; background: #1f2c34;
+    padding: 4px 12px; border-radius: 8px; margin-bottom: 4px; box-shadow: 0 1px 3px rgba(0,0,0,.3);
+  }
+
+  .bubble {
+    max-width: 80%; padding: 7px 10px 6px; border-radius: 11px; font-size: 13.5px; line-height: 1.5;
+    position: relative; white-space: pre-wrap; word-break: break-word;
+    animation: pop .34s cubic-bezier(.2,.8,.25,1) both; box-shadow: 0 1px 1px rgba(0,0,0,.3);
+  }
+  .bubble .meta { font-size: 9.5px; color: rgba(255,255,255,.5); margin-top: 3px; text-align: start; display:flex; gap:4px; align-items:center; justify-content:flex-start; }
+  .bubble.out { align-self: flex-end; background: #056452; color: #eafff4; border-top-right-radius: 3px; }
+  .bubble.in  { align-self: flex-start; background: #202d35; color: #e9eef1; border-top-left-radius: 3px; }
+  .bubble.bot { align-self: flex-start; background: linear-gradient(180deg,#10231b,#0f1d18); color: #eafff4; border: 1px solid rgba(37,211,102,.35); border-top-left-radius: 3px; }
+  .bubble.bot .botbadge { font-size: 9px; font-weight: 800; letter-spacing:.4px; color: var(--emerald); margin-bottom: 3px; display:flex; gap:5px; align-items:center; }
+  .bubble .fwd { font-size: 10.5px; color: rgba(255,255,255,.55); font-style: italic; margin-bottom: 3px; display:flex; gap:4px; align-items:center;}
+  .tick { color: #5ad7ff; }
+  .removed { opacity: .55; }
+  .removed .body { text-decoration: line-through; text-decoration-color: rgba(255,255,255,.5); }
+
+  .typing { align-self: flex-start; background: #202d35; padding: 11px 13px; border-radius: 11px; border-top-left-radius: 3px; display: inline-flex; gap: 4px; }
+  .typing span { width: 7px; height: 7px; border-radius: 999px; background: #6b7d88; animation: blink 1.2s infinite both; }
+  .typing span:nth-child(2){ animation-delay: .2s; } .typing span:nth-child(3){ animation-delay: .4s; }
+
+  .wa-input {
+    background: #1f2c34; padding: 9px 12px; display: flex; align-items: center; gap: 10px;
+  }
+  .wa-input .box { flex: 1; background: #2a3942; border-radius: 999px; padding: 9px 14px; font-size: 12.5px; color: #6b7d88; }
+  .wa-input .send { width: 38px; height: 38px; border-radius: 999px; background: var(--emerald); display: grid; place-items: center; font-size: 17px; color:#05140d; }
+
+  /* arrow + resulting card */
+  .flow-arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--muted); }
+  .flow-arrow .ar { font-size: 30px; color: var(--emerald); animation: nudge 1.8s ease-in-out infinite; }
+  .flow-arrow .cap { font-size: 11px; max-width: 130px; text-align: center; line-height: 1.5; }
+  .flow-arrow .cap b { color: var(--ink); }
+
+  .card-stage { display: flex; flex-direction: column; gap: 14px; width: 280px; }
+  .card-stage > .lbl { font-size: 11px; text-transform: uppercase; letter-spacing: 1.4px; color: var(--faint); font-weight: 600; }
+  .ecard {
+    background: #ffffff; color: #1b2430; border-radius: 16px; padding: 16px; position: relative;
+    box-shadow: var(--shadow); border: 1px solid rgba(0,0,0,.06); overflow: hidden;
+    animation: cardin .5s cubic-bezier(.2,.85,.25,1) both;
+  }
+  .ecard.gone { animation: cardout .45s ease forwards; }
+  .ecard .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; }
+  .ecard .kind { display: inline-flex; align-items: center; gap: 6px; font-size: 10.5px; font-weight: 700; letter-spacing: .3px; color: #6a7686; text-transform: uppercase; }
+  .ecard h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
+  .ecard .row { display: flex; align-items: center; gap: 8px; font-size: 13px; color: #38424f; margin-top: 6px; }
+  .ecard .row .gl { font-size: 14px; width: 18px; text-align: center; }
+  .ecard .foot { margin-top: 13px; padding-top: 12px; border-top: 1px dashed #e2e6ec; display: flex; align-items: center; justify-content: space-between; }
+  .ecard .added { font-size: 11px; color: var(--emerald-deep); font-weight: 700; display:flex; gap:5px; align-items:center;}
+  .pill-cap {
+    background: linear-gradient(180deg,#2a1408,#1a0d05); border:1px solid rgba(245,166,35,.4); color:#ffd9a0;
+    border-radius: 14px; padding: 14px 16px; font-size: 12.5px; line-height:1.6; width: 280px; box-shadow: var(--shadow);
+    animation: cardin .5s cubic-bezier(.2,.85,.25,1) both;
+  }
+  .pill-cap b { color: var(--amber); }
+
+  /* ── Kitchen tablet dashboard ─────────────────────────────────── */
+  .tablet {
+    width: min(940px, 100%); aspect-ratio: 16 / 10; border-radius: 26px; padding: 14px;
+    background: linear-gradient(160deg, #20262e, #0a0d11);
+    box-shadow: var(--shadow), inset 0 0 0 2px rgba(255,255,255,.05); flex: none;
+  }
+  .tboard {
+    height: 100%; border-radius: 16px; overflow: hidden; color: #20262e;
+    background: linear-gradient(180deg, #fbf7f0, #f1ece2);
+    display: grid; grid-template-rows: auto 1fr auto; gap: 0;
+    font-size: 13px;
+  }
+  .tbar { display: flex; align-items: center; gap: 16px; padding: 16px 20px 13px; border-bottom: 1px solid #e7e0d4; }
+  .tbar .greet { font-size: 21px; font-weight: 750; letter-spacing: -.4px; }
+  .tbar .greet small { display:block; font-size: 12px; font-weight: 600; color: #8a8276; letter-spacing: 0; margin-top: 2px; }
+  .tbar .hcal {
+    margin-inline-start: auto; text-align: end; font-size: 12.5px; color: #6f6757; line-height: 1.5;
+  }
+  .tbar .hcal b { color: #2c5e4f; }
+  .tbar .clock { font-size: 30px; font-weight: 800; letter-spacing: -1px; color:#20262e; font-variant-numeric: tabular-nums; }
+
+  .tgrid { display: grid; grid-template-columns: 1.25fr 1fr; gap: 0; min-height: 0; }
+  .col { padding: 14px 18px; overflow: auto; }
+  .col + .col { border-inline-start: 1px solid #e7e0d4; background: rgba(255,255,255,.4); }
+  .col h4 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; letter-spacing: 1.2px; color: #9a917f; display:flex; align-items:center; gap:7px; }
+  .col h4 .n { background:#e7e0d4; color:#6f6757; border-radius:999px; font-size:10px; padding:1px 7px; font-weight:700; letter-spacing:0;}
+
+  .appt { display: flex; gap: 12px; align-items: stretch; padding: 9px 0; }
+  .appt .time { font-size: 13px; font-weight: 800; color: #2c5e4f; width: 46px; flex: none; font-variant-numeric: tabular-nums; padding-top:2px; }
+  .appt .bar { width: 3px; border-radius: 3px; flex: none; background: #cfc8ba; }
+  .appt .ct { flex: 1; }
+  .appt .ct .t { font-weight: 650; font-size: 14px; }
+  .appt .ct .m { font-size: 11.5px; color: #897f6e; margin-top: 2px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}
+  .appt.glow .ct { position: relative; }
+  .appt.glow { background: linear-gradient(90deg, rgba(37,211,102,.16), transparent); border-radius: 10px; margin: 0 -8px; padding: 9px 8px; box-shadow: inset 0 0 0 1px rgba(37,211,102,.3); }
+  .justadded { font-size: 9.5px; font-weight: 800; color: #0c1014; background: var(--emerald); border-radius: 999px; padding: 1px 7px; letter-spacing:.3px;}
+
+  .mini-av { width: 19px; height: 19px; border-radius:999px; display:inline-grid; place-items:center; font-size:9.5px; font-weight:800; color:#0c1014; }
+  .tag { font-size: 10.5px; color:#6f6757; background:#efe9dd; border-radius:6px; padding:1px 7px; }
+
+  .remind { display:flex; gap:9px; align-items:center; padding:7px 0; font-size:13px; }
+  .remind .bx { width:16px; height:16px; border-radius:5px; border:2px solid #c3bbac; flex:none; }
+  .remind.done .bx { background:#2c5e4f; border-color:#2c5e4f; position:relative; }
+  .remind.done .bx::after { content:"✓"; color:#fff; font-size:11px; position:absolute; inset:0; display:grid; place-items:center; }
+  .remind.done span { text-decoration: line-through; color:#a59c8b; }
+
+  .tfoot { padding: 11px 20px; background: linear-gradient(90deg, #2c5e4f, #21483c); color: #eafff4; display:flex; align-items:center; gap:12px; font-size: 13px; }
+  .tfoot .shab { margin-inline-start:auto; font-size:12.5px; opacity:.92; }
+  .tfoot .weather { display:flex; align-items:center; gap:7px; opacity:.95; }
+
+  /* ── Task board (monday-style) ────────────────────────────────── */
+  .kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; width: min(960px, 100%); }
+  .kcol { background: var(--glass); border: 1px solid var(--line); border-radius: 16px; padding: 14px; min-height: 320px; }
+  .kcol .kh { display:flex; align-items:center; gap:8px; margin-bottom: 12px; font-size: 13px; font-weight: 700; }
+  .kcol .kh .dot { width:9px; height:9px; border-radius:999px; }
+  .kcol .kh .n { margin-inline-start:auto; font-size:11px; color: var(--faint); background: rgba(0,0,0,.25); border-radius:999px; padding:1px 8px; }
+  .task { background: #fff; color:#1b2430; border-radius:12px; padding: 12px; margin-bottom: 10px; box-shadow: 0 8px 22px -16px rgba(0,0,0,.8); border:1px solid rgba(0,0,0,.05); cursor: default; transition: transform .15s; animation: cardin .4s both; }
+  .task:hover { transform: translateY(-2px); }
+  .task .tt { font-size: 13.5px; font-weight: 650; }
+  .task .tm { display:flex; align-items:center; justify-content: space-between; margin-top: 10px; }
+  .task .status { font-size: 10px; font-weight: 700; border-radius: 6px; padding: 2px 8px; }
+
+  /* ── Prompt bar ───────────────────────────────────────────────── */
+  .promptbar {
+    background: var(--glass); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 14px 16px; display: flex; align-items: center; gap: 14px;
+  }
+  .promptbar .pt {
+    flex: 1; font-family: var(--mono); font-size: 12px; line-height: 1.6; color: #c7d2da;
+    max-height: 84px; overflow-y: auto;
+  }
+  .promptbar .pt b { color: var(--emerald); font-weight: 600; }
+  .copy {
+    flex: none; cursor: pointer; font-family: inherit; font-weight: 650; font-size: 12.5px;
+    border-radius: 11px; padding: 11px 16px; border: 1px solid transparent; color: #05140d;
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep));
+    box-shadow: 0 10px 26px -12px rgba(37,211,102,.8); transition: .16s;
+  }
+  .copy:hover { transform: translateY(-1px); }
+  .copy.done { background: var(--glass-2); color: var(--ink); box-shadow:none; border-color: var(--line); }
+
+  /* ── animations ───────────────────────────────────────────────── */
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.96); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(14px) scale(.94); } to { opacity: 1; transform: none; } }
+  @keyframes cardout { to { opacity: 0; transform: translateY(8px) scale(.9); } }
+  @keyframes blink { 0%, 60%, 100% { opacity: .3; transform: translateY(0);} 30% { opacity: 1; transform: translateY(-3px);} }
+  @keyframes nudge { 0%,100% { transform: translateY(0);} 50% { transform: translateY(6px);} }
+
+  @media (max-width: 1080px) {
+    .app { grid-template-columns: 1fr; grid-template-rows: auto 1fr; overflow:auto; height:auto; min-height:100vh; }
+    body { overflow: auto; }
+    .view-switch { width: auto; }
+  }
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- ── CONTROLS ─────────────────────────────────────────────── -->
+  <aside class="panel controls">
+    <div class="brand">
+      <div class="logo">🏠</div>
+      <div>
+        <h1>HomeOS · מגרש משחקים</h1>
+        <p>סיפורי משתמש + תצוגת UI · WhatsApp-first · עברית RTL</p>
+      </div>
+    </div>
+
+    <div class="group">
+      <div class="label"><span>סיפור משתמש</span><span>User story</span></div>
+      <div id="scnList"></div>
+    </div>
+
+    <div class="group">
+      <div class="label"><span>תצוגה</span><span>View</span></div>
+      <div class="seg" id="viewSeg">
+        <button data-view="whatsapp" aria-pressed="true">💬 WhatsApp</button>
+        <button data-view="tablet" aria-pressed="false">📺 לוח מטבח</button>
+        <button data-view="tasks" aria-pressed="false">✅ משימות</button>
+      </div>
+    </div>
+
+    <div class="group" id="transportGroup">
+      <div class="label"><span>הדגמת השיחה</span><span>Playback</span></div>
+      <div class="transport">
+        <button class="btn" id="prevBtn">‹ אחורה</button>
+        <button class="btn primary" id="playBtn">▶ הדגמה</button>
+        <button class="btn" id="nextBtn">קדימה ›</button>
+      </div>
+      <div class="hint" id="stepHint"></div>
+    </div>
+
+    <div class="group">
+      <div class="label"><span>בני המשפחה</span><span>Family</span></div>
+      <div class="fam" id="famChips"></div>
+    </div>
+
+    <div class="hint" style="margin-top:auto">
+      💡 בחרו סיפור, נגנו את ההדגמה, והחליפו ל<b>לוח המטבח</b> כדי לראות איך הפריט נוחת על הלוח.
+      העתיקו את ההנחיה למטה כדי לבנות את ה‑UI האמיתי.
+    </div>
+  </aside>
+
+  <!-- ── STAGE ────────────────────────────────────────────────── -->
+  <main class="stage">
+    <div class="stage-head">
+      <div class="stage-title">
+        <h2 id="stTitle"></h2>
+        <p id="stSub"></p>
+      </div>
+      <div class="view-switch"></div>
+    </div>
+
+    <section class="stage-body" id="stage"></section>
+
+    <div class="promptbar">
+      <div class="pt" id="promptOut"></div>
+      <button class="copy" id="copyBtn">📋 העתק הנחיה</button>
+    </div>
+  </main>
+</div>
+
+<script>
+/* ── Family roster ─────────────────────────────────────────────── */
+const FAM = {
+  aba:  { he:"אבא",  init:"א", color:"#5aa9e6" },
+  ima:  { he:"אמא",  init:"א", color:"#e8748a" },
+  yoav: { he:"יואב", init:"י", color:"#f5a623" },
+  noa:  { he:"נועה", init:"נ", color:"#2dd4bf" },
+};
+const av = (k, big) => {
+  const f = FAM[k]; if (!f) return "";
+  const cls = big ? "mini-av" : "mini-av";
+  return `<span class="${cls}" style="background:${f.color}">${f.init}</span>`;
+};
+
+/* ── Scenarios ─────────────────────────────────────────────────── */
+const SCN = {
+  "forward-school": {
+    ico:"🏫", tt:"העברת הודעה מבית הספר", sb:"הורה מעביר הודעת WhatsApp מהגן → אירוע על הלוח",
+    title:"מעבירים הודעה — היא הופכת לאירוע",
+    sub:"הזרימה היחידה שצריך ללמד את המשפחה: forward → אישור בעברית.",
+    chat:[
+      { kind:"out", fwd:"הועבר", body:"הורים יקרים 🌿 אסיפת הורים תתקיים ביום חמישי 18/6 בשעה 17:00 בגן רימון. נא לאשר הגעה. תודה, צוות הגן", time:"21:34" },
+      { kind:"typing" },
+      { kind:"bot", body:"הוספתי ליומן ✓\nאסיפת הורים · יום חמישי, 18 ביוני · 17:00 — גן רימון", time:"21:34" },
+    ],
+    cardAtStep:2,
+    card:{ kindHe:"אירוע", glyph:"📅", color:"#5aa9e6", title:"אסיפת הורים",
+      rows:[["📍","גן רימון"],["🗓️","יום חמישי, 18 ביוני"],["⏰","17:00"]], who:"ima" },
+  },
+  "direct-command": {
+    ico:"🗣️", tt:"פקודה בשפה חופשית", sb:"לא רק העברה — לכתוב ישירות לבוט בגוף ראשון",
+    title:"פקודה ישירה — גוף ראשון הופך לאחראי",
+    sub:"\"יש לי…\" → ה‑assignee הוא השולח (מתוך מפת MEMBERS, server-supplied).",
+    chat:[
+      { kind:"out", body:"יש לי פיזיותרפיה ביום שני, תכניס ליומן", time:"08:12" },
+      { kind:"typing" },
+      { kind:"bot", body:"הוספתי ליומן ✓\nפיזיותרפיה · יום שני, 22 ביוני — אבא", time:"08:12" },
+    ],
+    cardAtStep:2,
+    card:{ kindHe:"משימה", glyph:"🩺", color:"#f5a623", title:"פיזיותרפיה",
+      rows:[["🗓️","יום שני, 22 ביוני"],["👤","אבא (השולח)"]], who:"aba" },
+  },
+  "undo": {
+    ico:"↩️", tt:"ביטול (Undo)", sb:"טעות בפענוח? מילה אחת מחזירה את המצב",
+    title:"ביטול — שחזור מטעות בלחיצה אחת",
+    sub:"\"ביטול\" נתפס לפני המודל — מוחק את אירועי ההודעה האחרונה.",
+    chat:[
+      { kind:"out", body:"אסיפת הורים מחר ב-17:00", time:"21:40" },
+      { kind:"bot", body:"הוספתי ליומן ✓\nאסיפת הורים · יום חמישי, 18 ביוני · 17:00", time:"21:40" },
+      { kind:"out", body:"ביטול", time:"21:41" },
+      { kind:"bot", body:"בוטל ✓", time:"21:41" },
+    ],
+    cardAtStep:1, cardRemovedAtStep:3,
+    card:{ kindHe:"אירוע", glyph:"📅", color:"#5aa9e6", title:"אסיפת הורים",
+      rows:[["🗓️","יום חמישי, 18 ביוני"],["⏰","17:00"]], who:"ima" },
+  },
+  "daily-cap": {
+    ico:"🛡️", tt:"מכסת הודעות יומית (G16)", sb:"גבול עלות לכל שולח — שומר על ≤$100 לחודש",
+    title:"מכסה יומית לכל שולח — בלם עלות",
+    sub:"allowlist מגביל מי, גבול אורך מגביל גודל, וזה מגביל קצב — לפני כל קריאה ל‑Claude.",
+    chat:[
+      { kind:"out", body:"תזכורת לחלב 🥛", time:"23:01" },
+      { kind:"out", body:"וגם ביצים", time:"23:01" },
+      { kind:"out", body:"... (הודעה 51 היום)", time:"23:02" },
+      { kind:"typing" },
+      { kind:"bot", body:"הגעת למכסת ההודעות היומית 🙏 נמשיך מחר.", time:"23:02" },
+    ],
+    cardAtStep:4, capCard:true,
+  },
+  "gmail-calendar": {
+    ico:"📧", ph:"5", tt:"סנכרון Gmail + יומן Google", sb:"מקורות נוספים מעבר ל‑WhatsApp",
+    title:"Phase 5 — Gmail + Google Calendar",
+    sub:"מייל מהגן → אירוע; סנכרון דו‑כיווני ליומן Google. כלי נוסף שמתחבר ל‑registry של הסוכן.",
+    chat:[
+      { kind:"in", body:"✉️ Gmail · גן רימון\nנושא: טיול שנתי — יום ג׳ 23/6, להביא כובע ומים", time:"09:00" },
+      { kind:"typing" },
+      { kind:"bot", body:"הוספתי ליומן ✓ (מ‑Gmail)\nטיול שנתי · יום שלישי, 23 ביוני 🎒\nסונכרן ל‑Google Calendar ↗", time:"09:00" },
+    ],
+    cardAtStep:2, soon:true,
+    card:{ kindHe:"אירוע · Gmail", glyph:"🎒", color:"#2dd4bf", title:"טיול שנתי",
+      rows:[["🗓️","יום שלישי, 23 ביוני"],["🎒","כובע + מים"],["↗","סונכרן ליומן Google"]], who:"yoav" },
+  },
+};
+const SCN_ORDER = ["forward-school","direct-command","undo","daily-cap","gmail-calendar"];
+
+/* ── Board data (kitchen tablet) ───────────────────────────────── */
+const APPTS = [
+  { time:"08:00", t:"הסעה לבית הספר", who:["yoav"], tag:"אבא מסיע", color:"#5aa9e6" },
+  { time:"14:30", t:"איסוף מהצהרון", who:["noa"], tag:"אמא אוספת", color:"#e8748a" },
+  { time:"17:00", t:"אסיפת הורים", who:["ima"], tag:"גן רימון", color:"#5aa9e6", scn:"forward-school" },
+  { time:"18:00", t:"פיזיותרפיה", who:["aba"], tag:"", color:"#f5a623", scn:"direct-command" },
+  { time:"19:00", t:"חוג כדורגל", who:["yoav"], tag:"", color:"#2dd4bf" },
+];
+const REMIND = [
+  { t:"לשלם תשלום לבית הספר", done:false, who:["aba"] },
+  { t:"לחדש מרשם לרופא", done:false, who:["ima"] },
+  { t:"לקנות מתנה ליום הולדת של נועה", done:true, who:["ima"] },
+];
+const TASKS = {
+  todo:[ {t:"קניות לשבת", who:"ima"}, {t:"תשלום ארנונה", who:"aba"} ],
+  doing:[ {t:"לתאם רופא שיניים ליואב", who:"ima"} ],
+  done:[ {t:"להזמין שולחן למסעדה", who:"aba"} ],
+};
+
+/* ── State ─────────────────────────────────────────────────────── */
+const state = {
+  scn: "forward-school",
+  view: "whatsapp",
+  step: 0,
+  fam: { aba:true, ima:true, yoav:true, noa:true },
+  playing: false,
+};
+let playTimer = null;
+
+/* ── Build controls ────────────────────────────────────────────── */
+const scnList = document.getElementById("scnList");
+scnList.innerHTML = SCN_ORDER.map(id => {
+  const s = SCN[id];
+  return `<button class="scn" data-scn="${id}" aria-pressed="${id===state.scn}" style="margin-bottom:8px">
+    <span class="ico">${s.ico}</span>
+    <span style="flex:1">
+      <span class="tt">${s.tt}</span>
+      <span class="sb">${s.sb}</span>
+    </span>
+    ${s.soon ? '<span class="soon">בקרוב</span>' : ''}
+  </button>`;
+}).join("");
+
+const famChips = document.getElementById("famChips");
+famChips.innerHTML = Object.keys(FAM).map(k =>
+  `<button class="chip" data-fam="${k}" aria-pressed="true">
+    <span class="av" style="background:${FAM[k].color}">${FAM[k].init}</span>${FAM[k].he}
+  </button>`
+).join("");
+
+/* ── Renderers ─────────────────────────────────────────────────── */
+const stage = document.getElementById("stage");
+
+function maxStep() { return SCN[state.scn].chat.length - 1; }
+
+function renderHead() {
+  const s = SCN[state.scn];
+  document.getElementById("stTitle").textContent = s.title;
+  document.getElementById("stSub").textContent = s.sub;
+  document.getElementById("transportGroup").style.display = state.view === "whatsapp" ? "" : "none";
+  const last = maxStep();
+  document.getElementById("stepHint").innerHTML =
+    `שלב <b>${Math.min(state.step+1, last+1)}</b> מתוך <b>${last+1}</b>`;
+  document.getElementById("prevBtn").disabled = state.step <= 0;
+  document.getElementById("nextBtn").disabled = state.step >= last;
+}
+
+function chatBubble(m) {
+  if (m.kind === "typing") return `<div class="typing"><span></span><span></span><span></span></div>`;
+  if (m.kind === "bot") return `<div class="bubble bot">
+      <div class="botbadge">🏠 HomeOS</div><div class="body">${esc(m.body)}</div>
+      <div class="meta">${m.time||""} ✓✓</div></div>`;
+  if (m.kind === "in") return `<div class="bubble in"><div class="body">${esc(m.body)}</div><div class="meta">${m.time||""}</div></div>`;
+  // out
+  return `<div class="bubble out">
+    ${m.fwd ? `<div class="fwd">↪ ${m.fwd}</div>` : ""}
+    <div class="body">${esc(m.body)}</div>
+    <div class="meta">${m.time||""} <span class="tick">✓✓</span></div></div>`;
+}
+
+function renderWhatsApp() {
+  const s = SCN[state.scn];
+  const shown = s.chat.slice(0, state.step + 1);
+  const bubbles = shown.map(chatBubble).join("");
+
+  // resulting card logic
+  let cardHtml = `<div class="flow-arrow" style="opacity:.4"><div class="cap">נגנו את ההדגמה כדי לראות את התוצאה ◀</div></div>`;
+  const reached = state.step >= (s.cardAtStep ?? 99);
+  if (reached && s.capCard) {
+    cardHtml = `<div class="pill-cap">🛡️ <b>מכסת הודעות יומית (G16)</b><br>
+      ה‑allowlist מגביל <b>מי</b>, גבול האורך מגביל <b>גודל</b>, וזה מגביל <b>קצב</b>.<br>
+      ההודעה ה‑51 לא נשלחת ל‑Claude — מענה שקט בעברית, ואיפוס בחצות (Asia/Jerusalem).</div>`;
+  } else if (reached && s.card) {
+    const c = s.card;
+    const removed = s.cardRemovedAtStep != null && state.step >= s.cardRemovedAtStep;
+    cardHtml = `<div class="card-stage">
+      <div class="lbl">הכרטיס שנוצר על הלוח</div>
+      <div class="ecard ${removed ? 'gone' : ''}">
+        <div class="stripe" style="background:${c.color}"></div>
+        <div class="kind">${c.glyph} ${c.kindHe}</div>
+        <h3>${c.title}</h3>
+        ${c.rows.map(r=>`<div class="row"><span class="gl">${r[0]}</span>${esc(r[1])}</div>`).join("")}
+        <div class="foot">
+          <span class="added">${removed ? '↩️ בוטל' : '✓ נוסף ליומן'}</span>
+          ${c.who ? `<span style="display:flex;gap:6px;align-items:center;font-size:12px;color:#56616f">${av(c.who)} ${FAM[c.who].he}</span>`:''}
+        </div>
+      </div>
+      ${removed ? `<div class="hint" style="color:#e8748a">מילת ה‑"ביטול" מחקה את אירועי ההודעה האחרונה — לפני שהיא נשלחת ל‑Claude.</div>`:''}
+    </div>`;
+  }
+
+  stage.innerHTML = `<div class="wa-wrap">
+    <div class="phone"><div class="screen">
+      <div class="wa-head">
+        <div class="bot-av">🏠</div>
+        <div><div class="nm">HomeOS</div><div class="st">בוט משפחתי · מקוון</div></div>
+        <div class="dots">⋮</div>
+      </div>
+      <div class="wa-body" id="waBody">
+        <div class="day-pill">היום</div>
+        ${bubbles}
+      </div>
+      <div class="wa-input">
+        <div class="box">הקלידו הודעה…</div>
+        <div class="send">➤</div>
+      </div>
+    </div></div>
+    ${cardHtml}
+  </div>`;
+  const body = document.getElementById("waBody");
+  if (body) body.scrollTop = body.scrollHeight;
+}
+
+function famOn(list){ return !list || list.some(k => state.fam[k]); }
+
+function renderTablet() {
+  const activeScn = SCN[state.scn];
+  const justAdded = activeScn && activeScn.card ? state.scn : null;
+
+  const appts = APPTS.filter(a => famOn(a.who)).map(a => {
+    const glow = a.scn && a.scn === justAdded;
+    return `<div class="appt ${glow?'glow':''}">
+      <div class="time">${a.time}</div>
+      <div class="bar" style="background:${a.color}"></div>
+      <div class="ct">
+        <div class="t">${a.t}</div>
+        <div class="m">
+          ${a.who.map(w=>`<span style="display:inline-flex;gap:5px;align-items:center">${av(w)}${FAM[w].he}</span>`).join("")}
+          ${a.tag?`<span class="tag">${a.tag}</span>`:""}
+          ${glow?`<span class="justadded">נוסף עכשיו</span>`:""}
+        </div>
+      </div>
+    </div>`;
+  }).join("") || `<div class="hint" style="color:#a59c8b">אין פריטים לבני המשפחה שנבחרו</div>`;
+
+  const reminders = REMIND.filter(r=>famOn(r.who)).map(r =>
+    `<div class="remind ${r.done?'done':''}"><div class="bx"></div><span>${r.t}</span></div>`
+  ).join("");
+
+  stage.innerHTML = `<div class="tablet"><div class="tboard">
+    <div class="tbar">
+      <div class="greet">בוקר טוב, משפחת לוי 🌅<small>יום רביעי, 17 ביוני 2026</small></div>
+      <div class="clock">07:42</div>
+      <div class="hcal"><b>כ״ב בְּסִיוָן תשפ״ו</b><br>פרשת שלח · 3 ימים לשבת</div>
+    </div>
+    <div class="tgrid">
+      <div class="col">
+        <h4>📅 היום <span class="n">${APPTS.filter(a=>famOn(a.who)).length}</span></h4>
+        ${appts}
+      </div>
+      <div class="col">
+        <h4>🔔 תזכורות <span class="n">${REMIND.filter(r=>famOn(r.who)).length}</span></h4>
+        ${reminders}
+        <h4 style="margin-top:18px">👨‍👩‍👧‍👦 מי אוסף</h4>
+        <div class="remind"><span style="display:inline-flex;gap:6px;align-items:center">${av('aba')} אבא</span> <span class="tag">יואב · 08:00</span></div>
+        <div class="remind"><span style="display:inline-flex;gap:6px;align-items:center">${av('ima')} אמא</span> <span class="tag">נועה · 14:30</span></div>
+      </div>
+    </div>
+    <div class="tfoot">
+      <span class="weather">☀️ 29°C · תל אביב</span>
+      <span class="shab">🕯️ כניסת שבת 19:34 · שבת שלום</span>
+    </div>
+  </div></div>`;
+}
+
+function renderTasks() {
+  const justTitle = SCN[state.scn]?.card?.title;
+  const colDef = [
+    { key:"todo",  he:"לעשות",   dot:"#f5a623", st:"#fff7ec", stc:"#b97e12" },
+    { key:"doing", he:"בתהליך",  dot:"#5aa9e6", st:"#eaf4ff", stc:"#2f6fb0" },
+    { key:"done",  he:"הושלם",   dot:"#2c5e4f", st:"#e9f7f0", stc:"#1f7a5e" },
+  ];
+  const cols = colDef.map(c => {
+    const items = TASKS[c.key].filter(t => state.fam[t.who]);
+    return `<div class="kcol">
+      <div class="kh"><span class="dot" style="background:${c.dot}"></span>${c.he}<span class="n">${items.length}</span></div>
+      ${items.map(t=>`<div class="task">
+        <div class="tt">${t.t}</div>
+        <div class="tm">
+          <span style="display:flex;gap:6px;align-items:center;font-size:12px;color:#56616f">${av(t.who)} ${FAM[t.who].he}</span>
+          <span class="status" style="background:${c.st};color:${c.stc}">${c.he}</span>
+        </div>
+      </div>`).join("") || `<div class="hint" style="opacity:.5">—</div>`}
+    </div>`;
+  }).join("");
+  stage.innerHTML = `<div style="width:100%;max-width:980px">
+    <div class="hint" style="margin-bottom:14px">לוח משימות משפחתי — "monday.com לבית": משימה לכל אחד, סטטוס, אחראי. כל פריט שנוצר בוואטסאפ נוחת כאן או בלוח "היום".</div>
+    <div class="kanban">${cols}</div>
+  </div>`;
+}
+
+function render() {
+  renderHead();
+  if (state.view === "whatsapp") renderWhatsApp();
+  else if (state.view === "tablet") renderTablet();
+  else renderTasks();
+  updatePrompt();
+}
+
+/* ── Playback ──────────────────────────────────────────────────── */
+function stopPlay(){ state.playing=false; clearTimeout(playTimer); document.getElementById("playBtn").innerHTML="▶ הדגמה"; }
+function play() {
+  if (state.playing) { stopPlay(); return; }
+  state.playing = true;
+  document.getElementById("playBtn").innerHTML = "⏸ עצור";
+  state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) { stopPlay(); return; }
+    state.step++;
+    render();
+    const cur = SCN[state.scn].chat[state.step];
+    playTimer = setTimeout(tick, cur && cur.kind === "typing" ? 1100 : 1500);
+  };
+  tick();
+}
+
+/* ── Prompt output ─────────────────────────────────────────────── */
+function updatePrompt() {
+  const s = SCN[state.scn];
+  const viewHe = { whatsapp:"מסך WhatsApp (טלפון) עם כרטיס האירוע שנוצר",
+                   tablet:"לוח המטבח האמביינטי (טאבלט נחיתה) — תצוגת 'היום'",
+                   tasks:"לוח המשימות המשפחתי (קנבן בסגנון monday.com)" }[state.view];
+  const on = Object.keys(state.fam).filter(k=>state.fam[k]).map(k=>FAM[k].he);
+  const famTxt = on.length === 4 ? "כל המשפחה" : on.join(", ") || "אף אחד";
+  const parts = [];
+  parts.push(`בנה את ה‑UI של <b>HomeOS</b> — ${viewHe}`);
+  parts.push(`עבור סיפור המשתמש "<b>${s.tt}</b>": ${s.sub}`);
+  if (state.view === "whatsapp") parts.push(`הצג את שרשור ה‑WhatsApp (RTL) ולצדו את כרטיס האירוע שנוצר, עם אנימציית הופעה`);
+  if (state.view !== "whatsapp") parts.push(`מסונן ל: ${famTxt}`);
+  parts.push(`עברית RTL כשפה ראשונה, הקשר משפחה ישראלית (אבא/אמא/ילדים), אסתטיקה חמה (אמרלד+ענבר), זכוכית/צללים רכים, ≤$100 לחודש (Haiku), מובייל‑first`);
+  document.getElementById("promptOut").innerHTML = parts.join(". ") + ".";
+}
+
+/* ── Events ────────────────────────────────────────────────────── */
+scnList.addEventListener("click", e => {
+  const b = e.target.closest("[data-scn]"); if (!b) return;
+  stopPlay();
+  state.scn = b.dataset.scn; state.step = 0;
+  scnList.querySelectorAll(".scn").forEach(x => x.setAttribute("aria-pressed", x.dataset.scn === state.scn));
+  render();
+});
+document.getElementById("viewSeg").addEventListener("click", e => {
+  const b = e.target.closest("[data-view]"); if (!b) return;
+  state.view = b.dataset.view;
+  document.querySelectorAll("#viewSeg button").forEach(x => x.setAttribute("aria-pressed", x.dataset.view === state.view));
+  render();
+});
+famChips.addEventListener("click", e => {
+  const b = e.target.closest("[data-fam]"); if (!b) return;
+  const k = b.dataset.fam; state.fam[k] = !state.fam[k];
+  b.setAttribute("aria-pressed", state.fam[k]);
+  render();
+});
+document.getElementById("playBtn").addEventListener("click", play);
+document.getElementById("prevBtn").addEventListener("click", () => { stopPlay(); state.step = Math.max(0, state.step-1); render(); });
+document.getElementById("nextBtn").addEventListener("click", () => { stopPlay(); state.step = Math.min(maxStep(), state.step+1); render(); });
+
+document.getElementById("copyBtn").addEventListener("click", () => {
+  const txt = document.getElementById("promptOut").textContent;
+  navigator.clipboard.writeText(txt).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "✓ הועתק!"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 העתק הנחיה"; b.classList.remove("done"); }, 1600);
+  });
+});
+
+function esc(s){ return String(s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c])); }
+
+/* ── Boot ──────────────────────────────────────────────────────── */
+render();
+</script>
+</body>
+</html>

--- a/plugins/ork/skills/shared/assets/playground-exemplars/user-story-player.template.html
+++ b/plugins/ork/skills/shared/assets/playground-exemplars/user-story-player.template.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  USER-STORY PLAYER · generalized scaffold
+  OrchestKit playground exemplar — the "user-story-player" archetype.
+
+  Conforms to: skills/shared/rules/playground-visual-standard.md
+  Persona: warm-glass. Zero dependencies. Single file. LTR with RTL-ready
+  CSS logical properties (toggle dir="rtl" on <html> and it mirrors).
+
+  WHAT THIS IS
+  ------------
+  A clean-room, de-branded version of the HomeOS gold standard
+  (homeos-arieh.html). It plays a user story inside a high-fidelity device
+  mockup, draws a cause→effect flow arrow to the resulting card, and emits a
+  copy-prompt. Replace STORY + the device chrome with your product's and keep
+  the engine.
+
+  THREE MOVES that make it a "player", not a screenshot:
+    1. DEVICE MOCKUP   — a real phone frame (notch, bezel, screen radius).
+    2. TRANSPORT       — ▶ play / ‹ prev / next › steps through the story.
+    3. FLOW ARROW      — connects the trigger to the effect it produces.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>User-Story Player · Playground</title>
+<style>
+  /* ── §2 tokens (warm-glass persona, HSL) ────────────────────────────── */
+  :root {
+    --pg-bg: hsl(20 14% 7%);
+    --pg-ink: hsl(28 20% 94%);
+    --pg-muted: hsl(28 10% 64%);
+    --pg-faint: hsl(28 8% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(160 68% 45%);     /* emerald primary */
+    --pg-accent-deep: hsl(166 70% 30%);
+    --pg-warm: hsl(38 95% 60%);        /* amber secondary */
+    --pg-shadow: 0 20px 60px -22px hsl(20 40% 2% / 0.7), 0 4px 12px -6px hsl(20 40% 2% / 0.5);
+    --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(160 68% 45% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(38 95% 60% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+  .head { display: flex; align-items: flex-start; gap: 14px; }
+  .logo { width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: 0 8px 22px -8px hsl(160 68% 40% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 62ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+
+  /* transport */
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 11px; padding: 10px 14px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink); transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent; color: hsl(160 40% 8%); box-shadow: 0 10px 26px -12px hsl(160 68% 40% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; }
+  .hint b { color: var(--pg-muted); }
+
+  /* stage: phone + flow arrow + result card */
+  .stage { padding: 26px; display: flex; gap: 30px; align-items: center; justify-content: center; flex-wrap: wrap; }
+
+  .phone { width: 300px; height: 600px; border-radius: 54px; padding: 12px; flex: none; position: relative;
+    background: linear-gradient(160deg, hsl(20 12% 16%), hsl(20 16% 7%)); box-shadow: var(--pg-shadow), inset 0 0 0 2px hsl(0 0% 100% / 0.06); }
+  .phone::after { content: ""; position: absolute; top: 16px; left: 50%; transform: translateX(-50%); width: 110px; height: 24px; background: hsl(20 30% 3%); border-radius: 0 0 16px 16px; z-index: 5; }
+  .screen { height: 100%; border-radius: 42px; overflow: hidden; display: flex; flex-direction: column; background: hsl(195 30% 8%); }
+  .app-head { padding: 16px 14px 12px; display: flex; align-items: center; gap: 11px; background: hsl(195 24% 13%); }
+  .app-head .av { width: 38px; height: 38px; border-radius: 999px; flex: none; display: grid; place-items: center; font-size: 18px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .app-head .nm { font-size: 14px; font-weight: 650; }
+  .app-head .st { font-size: 11px; color: hsl(195 14% 60%); margin-top: 1px; }
+  .body { flex: 1; overflow-y: auto; padding: 16px 12px; display: flex; flex-direction: column; gap: 8px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .bubble { max-width: 82%; padding: 8px 11px; border-radius: 12px; font-size: 13px; line-height: 1.45; animation: pop var(--pg-dur-normal) var(--pg-ease) both; }
+  .bubble.out { align-self: flex-end; background: hsl(160 50% 22%); color: hsl(150 60% 92%); border-end-end-radius: 4px; }
+  .bubble.bot { align-self: flex-start; background: hsl(195 20% 16%); border: 1px solid hsl(160 68% 45% / 0.3); border-end-start-radius: 4px; }
+  .bubble .who { font-size: 9px; font-weight: 800; letter-spacing: .4px; color: var(--pg-accent); margin-bottom: 3px; }
+  .typing { align-self: flex-start; background: hsl(195 20% 16%); padding: 11px 13px; border-radius: 12px; border-end-start-radius: 4px; display: inline-flex; gap: 4px; }
+  .typing span { width: 7px; height: 7px; border-radius: 999px; background: hsl(195 14% 50%); animation: blink 1.2s infinite both; }
+  .typing span:nth-child(2) { animation-delay: .2s; } .typing span:nth-child(3) { animation-delay: .4s; }
+
+  /* flow arrow (RTL-sensitive — flips via scaleX) */
+  .arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--pg-muted); }
+  .arrow .ar { font-size: 30px; color: var(--pg-accent); }
+  [dir="rtl"] .arrow .ar { transform: scaleX(-1); }
+  .arrow .cap { font-size: 11px; max-width: 120px; text-align: center; line-height: 1.5; }
+
+  .card { width: 250px; background: #fff; color: hsl(215 25% 16%); border-radius: var(--pg-r-md); padding: 16px; position: relative; overflow: hidden; box-shadow: var(--pg-shadow); animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .card .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; background: var(--pg-accent); }
+  .card .kind { font-size: 10.5px; font-weight: 700; letter-spacing: .3px; color: hsl(215 12% 45%); text-transform: uppercase; }
+  .card h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
+  .card .row { display: flex; gap: 8px; font-size: 13px; color: hsl(215 16% 28%); margin-top: 6px; }
+  .card .added { margin-top: 13px; padding-top: 12px; border-top: 1px dashed hsl(215 16% 88%); font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+  .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
+
+  /* copy-prompt bar */
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
+  .promptbar .pt b { color: var(--pg-accent); }
+  .copy { flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(160 40% 8%); border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: 0 10px 26px -12px hsl(160 68% 40% / 0.8); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.96); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(14px) scale(.94); } to { opacity: 1; transform: none; } }
+  @keyframes blink { 0%,60%,100% { opacity: .3; } 30% { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  }
+  @media (max-width: 720px) { .arrow .ar { transform: rotate(90deg); } [dir="rtl"] .arrow .ar { transform: rotate(90deg) scaleX(-1); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="head">
+    <div class="logo">▶️</div>
+    <div>
+      <h1>User-Story Player</h1>
+      <p>Press <b>Play</b> to watch the story unfold inside the device, then see the
+         <b>result card</b> it produces. This is the scaffold for any feature demo — swap the
+         <code>STORY</code> data and the device chrome for your product.</p>
+    </div>
+    <div class="right"><button class="toggle" id="dirToggle" aria-pressed="false">⇄ RTL</button></div>
+  </header>
+
+  <div class="panel transport">
+    <button class="btn" id="prev">‹ Back</button>
+    <button class="btn primary" id="play">▶ Play</button>
+    <button class="btn" id="next">Next ›</button>
+    <span class="hint" id="stepHint"></span>
+  </div>
+
+  <main class="panel stage" id="stage"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">📋 Copy prompt</button>
+  </div>
+</div>
+
+<script>
+/* ═══════════ STORY — replace with your product's flow ═══════════════════
+   Each step is one chat turn. `cardAtStep` is when the result card appears. */
+const STORY = {
+  appName: "Acme Assistant",
+  appStatus: "online",
+  title: "Forward a message → it becomes a scheduled task",
+  steps: [
+    { kind: "out", who: "", body: "Forwarded: \"Team offsite next Thursday 2pm at the rooftop. RSVP please.\"" },
+    { kind: "typing" },
+    { kind: "bot", who: "Acme Assistant", body: "Added to your calendar ✓\nTeam offsite · Thursday · 2:00 PM — Rooftop" },
+  ],
+  cardAtStep: 2,
+  card: { kind: "Event", title: "Team offsite", rows: ["🗓️ Thursday, 2:00 PM", "📍 Rooftop", "👥 RSVP requested"] },
+};
+
+const state = { step: 0, playing: false, rtl: false };
+let timer = null;
+const stage = document.getElementById("stage");
+const esc = s => String(s).replace(/[&<>]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+const maxStep = () => STORY.steps.length - 1;
+
+function bubble(m) {
+  if (m.kind === "typing") return `<div class="typing"><span></span><span></span><span></span></div>`;
+  if (m.kind === "bot") return `<div class="bubble bot"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`;
+  return `<div class="bubble out">${esc(m.body)}</div>`;
+}
+
+function render() {
+  const shown = STORY.steps.slice(0, state.step + 1).map(bubble).join("");
+  const reached = state.step >= STORY.cardAtStep;
+  const c = STORY.card;
+  const result = reached
+    ? `<div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
+         <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
+         <div class="added">✓ Added</div></div>`
+    : `<div class="placeholder">Play the story to see the card it creates ◀</div>`;
+
+  stage.innerHTML = `
+    <div class="phone"><div class="screen">
+      <div class="app-head"><div class="av">🤖</div>
+        <div><div class="nm">${esc(STORY.appName)}</div><div class="st">${esc(STORY.appStatus)}</div></div></div>
+      <div class="body" id="body">${shown}</div>
+    </div></div>
+    <div class="arrow"><div class="ar">➜</div><div class="cap">the message becomes a card</div></div>
+    ${result}`;
+  const b = document.getElementById("body"); if (b) b.scrollTop = b.scrollHeight;
+
+  document.getElementById("stepHint").innerHTML = `Step <b>${state.step + 1}</b> of <b>${maxStep() + 1}</b>`;
+  document.getElementById("prev").disabled = state.step <= 0;
+  document.getElementById("next").disabled = state.step >= maxStep();
+  updatePrompt();
+}
+
+function updatePrompt() {
+  document.getElementById("promptOut").innerHTML =
+    `Build the <b>${esc(STORY.appName)}</b> UI for the user story "<b>${esc(STORY.title)}</b>": show the `
+    + `chat thread inside a phone mockup, and animate the resulting <b>${esc(STORY.card.kind)}</b> card appearing beside it.`;
+}
+
+function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }
+function play() {
+  if (state.playing) return stop();
+  state.playing = true; document.getElementById("play").innerHTML = "⏸ Pause"; state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) return stop();
+    state.step++; render();
+    const cur = STORY.steps[state.step];
+    timer = setTimeout(tick, cur && cur.kind === "typing" ? 1000 : 1400);
+  };
+  tick();
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => { stop(); state.step = Math.max(0, state.step - 1); render(); });
+document.getElementById("next").addEventListener("click", () => { stop(); state.step = Math.min(maxStep(), state.step + 1); render(); });
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl; document.documentElement.dir = state.rtl ? "rtl" : "ltr"; e.currentTarget.setAttribute("aria-pressed", state.rtl);
+});
+document.getElementById("copyBtn").addEventListener("click", () => {
+  navigator.clipboard.writeText(document.getElementById("promptOut").textContent).then(() => {
+    const b = document.getElementById("copyBtn"); b.textContent = "✓ Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 Copy prompt"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+render();
+</script>
+</body>
+</html>

--- a/plugins/ork/skills/shared/rules/_sections.md
+++ b/plugins/ork/skills/shared/rules/_sections.md
@@ -30,3 +30,11 @@ Prompt-injection defense for skills that read untrusted GitHub/CI content (ci-se
 fix-issue, review-pr) — separate the agent that reads untrusted text from the one that acts.
 
 - `untrusted-input-quarantine.md` — reader/actor split, structured-facts contract, per-skill bindings
+
+## 5. Playground Visual Quality (playground) — HIGH — 1 rule
+
+Falsifiable design standard for the *visual* playgrounds OrchestKit emits (create-pr gate,
+visualize-plan) — device-mockup user-story players and drag-and-drop decision boards. Exemplars
+live in `../assets/playground-exemplars/`.
+
+- `playground-visual-standard.md` — §0 archetype routing, HSL tokens, glass do/don't, motion budget, drag-and-drop accessibility, RTL, anti-generic checklist

--- a/plugins/ork/skills/shared/rules/playground-visual-standard.md
+++ b/plugins/ork/skills/shared/rules/playground-visual-standard.md
@@ -1,0 +1,193 @@
+---
+title: "Playground Visual Standard"
+impact: HIGH
+impactDescription: "Governs the visual quality of every playground OrchestKit emits. The difference between a considered product demo and a generic AI dashboard is the specific values in this file."
+tags: [playground, design, visual, frontend, ui, drag-and-drop, glassmorphism, rtl]
+---
+
+# Playground Visual Standard
+
+<!-- Sync rule: edit this standard and its exemplars in assets/playground-exemplars/ in the SAME PR (colocation). -->
+
+> **Load when:** generating a single-file HTML playground that demonstrates a feature, user story,
+> flow, or decision — i.e. a *visual* playground.
+> **Skip for:** plan/config/data/architecture dashboards (their current card layout is fine).
+
+A playground is not a slide. It is a thing the viewer can *operate*: play a user story, or make a
+decision by dragging. This standard makes that quality reproducible. Every rule carries a concrete,
+falsifiable value — a rule without a measurable threshold is not shippable.
+
+Reference exemplars (read the one matching your archetype before building):
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/assets/playground-exemplars/`
+- `homeos-arieh.html` — canonical gold standard (user-story player, RTL Hebrew). Study the bar.
+- `user-story-player.template.html` — generalized player scaffold (device mockup + transport + flow).
+- `decision-board.template.html` — drag-and-drop prioritization toolkit (the decision archetype).
+
+---
+
+## §0 Routing rule — does this standard apply?
+
+Decision, not vibe. Count the signals:
+
+```
+PLAYGROUND (apply this standard) if ≥2 are true:
+  □ device mockup (phone/tablet/app frame)     □ playback / step controls (▶ prev next)
+  □ cause→effect flow arrows                    □ narrative user-story copy
+  □ drag-and-drop decision surface              □ copy-prompt bar ("build / decide" affordance)
+
+Then pick ONE archetype:
+  • USER-STORY PLAYER  → the playground plays a flow over ≥2 steps/screens
+  • DECISION BOARD     → the core is prioritization/management via drag-and-drop
+  • (neither, <2 signals) → DASHBOARD → this standard does NOT apply; keep today's behavior
+```
+
+---
+
+## §1 Persona — pick one, up front, and don't mix
+
+Aesthetic primes emotion in <100ms, before content is read. The frame's persona is the first
+*functional* decision.
+
+- **warm-glass** ("warm intelligence") — amber/emerald accents, frosted surfaces, rounded. Default
+  for consumer/family/approachable products. Matches the HomeOS reference.
+- **cool-glass** ("technical precision") — indigo/violet/teal accents, tighter radii. For
+  developer/enterprise/data products.
+
+**Don't** mix warm and cool accents in one playground. **Don't** spend your one bold move on more
+than one place (§3).
+
+---
+
+## §2 Design tokens
+
+Define as CSS custom properties prefixed `--pg-`. **Use HSL, not hex** — you can derive a lighter
+shade from `hsl(248 84% 68%)` by hand; you cannot from `#7c6cf0`. Every color carries a **role**.
+
+| Token | Example (cool) | Role |
+|---|---|---|
+| `--pg-bg` | `hsl(232 26% 7%)` | Page background (rich + dark, ≤8% L — never `#000`) |
+| `--pg-ink` | `hsl(220 18% 93%)` | Primary text (never pure white) |
+| `--pg-muted` / `--pg-faint` | `…64%` / `…46%` | Secondary / tertiary text |
+| `--pg-glass` / `--pg-glass-2` | `hsl(0 0% 100% / .05)` / `.08` | Glass fill (see §5) |
+| `--pg-glass-edge` | `hsl(0 0% 100% / .18)` | Glass border |
+| `--pg-accent` (+`-deep`) | `hsl(248 84% 68%)` | Primary action / active state / flow arrow |
+| `--pg-warm` | `hsl(38 95% 60%)` | Secondary accent |
+
+- **Spacing:** only `4 · 8 · 12 · 16 · 24 · 48 · 96`. No `13px`, no `22px`.
+- **Radius:** `sm 9px · md 16px · lg 24px · device-bezel 40px · device-outer 54px`. Glass cards ≥16px.
+- **Shadow (two-part, §5):** ambient `0 20px 60px -22px hsl(… / .7)` + tight `0 4px 12px -6px hsl(… / .5)`.
+- **Motion:** exactly four durations — `100 / 200 / 300 / 500ms`, ease `cubic-bezier(.2,.8,.25,1)` (§6).
+- **Gradient mesh background:** 2–3 radial-gradients in accent hues over `--pg-bg`, with
+  `background-attachment: fixed`. **Hue span ≤30°** across the mesh — wider reads as garish.
+
+---
+
+## §3 Visual hierarchy — emphasize by de-emphasizing
+
+The most-violated rule in generic AI playgrounds: everything competes at full strength.
+
+- **Do** assign every element a tier before styling: Primary (the mockup / the board), Secondary
+  (transport / controls), Tertiary (copy-prompt bar / metadata).
+- **Values:** competing elements drop to ~60% opacity or `--pg-faint`; remove their borders. Primary
+  text weight 600–700; tertiary 400.
+- **Don't** give two elements the same visual weight and expect one to read as primary.
+
+---
+
+## §4 Typography
+
+- **Do** set roles: a display face used with restraint, a body face, a mono utility face for
+  values/code. Letter-spacing `-.2px…-.3px` on headings; tabular-nums on any live numbers.
+- **Don't** treat type as a neutral delivery vehicle — it carries the persona.
+
+---
+
+## §5 Glass system
+
+Glass reads as glass only against a dark, contrasted backdrop with a visible edge.
+
+- **Do:** fill `rgba(255,255,255, .05–.12)`; 1px border `rgba(255,255,255, .15–.25)`;
+  `backdrop-filter: blur(12–20px)` (+ `-webkit-` prefix); top-left light source
+  (inset `0 1px 0 rgba(255,255,255,.1–.2)`); the §2 two-part shadow.
+- **Don't:** glass on a light background (invisible); >2 stacked glass layers; radius <16px; a glow
+  halo (`box-shadow: 0 0 40px accent` = the "generic AI glowing card"); glass as a hierarchy signal.
+
+---
+
+## §6 Motion budget
+
+- **Values:** step/screen transition `300ms`; panel/arrow appear `200ms`; button press/highlight
+  `100ms`; device slide-in on load `500ms`. **Everything else animates `0`.**
+- **Do** allow exactly **one signature moment** (usually the step transition or the drop-settle).
+- **Do** ship the reduced-motion gate verbatim:
+  ```css
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  }
+  ```
+- **Don't** animate every element — animation everywhere is the fastest path to "AI-generated".
+
+---
+
+## §7 Component specs
+
+- **Device frame:** outer radius 54px, bezel 12–16px, inner screen radius 40px (`overflow:hidden`,
+  content never escapes the bezel), shadow level 4. Phone notch optional but consistent.
+- **Transport bar:** ▶ play / ‹ prev / next ›; primary button = `--pg-accent`; disabled at ends; a
+  "step N of M" hint.
+- **Flow arrow:** connects cause→effect; uses `--pg-accent`; **RTL-sensitive** — flip with
+  `transform: scaleX(-1)` when `dir="rtl"`.
+- **Copy-prompt bar:** mono text + one `<button>`; **1 click to clipboard** (no modal/toast to
+  dismiss); on copy, icon→✓ for 1500ms then revert. The prompt is a natural-language instruction
+  that only mentions non-default choices — not a value dump.
+- **Drag-and-drop decision surface** (the decision-board archetype):
+  - **Do NOT use native HTML5 DnD** — it is mouse-only and inaccessible.
+  - **Do** implement with **Pointer Events** (covers mouse + touch + pen): a floating ghost clone,
+    a dimmed source, a drop indicator, hit-test via `elementFromPoint`.
+  - **Keyboard is mandatory:** cards `tabindex="0"`; arrow keys move the focused card (reorder /
+    nudge axis / change bucket); `:focus-visible` ring; re-focus the card after re-render.
+  - **ARIA:** `role="button"`, `aria-roledescription="draggable card"`, and an `aria-live="polite"`
+    region that announces every move ("X moved to Should").
+  - `touch-action: none` on cards so touch-drag doesn't scroll the page.
+  - Supported patterns: Impact×Effort 2×2 · ranked-list reorder · MoSCoW / Now-Next-Later buckets ·
+    live score (RICE/WSJF) + copy-prompt. Copy `decision-board.template.html` and swap the data.
+
+---
+
+## §8 RTL / i18n
+
+- **Do** use CSS **logical properties everywhere**: `margin-inline-start`, `padding-inline-end`,
+  `inset-inline-start`, `inset-block-end` — never `left`/`right`/`margin-left`.
+- **Do** flag flow arrows and any directional position math as RTL-sensitive (flip / invert the
+  pointer-X→value mapping when `dir="rtl"`).
+- **Do** reserve +50% width for labels (text expands in other languages); never truncate the prompt bar.
+
+---
+
+## §9 Anti-"generic AI aesthetic" checklist (falsifiable DO-NOTs)
+
+1. No pure black `#000` background or text.
+2. No gradient with >30° hue span.
+3. No two elements at equal visual weight (§3).
+4. No glow-halo cards (§5).
+5. More than one signature animation → cut to one (§6).
+6. Arbitrary spacing (`13px`, `22px`) → snap to the §2 scale.
+7. Hex colors in tokens → convert to HSL.
+8. Native `draggable="true"` DnD → replace with the §7 pointer+keyboard engine.
+9. Physical `left`/`right` CSS in a playground that may be RTL → logical properties.
+10. Copy-prompt that dumps values instead of a natural-language instruction.
+
+---
+
+## §10 Self-audit (run before declaring done)
+
+- [ ] Routing (§0): correct archetype chosen; this standard actually applies.
+- [ ] One persona, no warm/cool mix (§1).
+- [ ] Tokens are HSL with roles; spacing/radius/motion on the scales (§2, §6).
+- [ ] Hierarchy: primary element is unmistakably dominant (§3).
+- [ ] Glass passes the do/don't (§5); no glow halos.
+- [ ] Motion ≤4 durations, one signature moment, reduced-motion gate present (§6).
+- [ ] If a decision surface exists: mouse **and** keyboard work, live region announces, touch ok (§7).
+- [ ] RTL: toggle `dir="rtl"` — layout + arrows mirror correctly (§8).
+- [ ] Single file, zero external deps; copy-prompt is 1-click and natural-language.
+- [ ] Ran the §9 checklist; zero hits.

--- a/plugins/ork/skills/visualize-plan/SKILL.md
+++ b/plugins/ork/skills/visualize-plan/SKILL.md
@@ -239,11 +239,17 @@ Render the selected sections into the `FORMATS` chosen in STEP 0.5. **ASCII alwa
 | Format | Action |
 |--------|--------|
 | ASCII | Native render (above) — always, the floor |
-| Playground | Hand the plan brief to the `playground` skill → write `docs/<branch-dir>/plan-viz.html`, link it |
+| Playground | Classify the archetype (below), then hand the plan brief to the `playground` skill → write `docs/<branch-dir>/plan-viz.html`, link it |
 | Infographic | Run the `notebooklm` `studio_create(artifact_type=infographic\|slides)` flow — **fire-and-notify**, poll `studio_status`, never await |
 | All | ASCII inline now + the rest linked as they finish |
 
 `<branch-dir>` = branch with `/` → `--` (same path the PR Playground gate checks).
+
+> **Playground archetype:** a plan visualization is usually a **DASHBOARD** (current behavior — fine).
+> But if the plan demonstrates a *user-facing flow* or a *prioritization/decision*, route to the
+> **user-story-player** or **decision-board** archetype instead of a flat card grid. Apply the §0 routing
+> rule in `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")` and adapt the
+> matching exemplar under `skills/shared/assets/playground-exemplars/`.
 
 ---
 

--- a/plugins/ork/skills/visualize-plan/references/format-dispatch.md
+++ b/plugins/ork/skills/visualize-plan/references/format-dispatch.md
@@ -35,11 +35,17 @@ Hide unavailable options from the AskUserQuestion list and add a one-line instal
 | Format | How | Output | Blocks? |
 |--------|-----|--------|---------|
 | ASCII + emojis | Native — render sections per `rules/section-rendering.md` | In chat | n/a (always first) |
-| Interactive playground | Build the plan brief, hand to the `playground` skill | `docs/<branch-dir>/plan-viz.html` | No — write then link |
+| Interactive playground | Classify archetype (§0 of the visual standard), build the plan brief, hand to the `playground` skill | `docs/<branch-dir>/plan-viz.html` | No — write then link |
 | NotebookLM infographic/slides | Build a source doc, run the notebooklm `studio_create(artifact_type=infographic\|slides)` flow | `.png`/slides artifact | **No — fire-and-notify** |
 | All available | Fan out: ASCII inline now + the others as they finish | all of the above | No |
 
 `<branch-dir>` = current branch with `/` → `--` (matches the PR Playground CI gate path, so the playground also satisfies that gate for free).
+
+> **Archetype before generation.** Most plan visualizations are a **DASHBOARD** (the default card grid).
+> But a plan that demonstrates a *user-facing flow* or a *prioritization/decision* should be a
+> **user-story-player** or **decision-board** — `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")`
+> for the §0 routing rule, the token/glass/motion spec, and the exemplars to adapt
+> (`skills/shared/assets/playground-exemplars/`). Brief the `playground` skill with archetype + persona, not raw HTML.
 
 ## The plan brief (shared interchange, v1)
 

--- a/src/skills/create-pr/SKILL.md
+++ b/src/skills/create-pr/SKILL.md
@@ -258,16 +258,29 @@ Generate an interactive HTML playground visualizing the PR's changes. CI validat
 
 > **Requires** the `playground` plugin (external): `/plugin marketplace add anthropics/claude-plugins-official && /plugin install playground`
 
+**First classify the archetype** — a feature PR must not ship as a flat dashboard.
+`Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")` and apply its §0 routing rule:
+
+- **Visual PR** (adds/changes a user-facing feature, flow, or a prioritization/decision surface) →
+  **USER-STORY PLAYER** or **DECISION BOARD**. Build to the standard: adapt the matching exemplar at
+  `${CLAUDE_PLUGIN_ROOT}/skills/shared/assets/playground-exemplars/` (`user-story-player.template.html`
+  or `decision-board.template.html`), and bring full design firepower (the `frontend-design` skill /
+  the `ork:frontend-ui-developer` agent). When delegating to `playground:playground`, brief it with the
+  **archetype + persona + tokens** — never hand it a pre-built HTML blob.
+- **Non-visual PR** (infra/CI/refactor/config/docs) → **DASHBOARD** — the default summary below is fine.
+
 ```python
 BRANCH=$(git branch --show-current)
 BRANCH_DIR = BRANCH.replace("/", "--")  # feat/foo → feat--foo
 
-# Invoke the playground skill with a summary of the PR changes
+# Invoke the playground skill with a summary of the PR changes.
+# For a VISUAL PR, set archetype/persona/exemplar per playground-visual-standard.md instead of this default.
 Skill("playground:playground", args=f"""
   {PR_TITLE} — visualize the key changes in this PR.
-  Show: architecture/data flow, before/after, key components changed.
-  Include presets for the main change areas.
-  Dark theme with purple/violet OrchestKit brand colors.
+  Archetype: <user-story-player | decision-board | dashboard> per playground-visual-standard.md §0.
+  For visual archetypes: follow that standard's tokens/glass/motion and adapt the matching exemplar.
+  Show: architecture/data flow, before/after, key components changed; presets for the main change areas.
+  Dark glass theme, OrchestKit brand accents.
 """)
 
 # The playground skill writes to a temp path — move it to the correct location

--- a/src/skills/shared/assets/playground-exemplars/README.md
+++ b/src/skills/shared/assets/playground-exemplars/README.md
@@ -1,0 +1,35 @@
+# Playground exemplars
+
+Gold-standard, single-file HTML playgrounds for the **visual** playground archetypes. They are the
+copyable starting points enforced by
+[`../../rules/playground-visual-standard.md`](../../rules/playground-visual-standard.md).
+
+> **Edit discipline (colocation):** if you change a token, component, or rule in the standard, update
+> the matching exemplar in the **same PR** — and vice versa. They are one unit of change.
+
+| File | Archetype | Persona | Use it when… |
+|---|---|---|---|
+| `homeos-arieh.html` | User-story player | warm-glass | …you want to see the bar. Designed by **Arieh**; committed verbatim — study, don't edit. |
+| `user-story-player.template.html` | User-story player | warm-glass | …the playground demonstrates a **feature or flow** (message→card, action→result). Swap `STORY`. |
+| `decision-board.template.html` | Decision board | cool-glass | …the playground is for **prioritization / management** via drag-and-drop. Swap `ITEMS`. |
+
+## What makes these different from a dashboard
+
+A dashboard *shows* state; these let the viewer **operate** something:
+
+- **Player** — a device mockup + a transport (▶ play / ‹ prev / next ›) + a cause→effect flow arrow.
+- **Decision board** — drag-and-drop across an Impact×Effort matrix, a ranked list, or buckets, with
+  a live RICE/WSJF score and a 1-click copy-prompt.
+
+Both are zero-dependency, single-file, dark warm/cool **glass** aesthetic, RTL-ready via CSS logical
+properties, accessible (the decision board has full keyboard control + `aria-live` announcements),
+and honor `prefers-reduced-motion`.
+
+## Reuse
+
+1. Copy the template matching your archetype.
+2. Replace the data block (`STORY` / `ITEMS`) — keep the engine.
+3. Run the §10 self-audit checklist in the standard before shipping.
+
+For the routing rule (player vs decision-board vs plain dashboard) and the full token/glass/motion
+spec, read the standard.

--- a/src/skills/shared/assets/playground-exemplars/decision-board.template.html
+++ b/src/skills/shared/assets/playground-exemplars/decision-board.template.html
@@ -135,6 +135,10 @@
   .card .meta { margin-top: 7px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
   .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); }
   .chip.rice { background: hsl(248 84% 68% / 0.16); color: hsl(248 84% 82%); font-family: var(--pg-mono); }
+  .chip.q-qw { background: hsl(160 68% 45% / 0.18); color: hsl(160 68% 72%); }
+  .chip.q-bb { background: hsl(248 84% 68% / 0.18); color: hsl(248 84% 82%); }
+  .chip.q-fi { background: hsl(206 85% 62% / 0.16); color: hsl(206 85% 76%); }
+  .chip.q-ts { background: hsl(345 76% 63% / 0.16); color: hsl(345 76% 78%); }
   .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
 
   /* dragging states */
@@ -220,7 +224,7 @@
       <h1>Decision Board</h1>
       <p>The decision-making parts of a playground should let you <b>act on the decision</b>, not just read it.
          Drag a card to set its impact &amp; effort, reorder the backlog, or sort it into buckets — the
-         <b>RICE score</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
+         <b>scores</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
          (<span class="kbd">Tab</span> a card, then <span class="kbd">← ↑ ↓ →</span>).</p>
     </div>
     <div class="right">
@@ -253,14 +257,14 @@
    Swap ITEMS for your own to reuse the template.
    ═══════════════════════════════════════════════════════════════════════ */
 const ITEMS = [
-  { id:"a", title:"One-click onboarding wizard",      reach:900, impact:3,   confidence:0.8,  effort:3 },
-  { id:"b", title:"Dark mode",                          reach:1200,impact:1,   confidence:0.95, effort:1 },
-  { id:"c", title:"SSO / SAML for enterprise",          reach:140, impact:3,   confidence:0.7,  effort:5 },
-  { id:"d", title:"Inline AI code review",              reach:600, impact:3,   confidence:0.6,  effort:4 },
-  { id:"e", title:"Mobile app",                         reach:2000,impact:2,   confidence:0.4,  effort:5 },
-  { id:"f", title:"Keyboard shortcuts",                 reach:500, impact:1,   confidence:0.9,  effort:1 },
-  { id:"g", title:"Usage analytics dashboard",          reach:350, impact:2,   confidence:0.8,  effort:3 },
-  { id:"h", title:"Slack notifications",                reach:700, impact:1,   confidence:0.85, effort:2 },
+  { id:"a", title:"One-click onboarding wizard", reach:900,  impact:4, confidence:0.8,  effort:2 }, // quick win
+  { id:"b", title:"Usage analytics dashboard",   reach:350,  impact:5, confidence:0.8,  effort:2 }, // quick win
+  { id:"c", title:"Keyboard shortcuts",          reach:500,  impact:2, confidence:0.9,  effort:1 }, // fill-in
+  { id:"d", title:"Dark mode",                   reach:1200, impact:2, confidence:0.95, effort:2 }, // fill-in
+  { id:"e", title:"SSO / SAML for enterprise",   reach:140,  impact:5, confidence:0.7,  effort:5 }, // big bet
+  { id:"f", title:"Inline AI code review",       reach:600,  impact:5, confidence:0.6,  effort:4 }, // big bet
+  { id:"g", title:"Mobile app",                  reach:2000, impact:4, confidence:0.4,  effort:5 }, // big bet
+  { id:"h", title:"Slack notifications",         reach:700,  impact:2, confidence:0.85, effort:4 }, // time sink
 ];
 
 const BUCKET_SCHEMES = {
@@ -298,19 +302,40 @@ const live  = document.getElementById("live");
 const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
 
 /* ── card markup ─────────────────────────────────────────────────────── */
+// Impact×Effort quadrant (split at the plane midpoint, impact/effort = 3).
+function quadrant(it) {
+  const hiI = it.impact > 3, hiE = it.effort > 3;
+  if (hiI && !hiE) return { key: "qw", label: "Quick win" };
+  if (hiI && hiE)  return { key: "bb", label: "Big bet" };
+  if (!hiI && !hiE) return { key: "fi", label: "Fill-in" };
+  return { key: "ts", label: "Time sink" };
+}
+// Chips are VIEW-AWARE: the matrix shows quadrant (position-consistent, no RICE),
+// the ranked list shows the full RICE breakdown (where reach/confidence are visible).
+function cardChips(it) {
+  if (state.view === "matrix") {
+    const q = quadrant(it);
+    return `<span class="chip q-${q.key}">${q.label}</span><span class="chip">I ${it.impact} · E ${it.effort}</span>`;
+  }
+  if (state.view === "list") {
+    return `<span class="chip rice">RICE ${rice(it)}</span><span class="chip">reach ${it.reach}</span>`
+         + `<span class="chip">impact ${it.impact}</span><span class="chip">conf ${Math.round(it.confidence * 100)}%</span><span class="chip">effort ${it.effort}</span>`;
+  }
+  return `<span class="chip">I ${it.impact} · E ${it.effort}</span>`;
+}
+function cardLabel(it) {
+  if (state.view === "matrix") return `${esc(it.title)}. ${quadrant(it).label}, impact ${it.impact}, effort ${it.effort}.`;
+  if (state.view === "list")   return `${esc(it.title)}. RICE ${rice(it)}.`;
+  return `${esc(it.title)}.`;
+}
 function cardHTML(it, extra = "") {
   return `<div class="card" data-id="${it.id}" tabindex="0" role="button"
             aria-roledescription="draggable card"
-            aria-label="${esc(it.title)}. RICE ${rice(it)}. ${kbdHint()}">
+            aria-label="${cardLabel(it)} ${kbdHint()}">
       <span class="grip" aria-hidden="true">⠿</span>
       ${extra}
       <div class="ct">${esc(it.title)}</div>
-      <div class="meta">
-        <span class="chip rice">RICE ${rice(it)}</span>
-        <span class="chip">reach ${it.reach}</span>
-        <span class="chip">impact ${it.impact}</span>
-        <span class="chip">effort ${it.effort}</span>
-      </div>
+      <div class="meta">${cardChips(it)}</div>
     </div>`;
 }
 function kbdHint() {
@@ -340,8 +365,9 @@ function renderList() {
 function renderMatrix() {
   const pct = v => 12 + ((v - 1) / 4) * 76;    // 1..5 → 12..88 (padded so cards never clip the edge)
   stage.innerHTML = `
-    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and RICE recomputes.
-       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.</p>
+    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and its quadrant updates.
+       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.
+       <span style="color:var(--pg-faint)">(full RICE score lives in the Ranked-list view)</span></p>
     <div class="matrix-wrap">
       <div class="axis-y" aria-hidden="true">Impact →</div>
       <div class="plane" id="plane">
@@ -454,7 +480,7 @@ function commitDrop(under, e) {
       const it = byId(drag.id);
       it.effort = clamp15(Math.round(fx * 4 + 1));
       it.impact = clamp15(Math.round(fy * 4 + 1));
-      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort} — ${quadrant(it).label}.`);
     }
   } else if (state.view === "list") {
     const list = document.getElementById("v-list");
@@ -491,7 +517,7 @@ stage.addEventListener("keydown", e => {
     const dir = state.rtl ? -1 : 1;
     if (e.key === "ArrowRight") it.effort = clamp15(it.effort + dir);
     if (e.key === "ArrowLeft")  it.effort = clamp15(it.effort - dir);
-    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort} — ${quadrant(it).label}.`);
   } else {
     const sch = BUCKET_SCHEMES[state.bucketScheme], order = sch.defs.map(d => d.key);
     const cur = order.indexOf(state.bucket[id]);
@@ -514,11 +540,11 @@ function refocus(id, msg) {
 function updatePrompt() {
   let txt = "";
   if (state.view === "matrix") {
-    const sorted = [...ITEMS].sort((a,b) => rice(b) - rice(a));
-    const top = sorted.slice(0,3).map(i => i.title);
-    const sink = sorted[sorted.length-1];
-    txt = `Prioritize the backlog by <b>RICE</b>. Top: <b>${esc(top.join(", "))}</b>. `
-        + `Deprioritize <span class="warm">${esc(sink.title)}</span> (RICE ${rice(sink)} — low impact for the effort).`;
+    const g = k => ITEMS.filter(i => quadrant(i).key === k).map(i => i.title);
+    const seg = (label, names) => `${label}: ${names.length ? esc(names.join(", ")) : "—"}`;
+    txt = `Prioritize by impact vs effort. `
+        + `<b>${seg("Do first (quick wins)", g("qw"))}</b>  ·  ${seg("Plan (big bets)", g("bb"))}  ·  `
+        + `${seg("Maybe (fill-ins)", g("fi"))}  ·  <span class="warm">${seg("Avoid (time sinks)", g("ts"))}</span>.`;
   } else if (state.view === "list") {
     const o = state.order.map((id,i) => `${i+1}. ${byId(id).title}`);
     txt = `Work the backlog in this <b>explicit order</b>: ${esc(o.join("  ·  "))}.`;

--- a/src/skills/shared/assets/playground-exemplars/decision-board.template.html
+++ b/src/skills/shared/assets/playground-exemplars/decision-board.template.html
@@ -1,0 +1,561 @@
+<!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  DECISION BOARD · drag-and-drop prioritization toolkit
+  OrchestKit playground exemplar — the "decision-board" archetype.
+
+  Conforms to: skills/shared/rules/playground-visual-standard.md
+  Persona: cool-glass ("technical precision", indigo). Zero dependencies. Single file.
+
+  WHAT THIS IS
+  ------------
+  The visual playgrounds OrchestKit generates should let you *make the
+  decision*, not just read a dashboard. This is the reusable template for
+  the decision-making parts: drag cards to prioritize and to manage. One
+  shared item set, four lenses:
+
+    1. Impact × Effort 2×2  — drop a card on the plane → sets its impact/effort
+    2. Ranked list          — drag to reorder 1..N (explicit priority override)
+    3. Buckets / columns    — drag between MoSCoW or Now / Next / Later
+    4. Live score + prompt   — RICE recomputes as you drag; copy the decision
+
+  ACCESSIBILITY (the part most drag-drop demos skip)
+  --------------------------------------------------
+  Native HTML5 drag-and-drop is mouse-only and inaccessible. This uses
+  vanilla Pointer Events (mouse + touch + pen) PLUS full keyboard control:
+  Tab to a card, arrow keys move it, every move is announced via aria-live.
+  Honors prefers-reduced-motion. RTL via CSS logical properties + a toggle.
+
+  TO REUSE: replace ITEMS below with your own; keep the engine.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Decision Board · Prioritization Playground</title>
+<style>
+  /* ── §2 Design tokens (HSL so shades are derivable) ─────────────────── */
+  :root {
+    --pg-bg:            hsl(232 26% 7%);
+    --pg-ink:           hsl(220 18% 93%);
+    --pg-muted:         hsl(220 12% 64%);
+    --pg-faint:         hsl(220 10% 46%);
+    --pg-line:          hsl(0 0% 100% / 0.10);
+    --pg-glass:         hsl(0 0% 100% / 0.05);
+    --pg-glass-2:       hsl(0 0% 100% / 0.08);
+    --pg-glass-edge:    hsl(0 0% 100% / 0.18);
+
+    --pg-accent:        hsl(248 84% 68%);   /* indigo — primary action / active */
+    --pg-accent-deep:   hsl(248 60% 52%);
+    --pg-warm:          hsl(38 95% 60%);    /* amber — secondary accent */
+    --pg-emerald:       hsl(160 68% 45%);   /* quick wins / success */
+    --pg-sky:           hsl(206 85% 62%);   /* fill-ins / could */
+    --pg-rose:          hsl(345 76% 63%);   /* time sinks / must */
+
+    /* two-part shadow (§5) — ambient + tight */
+    --pg-shadow: 0 20px 60px -22px hsl(232 40% 2% / 0.7), 0 4px 12px -6px hsl(232 40% 2% / 0.5);
+
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+
+    /* §6 motion budget — four tiers, nothing else animates */
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 88% -8%, hsl(248 84% 68% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 4% 110%, hsl(38 95% 60% / 0.12), transparent 58%),
+      radial-gradient(700px 520px at 50% 50%, hsl(160 68% 45% / 0.05), transparent 70%),
+      var(--pg-bg);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased; min-height: 100vh;
+  }
+
+  .wrap { max-width: 1120px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+
+  /* ── header / explainer ─────────────────────────────────────────────── */
+  .head { display: flex; align-items: flex-start; gap: 14px; flex-wrap: wrap; }
+  .logo {
+    width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 22px -8px hsl(248 84% 60% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4);
+  }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; display: flex; gap: 8px; align-items: center; }
+
+  .toggle {
+    cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px;
+    transition: color var(--pg-dur-fast), border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); background: var(--pg-glass-2); border-color: var(--pg-glass-edge); }
+
+  /* ── glass panel ────────────────────────────────────────────────────── */
+  .panel {
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow);
+  }
+
+  /* ── §7 segmented view switch ───────────────────────────────────────── */
+  .views { display: flex; gap: 4px; padding: 5px; background: hsl(0 0% 0% / 0.28); border: 1px solid var(--pg-line); border-radius: 13px; flex-wrap: wrap; }
+  .views button {
+    flex: 1 1 auto; min-width: 140px; border: 0; background: transparent; color: var(--pg-muted); cursor: pointer;
+    font: inherit; font-size: 13px; font-weight: 600; padding: 10px 12px; border-radius: 9px; letter-spacing: -.1px;
+    transition: color var(--pg-dur-fast), background var(--pg-dur-fast); display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  }
+  .views button:hover { color: var(--pg-ink); }
+  .views button[aria-pressed="true"] {
+    color: var(--pg-ink); background: linear-gradient(180deg, var(--pg-glass-2), hsl(0 0% 100% / 0.03));
+    box-shadow: 0 2px 10px -4px hsl(232 40% 2% / 0.6), inset 0 1px 0 hsl(0 0% 100% / 0.12);
+  }
+
+  .stage { padding: 20px; min-height: 440px; position: relative; }
+  .scheme-note { font-size: 12px; color: var(--pg-faint); margin: 0 0 14px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+  .scheme-note b { color: var(--pg-muted); font-weight: 650; }
+  .kbd { font-family: var(--pg-mono); font-size: 10.5px; color: var(--pg-muted); background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); border-radius: 6px; padding: 1px 6px; }
+
+  /* ── card (shared across views) ─────────────────────────────────────── */
+  .card {
+    background: hsl(0 0% 100% / 0.045); border: 1px solid var(--pg-line); border-radius: var(--pg-r-md);
+    padding: 11px 12px; cursor: grab; user-select: none; touch-action: none; position: relative;
+    transition: transform var(--pg-dur-fast) var(--pg-ease), border-color var(--pg-dur-fast), box-shadow var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .card:hover { border-color: var(--pg-glass-edge); background: hsl(0 0% 100% / 0.07); }
+  .card:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .card .ct { font-size: 13.5px; font-weight: 600; letter-spacing: -.1px; line-height: 1.3; }
+  .card .meta { margin-top: 7px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
+  .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); }
+  .chip.rice { background: hsl(248 84% 68% / 0.16); color: hsl(248 84% 82%); font-family: var(--pg-mono); }
+  .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
+
+  /* dragging states */
+  .card.source { opacity: .35; }
+  .ghost {
+    position: fixed; z-index: 999; pointer-events: none; width: var(--ghost-w, 220px);
+    transform: rotate(1.5deg) scale(1.03); box-shadow: 0 26px 60px -18px hsl(232 60% 2% / 0.8); cursor: grabbing;
+  }
+  .card.lifted { border-color: var(--pg-accent); box-shadow: 0 0 0 2px hsl(248 84% 68% / 0.4); }
+
+  /* ── view: ranked list ──────────────────────────────────────────────── */
+  #v-list { display: flex; flex-direction: column; gap: 9px; max-width: 660px; margin: 0 auto; }
+  #v-list .card { display: grid; grid-template-columns: 30px 1fr auto; align-items: center; gap: 12px; padding-inline-end: 26px; }
+  #v-list .rank { font-family: var(--pg-mono); font-size: 17px; font-weight: 800; color: var(--pg-accent); width: 30px; text-align: center; }
+  .drop-line { height: 2px; background: var(--pg-accent); border-radius: 2px; margin: -5px 0; box-shadow: 0 0 8px hsl(248 84% 68% / 0.7); }
+
+  /* ── view: impact × effort matrix ───────────────────────────────────── */
+  .matrix-wrap { display: grid; grid-template-columns: 26px 1fr; grid-template-rows: 1fr 26px; gap: 8px; height: 460px; }
+  .axis-y { writing-mode: vertical-rl; transform: rotate(180deg); text-align: center; font-size: 11px; letter-spacing: 1px; color: var(--pg-faint); text-transform: uppercase; }
+  .axis-x { grid-column: 2; text-align: center; font-size: 11px; letter-spacing: 1px; color: var(--pg-faint); text-transform: uppercase; }
+  .plane {
+    position: relative; border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); overflow: hidden;
+    background:
+      linear-gradient(hsl(0 0% 100% / 0.05), hsl(0 0% 100% / 0.05)) 0 0 / 100% 1px no-repeat,
+      linear-gradient(hsl(0 0% 100% / 0.05), hsl(0 0% 100% / 0.05)) 50% 0 / 1px 100% no-repeat,
+      hsl(0 0% 100% / 0.015);
+  }
+  .quad { position: absolute; width: 50%; height: 50%; padding: 10px 12px; font-size: 11px; font-weight: 700; letter-spacing: .3px; text-transform: uppercase; pointer-events: none; }
+  .quad.q-qw { inset-block-start: 0; inset-inline-start: 0;  color: hsl(160 68% 62%); background: radial-gradient(120% 120% at 0 0, hsl(160 68% 45% / 0.14), transparent 70%); }
+  .quad.q-bb { inset-block-start: 0; inset-inline-end: 0;  color: hsl(248 84% 80%); background: radial-gradient(120% 120% at 100% 0, hsl(248 84% 68% / 0.14), transparent 70%); text-align: end; }
+  .quad.q-fi { inset-block-end: 0; inset-inline-start: 0;  color: hsl(206 85% 74%); background: radial-gradient(120% 120% at 0 100%, hsl(206 85% 62% / 0.12), transparent 70%); }
+  .quad.q-ts { inset-block-end: 0; inset-inline-end: 0;  color: hsl(345 76% 76%); background: radial-gradient(120% 120% at 100% 100%, hsl(345 76% 63% / 0.13), transparent 70%); text-align: end; }
+  .plane .card { position: absolute; width: 150px; transform: translate(-50%, -50%); cursor: grab; }
+  .plane.hot { box-shadow: inset 0 0 0 2px hsl(248 84% 68% / 0.45); }
+
+  /* ── view: buckets ──────────────────────────────────────────────────── */
+  .buckets { display: grid; grid-template-columns: repeat(var(--cols, 4), 1fr); gap: 14px; }
+  .bucket { display: flex; flex-direction: column; min-height: 320px; }
+  .bucket-h { display: flex; align-items: center; gap: 8px; margin-bottom: 11px; font-size: 13px; font-weight: 700; }
+  .bucket-h .dot { width: 9px; height: 9px; border-radius: 999px; flex: none; }
+  .bucket-h .n { margin-inline-start: auto; font-size: 11px; color: var(--pg-faint); background: hsl(0 0% 0% / 0.25); border-radius: 999px; padding: 1px 8px; font-family: var(--pg-mono); }
+  .drop {
+    flex: 1; display: flex; flex-direction: column; gap: 9px; padding: 10px; border-radius: var(--pg-r-md);
+    background: hsl(0 0% 100% / 0.02); border: 1px dashed var(--pg-line);
+    transition: border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .drop.hot { border-color: var(--pg-accent); border-style: solid; background: hsl(248 84% 68% / 0.07); }
+  .drop:empty::after { content: "drop here"; color: var(--pg-faint); font-size: 11px; margin: auto; opacity: .6; }
+
+  /* ── §7 score + copy-prompt bar ─────────────────────────────────────── */
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(220 16% 80%); max-height: 92px; overflow-y: auto; }
+  .promptbar .pt b { color: var(--pg-accent); font-weight: 600; }
+  .promptbar .pt .warm { color: var(--pg-warm); }
+  .copy {
+    flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(248 30% 12%);
+    border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 10px 26px -12px hsl(248 84% 60% / 0.8); transition: transform var(--pg-dur-instant);
+  }
+  .copy:hover { transform: translateY(-1px); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+
+  /* ── §6 reduced motion ──────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    .ghost { transform: none; }
+  }
+  @media (max-width: 720px) {
+    .buckets { grid-template-columns: repeat(2, 1fr); }
+    .matrix-wrap { height: 520px; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="head">
+    <div class="logo">🎚️</div>
+    <div>
+      <h1>Decision Board</h1>
+      <p>The decision-making parts of a playground should let you <b>act on the decision</b>, not just read it.
+         Drag a card to set its impact &amp; effort, reorder the backlog, or sort it into buckets — the
+         <b>RICE score</b> and the copy-out prompt update live. Mouse, touch, and keyboard all work
+         (<span class="kbd">Tab</span> a card, then <span class="kbd">← ↑ ↓ →</span>).</p>
+    </div>
+    <div class="right">
+      <button class="toggle" id="dirToggle" aria-pressed="false" title="Toggle text direction">⇄ RTL</button>
+    </div>
+  </header>
+
+  <div class="panel" style="padding:6px">
+    <div class="views" id="views" role="tablist" aria-label="Decision view">
+      <button data-view="matrix" aria-pressed="true">📊 Impact × Effort</button>
+      <button data-view="list"   aria-pressed="false">🔢 Ranked list</button>
+      <button data-view="buckets" aria-pressed="false">🗂️ Buckets</button>
+    </div>
+  </div>
+
+  <main class="panel stage" id="stage" aria-live="off"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">📋 Copy decision</button>
+  </div>
+
+  <div class="sr-only" id="live" role="status" aria-live="polite"></div>
+</div>
+
+<script>
+/* ═══════════════════════════════════════════════════════════════════════
+   DATA MODEL — one shared item set. Each view is a lens that edits or
+   orders these fields. RICE = round(reach × impact × confidence / effort).
+   Swap ITEMS for your own to reuse the template.
+   ═══════════════════════════════════════════════════════════════════════ */
+const ITEMS = [
+  { id:"a", title:"One-click onboarding wizard",      reach:900, impact:3,   confidence:0.8,  effort:3 },
+  { id:"b", title:"Dark mode",                          reach:1200,impact:1,   confidence:0.95, effort:1 },
+  { id:"c", title:"SSO / SAML for enterprise",          reach:140, impact:3,   confidence:0.7,  effort:5 },
+  { id:"d", title:"Inline AI code review",              reach:600, impact:3,   confidence:0.6,  effort:4 },
+  { id:"e", title:"Mobile app",                         reach:2000,impact:2,   confidence:0.4,  effort:5 },
+  { id:"f", title:"Keyboard shortcuts",                 reach:500, impact:1,   confidence:0.9,  effort:1 },
+  { id:"g", title:"Usage analytics dashboard",          reach:350, impact:2,   confidence:0.8,  effort:3 },
+  { id:"h", title:"Slack notifications",                reach:700, impact:1,   confidence:0.85, effort:2 },
+];
+
+const BUCKET_SCHEMES = {
+  moscow: { cols: 4, defs: [
+    { key:"must",   label:"Must",   dot:"var(--pg-rose)" },
+    { key:"should", label:"Should", dot:"var(--pg-warm)" },
+    { key:"could",  label:"Could",  dot:"var(--pg-sky)" },
+    { key:"wont",   label:"Won't",  dot:"var(--pg-faint)" },
+  ]},
+  nnl: { cols: 3, defs: [
+    { key:"now",   label:"Now",   dot:"var(--pg-emerald)" },
+    { key:"next",  label:"Next",  dot:"var(--pg-warm)" },
+    { key:"later", label:"Later", dot:"var(--pg-faint)" },
+  ]},
+};
+
+/* per-item view state, derived/seeded from the model */
+const state = {
+  view: "matrix",
+  rtl: false,
+  bucketScheme: "moscow",
+  // matrix position: impact & effort already on items (1..5)
+  order: ITEMS.map(i => i.id),           // ranked-list order
+  bucket: {},                            // id -> bucket key
+};
+ITEMS.forEach((it, idx) => {
+  state.bucket[it.id] = ["must","must","should","could","should","could","should","could"][idx] || "could";
+});
+
+const byId = id => ITEMS.find(i => i.id === id);
+const rice = it => Math.round((it.reach * it.impact * it.confidence) / it.effort);
+const esc = s => String(s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+const stage = document.getElementById("stage");
+const live  = document.getElementById("live");
+const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
+
+/* ── card markup ─────────────────────────────────────────────────────── */
+function cardHTML(it, extra = "") {
+  return `<div class="card" data-id="${it.id}" tabindex="0" role="button"
+            aria-roledescription="draggable card"
+            aria-label="${esc(it.title)}. RICE ${rice(it)}. ${kbdHint()}">
+      <span class="grip" aria-hidden="true">⠿</span>
+      ${extra}
+      <div class="ct">${esc(it.title)}</div>
+      <div class="meta">
+        <span class="chip rice">RICE ${rice(it)}</span>
+        <span class="chip">reach ${it.reach}</span>
+        <span class="chip">impact ${it.impact}</span>
+        <span class="chip">effort ${it.effort}</span>
+      </div>
+    </div>`;
+}
+function kbdHint() {
+  if (state.view === "list")   return "Use arrow up and down to reorder.";
+  if (state.view === "matrix") return "Arrows change impact and effort.";
+  return "Arrow left and right move between buckets.";
+}
+
+/* ═══════════════════════════ RENDERERS ════════════════════════════════ */
+function render() {
+  if (state.view === "matrix") renderMatrix();
+  else if (state.view === "list") renderList();
+  else renderBuckets();
+  updatePrompt();
+}
+
+function renderList() {
+  const items = state.order.map(byId);
+  stage.innerHTML = `
+    <p class="scheme-note">Drag to reorder — this is your <b>explicit priority</b>, overriding the computed score.
+       <span class="kbd">↑</span><span class="kbd">↓</span> move the focused card.</p>
+    <div id="v-list">
+      ${items.map((it, i) => cardHTML(it, `<span class="rank" aria-hidden="true">${i+1}</span>`)).join("")}
+    </div>`;
+}
+
+function renderMatrix() {
+  const pct = v => 12 + ((v - 1) / 4) * 76;    // 1..5 → 12..88 (padded so cards never clip the edge)
+  stage.innerHTML = `
+    <p class="scheme-note">Drop a card on the plane — its position <b>sets impact &amp; effort</b>, and RICE recomputes.
+       Focus a card and use <span class="kbd">←→</span> effort · <span class="kbd">↑↓</span> impact.</p>
+    <div class="matrix-wrap">
+      <div class="axis-y" aria-hidden="true">Impact →</div>
+      <div class="plane" id="plane">
+        <div class="quad q-qw">Quick wins</div>
+        <div class="quad q-bb">Big bets</div>
+        <div class="quad q-fi">Fill-ins</div>
+        <div class="quad q-ts">Time sinks</div>
+        ${ITEMS.map(it => `${cardWrapMatrix(it, pct)}`).join("")}
+      </div>
+      <div class="axis-x" aria-hidden="true">Effort →</div>
+    </div>`;
+}
+function cardWrapMatrix(it, pct) {
+  // inset-inline-start auto-mirrors in RTL; center-anchored (translate -50%,-50%)
+  // high impact → near top, so top% = 100 - impact%
+  const x = pct(it.effort), y = pct(it.impact);
+  const el = cardHTML(it);
+  return el.replace('class="card"', `class="card" style="inset-inline-start:${x}%; inset-block-start:${100 - y}%;"`);
+}
+
+function renderBuckets() {
+  const sch = BUCKET_SCHEMES[state.bucketScheme];
+  stage.style.setProperty("--cols", sch.cols);
+  const other = state.bucketScheme === "moscow" ? "nnl" : "moscow";
+  stage.innerHTML = `
+    <p class="scheme-note">Drag cards between buckets to manage scope.
+       <button class="toggle" id="schemeToggle" aria-pressed="false">↔ ${other === "moscow" ? "MoSCoW" : "Now / Next / Later"}</button>
+       <span class="kbd">←</span><span class="kbd">→</span> move the focused card.</p>
+    <div class="buckets">
+      ${sch.defs.map(b => `
+        <div class="bucket">
+          <div class="bucket-h"><span class="dot" style="background:${b.dot}"></span>${b.label}
+            <span class="n">${ITEMS.filter(i => state.bucket[i.id] === b.key).length}</span></div>
+          <div class="drop" data-bucket="${b.key}">
+            ${ITEMS.filter(i => state.bucket[i.id] === b.key).map(i => cardHTML(i)).join("")}
+          </div>
+        </div>`).join("")}
+    </div>`;
+  const st = document.getElementById("schemeToggle");
+  if (st) st.addEventListener("click", () => { state.bucketScheme = other; render(); });
+}
+
+/* ═══════════════════════ POINTER DRAG ENGINE ══════════════════════════ */
+let drag = null;
+stage.addEventListener("pointerdown", e => {
+  const card = e.target.closest(".card");
+  if (!card || e.button !== 0) return;
+  e.preventDefault();
+  const rect = card.getBoundingClientRect();
+  const ghost = card.cloneNode(true);
+  ghost.classList.add("ghost"); ghost.classList.remove("source");
+  ghost.style.setProperty("--ghost-w", rect.width + "px");
+  ghost.style.left = rect.left + "px"; ghost.style.top = rect.top + "px";
+  document.body.appendChild(ghost);
+  card.classList.add("source");
+  drag = { id: card.dataset.id, ghost, card, dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp, { once: true });
+});
+function onMove(e) {
+  if (!drag) return;
+  drag.ghost.style.left = (e.clientX - drag.dx) + "px";
+  drag.ghost.style.top  = (e.clientY - drag.dy) + "px";
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  drag.ghost.style.display = "";
+  hover(under, e);
+}
+function onUp(e) {
+  if (!drag) return;
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  commitDrop(under, e);
+  drag.ghost.remove();
+  document.querySelectorAll(".hot").forEach(x => x.classList.remove("hot"));
+  document.querySelectorAll(".drop-line").forEach(x => x.remove());
+  drag = null;
+  window.removeEventListener("pointermove", onMove);
+}
+
+function hover(under, e) {
+  document.querySelectorAll(".drop-line").forEach(x => x.remove());
+  if (state.view === "buckets") {
+    document.querySelectorAll(".drop").forEach(d => d.classList.remove("hot"));
+    const drop = under && under.closest(".drop"); if (drop) drop.classList.add("hot");
+  } else if (state.view === "matrix") {
+    const plane = document.getElementById("plane"); if (plane) plane.classList.toggle("hot", !!(under && under.closest(".plane")));
+  } else if (state.view === "list") {
+    const list = document.getElementById("v-list");
+    const over = under && under.closest(".card");
+    if (over && over !== drag.card) {
+      const r = over.getBoundingClientRect();
+      const after = e.clientY > r.top + r.height / 2;
+      const line = document.createElement("div"); line.className = "drop-line";
+      list.insertBefore(line, after ? over.nextSibling : over);
+    }
+  }
+}
+function commitDrop(under, e) {
+  if (state.view === "buckets") {
+    const drop = under && under.closest(".drop");
+    if (drop) { state.bucket[drag.id] = drop.dataset.bucket; render();
+      announce(`${byId(drag.id).title} moved to ${drop.dataset.bucket}.`); }
+  } else if (state.view === "matrix") {
+    const plane = document.getElementById("plane");
+    if (plane && under && under.closest(".plane")) {
+      const r = plane.getBoundingClientRect();
+      let fx = (e.clientX - r.left) / r.width; if (state.rtl) fx = 1 - fx;
+      const fy = 1 - (e.clientY - r.top) / r.height;          // bottom = low impact
+      const it = byId(drag.id);
+      it.effort = clamp15(Math.round(fx * 4 + 1));
+      it.impact = clamp15(Math.round(fy * 4 + 1));
+      render(); announce(`${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+    }
+  } else if (state.view === "list") {
+    const list = document.getElementById("v-list");
+    const cards = [...list.querySelectorAll(".card")];
+    const over = under && under.closest(".card");
+    let to = over ? cards.indexOf(over) : cards.length - 1;
+    const from = state.order.indexOf(drag.id);
+    if (over) { const r = over.getBoundingClientRect(); if (e.clientY > r.top + r.height/2) to++; }
+    if (to > from) to--;
+    state.order.splice(from, 1);
+    state.order.splice(Math.max(0, Math.min(to, state.order.length)), 0, drag.id);
+    render(); announce(`${byId(drag.id).title} moved to position ${state.order.indexOf(drag.id)+1}.`);
+  }
+}
+const clamp15 = v => Math.max(1, Math.min(5, v));
+
+/* ═══════════════════════ KEYBOARD ENGINE ══════════════════════════════ */
+stage.addEventListener("keydown", e => {
+  const card = e.target.closest(".card"); if (!card) return;
+  const id = card.dataset.id, it = byId(id);
+  const keys = ["ArrowUp","ArrowDown","ArrowLeft","ArrowRight"];
+  if (!keys.includes(e.key)) return;
+  e.preventDefault();
+  if (state.view === "list") {
+    const i = state.order.indexOf(id);
+    const j = e.key === "ArrowUp" ? i - 1 : e.key === "ArrowDown" ? i + 1 : i;
+    if (j !== i && j >= 0 && j < state.order.length) {
+      state.order.splice(i, 1); state.order.splice(j, 0, id);
+      refocus(id, `${it.title} now position ${j+1}.`);
+    }
+  } else if (state.view === "matrix") {
+    if (e.key === "ArrowUp")    it.impact = clamp15(it.impact + 1);
+    if (e.key === "ArrowDown")  it.impact = clamp15(it.impact - 1);
+    const dir = state.rtl ? -1 : 1;
+    if (e.key === "ArrowRight") it.effort = clamp15(it.effort + dir);
+    if (e.key === "ArrowLeft")  it.effort = clamp15(it.effort - dir);
+    refocus(id, `${it.title}: impact ${it.impact}, effort ${it.effort}, RICE ${rice(it)}.`);
+  } else {
+    const sch = BUCKET_SCHEMES[state.bucketScheme], order = sch.defs.map(d => d.key);
+    const cur = order.indexOf(state.bucket[id]);
+    const step = (e.key === "ArrowRight" ? 1 : e.key === "ArrowLeft" ? -1 : 0) * (state.rtl ? -1 : 1);
+    const nx = cur + step;
+    if (step && nx >= 0 && nx < order.length) {
+      state.bucket[id] = order[nx];
+      refocus(id, `${it.title} moved to ${sch.defs[nx].label}.`);
+    }
+  }
+});
+function refocus(id, msg) {
+  render();
+  const el = stage.querySelector(`.card[data-id="${id}"]`);
+  if (el) el.focus();
+  announce(msg);
+}
+
+/* ═══════════════════════ COPY-PROMPT BAR ══════════════════════════════ */
+function updatePrompt() {
+  let txt = "";
+  if (state.view === "matrix") {
+    const sorted = [...ITEMS].sort((a,b) => rice(b) - rice(a));
+    const top = sorted.slice(0,3).map(i => i.title);
+    const sink = sorted[sorted.length-1];
+    txt = `Prioritize the backlog by <b>RICE</b>. Top: <b>${esc(top.join(", "))}</b>. `
+        + `Deprioritize <span class="warm">${esc(sink.title)}</span> (RICE ${rice(sink)} — low impact for the effort).`;
+  } else if (state.view === "list") {
+    const o = state.order.map((id,i) => `${i+1}. ${byId(id).title}`);
+    txt = `Work the backlog in this <b>explicit order</b>: ${esc(o.join("  ·  "))}.`;
+  } else {
+    const sch = BUCKET_SCHEMES[state.bucketScheme];
+    txt = sch.defs.map(b => {
+      const names = ITEMS.filter(i => state.bucket[i.id] === b.key).map(i => i.title);
+      return `<b>${b.label}:</b> ${names.length ? esc(names.join(", ")) : "—"}`;
+    }).join("  ·  ");
+    txt = `Scope decision (${state.bucketScheme === "moscow" ? "MoSCoW" : "Now/Next/Later"}). ${txt}.`;
+  }
+  document.getElementById("promptOut").innerHTML = txt;
+}
+document.getElementById("copyBtn").addEventListener("click", () => {
+  const txt = document.getElementById("promptOut").textContent;
+  navigator.clipboard.writeText(txt).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "✓ Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 Copy decision"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+/* ═══════════════════════ CHROME / EVENTS ══════════════════════════════ */
+document.getElementById("views").addEventListener("click", e => {
+  const b = e.target.closest("[data-view]"); if (!b) return;
+  state.view = b.dataset.view;
+  document.querySelectorAll("#views button").forEach(x => x.setAttribute("aria-pressed", x.dataset.view === state.view));
+  render();
+});
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl;
+  document.documentElement.dir = state.rtl ? "rtl" : "ltr";
+  e.currentTarget.setAttribute("aria-pressed", state.rtl);
+  render();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/src/skills/shared/assets/playground-exemplars/homeos-arieh.html
+++ b/src/skills/shared/assets/playground-exemplars/homeos-arieh.html
@@ -1,0 +1,830 @@
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  CANONICAL GOLD-STANDARD REFERENCE — "HomeOS · App UI Explorer"
+  Designed by Arieh. Committed verbatim as the quality bar for OrchestKit
+  visual playgrounds. Do not edit — study it.
+
+  Why it is the bar (see skills/shared/rules/playground-visual-standard.md):
+   • USER-STORY PLAYER archetype: high-fidelity device mockups (WhatsApp phone
+     w/ notch + chat bubbles + typing dots, kitchen tablet, kanban).
+   • Plays a user story with a transport (play / prev / next).
+   • Cause→effect flow arrow: a forwarded message becomes a calendar-event card.
+   • Warm-glass persona: gradient mesh, backdrop-filter, two-part shadows.
+   • RTL Hebrew first-class via logical properties. 1-click copy-prompt bar.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<!doctype html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>HomeOS · App UI Explorer</title>
+<style>
+  /* ───────────────────────────────────────────────────────────────
+     HomeOS — App UI & User-Story Explorer
+     Single-file, no external deps. RTL Hebrew first-class.
+     Aesthetic: warm "family tech" — emerald (WhatsApp nod) + amber,
+     glass chrome over a gradient mesh, parchment kitchen-tablet surface.
+     ─────────────────────────────────────────────────────────────── */
+  :root {
+    --bg: #0c1014;
+    --ink: #e9eef1;
+    --muted: #93a1ab;
+    --faint: #66727c;
+    --line: rgba(255,255,255,.09);
+    --glass: rgba(255,255,255,.045);
+    --glass-2: rgba(255,255,255,.07);
+    --emerald: #25d366;       /* WhatsApp green */
+    --emerald-deep: #0e7c66;
+    --amber: #f5a623;
+    --rose: #e8748a;
+    --sky: #5aa9e6;
+    --teal: #2dd4bf;
+    --radius: 18px;
+    --shadow: 0 20px 50px -20px rgba(0,0,0,.7);
+    --font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI",
+            "Assistant", "Heebo", "Rubik", system-ui, sans-serif;
+    --mono: "SF Mono", "JetBrains Mono", "Fira Code", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    font-family: var(--font);
+    color: var(--ink);
+    background:
+      radial-gradient(900px 600px at 88% -8%, rgba(37,211,102,.16), transparent 60%),
+      radial-gradient(800px 620px at 6% 108%, rgba(245,166,35,.13), transparent 58%),
+      radial-gradient(700px 500px at 50% 50%, rgba(45,212,191,.06), transparent 70%),
+      var(--bg);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased;
+    overflow: hidden;
+  }
+
+  .app {
+    height: 100vh;
+    display: grid;
+    grid-template-columns: 350px 1fr;
+    gap: 18px;
+    padding: 18px;
+  }
+
+  /* ── Controls panel ───────────────────────────────────────────── */
+  .panel {
+    background: var(--glass);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+  }
+  .controls {
+    padding: 20px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+  }
+  .brand { display: flex; align-items: center; gap: 12px; }
+  .brand .logo {
+    width: 42px; height: 42px; border-radius: 13px; flex: none;
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep));
+    display: grid; place-items: center;
+    box-shadow: 0 8px 22px -8px rgba(37,211,102,.7), inset 0 1px 0 rgba(255,255,255,.4);
+    font-size: 22px;
+  }
+  .brand h1 { margin: 0; font-size: 18px; letter-spacing: -.2px; }
+  .brand p { margin: 2px 0 0; font-size: 11.5px; color: var(--muted); letter-spacing: .2px; }
+
+  .group { display: flex; flex-direction: column; gap: 10px; }
+  .group > .label {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 1.4px;
+    color: var(--faint); font-weight: 600; display:flex; justify-content:space-between; align-items:center;
+  }
+
+  /* scenario cards */
+  .scn {
+    text-align: start; width: 100%; cursor: pointer;
+    background: var(--glass); border: 1px solid var(--line);
+    border-radius: 14px; padding: 12px 13px; color: var(--ink);
+    display: flex; gap: 11px; align-items: flex-start;
+    transition: transform .18s ease, border-color .18s, background .18s, box-shadow .18s;
+    font-family: inherit;
+  }
+  .scn:hover { transform: translateY(-2px); background: var(--glass-2); border-color: rgba(255,255,255,.18); }
+  .scn[aria-pressed="true"] {
+    border-color: rgba(37,211,102,.6);
+    background: linear-gradient(180deg, rgba(37,211,102,.14), rgba(37,211,102,.04));
+    box-shadow: 0 10px 30px -16px rgba(37,211,102,.6);
+  }
+  .scn .ico { font-size: 20px; line-height: 1; margin-top: 1px; }
+  .scn .tt { font-size: 13.5px; font-weight: 650; letter-spacing: -.1px; }
+  .scn .sb { font-size: 11.5px; color: var(--muted); margin-top: 3px; line-height: 1.45; }
+  .scn .soon {
+    font-size: 9.5px; font-weight: 700; letter-spacing: .5px; color: #0c1014;
+    background: var(--amber); border-radius: 999px; padding: 2px 7px; margin-inline-start: auto; align-self:center;
+  }
+
+  /* segmented control */
+  .seg { display: flex; background: rgba(0,0,0,.28); border: 1px solid var(--line); border-radius: 12px; padding: 4px; gap: 4px; }
+  .seg button {
+    flex: 1; border: 0; background: transparent; color: var(--muted);
+    font-family: inherit; font-size: 12.5px; font-weight: 600; padding: 9px 6px; border-radius: 9px;
+    cursor: pointer; transition: .16s; letter-spacing: -.1px;
+  }
+  .seg button:hover { color: var(--ink); }
+  .seg button[aria-pressed="true"] {
+    background: linear-gradient(180deg, var(--glass-2), rgba(255,255,255,.03));
+    color: var(--ink); box-shadow: 0 2px 10px -4px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.12);
+  }
+
+  /* family chips */
+  .fam { display: flex; gap: 8px; flex-wrap: wrap; }
+  .chip {
+    display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+    background: var(--glass); border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 11px 5px 6px; font-size: 12.5px; color: var(--ink); transition: .16s; font-family: inherit;
+  }
+  .chip[aria-pressed="false"] { opacity: .4; filter: grayscale(.6); }
+  .chip:hover { border-color: rgba(255,255,255,.22); }
+  .av {
+    width: 22px; height: 22px; border-radius: 999px; display: grid; place-items: center;
+    font-size: 11px; font-weight: 800; color: #0c1014;
+  }
+
+  /* transport */
+  .transport { display: flex; gap: 8px; }
+  .btn {
+    flex: 1; cursor: pointer; font-family: inherit; font-size: 13px; font-weight: 650;
+    border-radius: 11px; padding: 11px; border: 1px solid var(--line);
+    background: var(--glass); color: var(--ink); transition: .16s;
+    display: inline-flex; align-items: center; justify-content: center; gap: 7px;
+  }
+  .btn:hover { background: var(--glass-2); transform: translateY(-1px); }
+  .btn.primary {
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep));
+    border-color: transparent; color: #05140d;
+    box-shadow: 0 10px 26px -12px rgba(37,211,102,.8);
+  }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+
+  .hint { font-size: 11.5px; color: var(--faint); line-height: 1.5; }
+  .hint b { color: var(--muted); font-weight: 650; }
+
+  /* ── Stage ────────────────────────────────────────────────────── */
+  .stage { display: grid; grid-template-rows: auto 1fr auto; gap: 16px; min-width: 0; }
+  .stage-head {
+    display: flex; align-items: center; justify-content: space-between; gap: 16px;
+  }
+  .stage-title { min-width: 0; }
+  .stage-title h2 { margin: 0; font-size: 19px; letter-spacing: -.3px; }
+  .stage-title p { margin: 3px 0 0; font-size: 12.5px; color: var(--muted); }
+  .view-switch { flex: none; width: 360px; max-width: 42vw; }
+
+  .stage-body {
+    background: var(--glass); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 26px; overflow: auto; display: grid; place-items: center; position: relative;
+  }
+  .stage-body::before {
+    content: ""; position: absolute; inset: 0; border-radius: var(--radius); pointer-events: none;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.05);
+  }
+
+  /* ── WhatsApp phone view ──────────────────────────────────────── */
+  .wa-wrap { display: flex; gap: 34px; align-items: center; flex-wrap: wrap; justify-content: center; }
+
+  .phone {
+    width: 330px; height: 660px; border-radius: 42px; padding: 12px;
+    background: linear-gradient(160deg, #1c2530, #0b0f14);
+    box-shadow: var(--shadow), inset 0 0 0 2px rgba(255,255,255,.06);
+    flex: none; position: relative;
+  }
+  .phone::after { /* notch */
+    content: ""; position: absolute; top: 18px; left: 50%; transform: translateX(-50%);
+    width: 120px; height: 26px; background: #05080b; border-radius: 0 0 16px 16px; z-index: 5;
+  }
+  .screen {
+    height: 100%; border-radius: 31px; overflow: hidden; display: flex; flex-direction: column;
+    background: #0b141a;
+  }
+  .wa-head {
+    background: #1f2c34; padding: 16px 14px 12px; display: flex; align-items: center; gap: 11px;
+    border-bottom: 1px solid rgba(0,0,0,.4);
+  }
+  .wa-head .bot-av {
+    width: 38px; height: 38px; border-radius: 999px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep)); font-size: 19px;
+    box-shadow: inset 0 1px 0 rgba(255,255,255,.4);
+  }
+  .wa-head .nm { font-size: 14.5px; font-weight: 650; color: #e9eef1; }
+  .wa-head .st { font-size: 11px; color: #8aa0ad; margin-top: 1px; }
+  .wa-head .dots { margin-inline-start: auto; color: #8aa0ad; font-size: 18px; letter-spacing: 1px; }
+
+  .wa-body {
+    flex: 1; overflow-y: auto; padding: 16px 12px; display: flex; flex-direction: column; gap: 8px;
+    background-color: #0b141a;
+    background-image:
+      radial-gradient(rgba(255,255,255,.022) 1px, transparent 1px),
+      radial-gradient(rgba(255,255,255,.022) 1px, transparent 1px);
+    background-size: 26px 26px, 26px 26px;
+    background-position: 0 0, 13px 13px;
+  }
+  .wa-body::-webkit-scrollbar { width: 0; }
+  .day-pill {
+    align-self: center; font-size: 10.5px; color: #c9d6dd; background: #1f2c34;
+    padding: 4px 12px; border-radius: 8px; margin-bottom: 4px; box-shadow: 0 1px 3px rgba(0,0,0,.3);
+  }
+
+  .bubble {
+    max-width: 80%; padding: 7px 10px 6px; border-radius: 11px; font-size: 13.5px; line-height: 1.5;
+    position: relative; white-space: pre-wrap; word-break: break-word;
+    animation: pop .34s cubic-bezier(.2,.8,.25,1) both; box-shadow: 0 1px 1px rgba(0,0,0,.3);
+  }
+  .bubble .meta { font-size: 9.5px; color: rgba(255,255,255,.5); margin-top: 3px; text-align: start; display:flex; gap:4px; align-items:center; justify-content:flex-start; }
+  .bubble.out { align-self: flex-end; background: #056452; color: #eafff4; border-top-right-radius: 3px; }
+  .bubble.in  { align-self: flex-start; background: #202d35; color: #e9eef1; border-top-left-radius: 3px; }
+  .bubble.bot { align-self: flex-start; background: linear-gradient(180deg,#10231b,#0f1d18); color: #eafff4; border: 1px solid rgba(37,211,102,.35); border-top-left-radius: 3px; }
+  .bubble.bot .botbadge { font-size: 9px; font-weight: 800; letter-spacing:.4px; color: var(--emerald); margin-bottom: 3px; display:flex; gap:5px; align-items:center; }
+  .bubble .fwd { font-size: 10.5px; color: rgba(255,255,255,.55); font-style: italic; margin-bottom: 3px; display:flex; gap:4px; align-items:center;}
+  .tick { color: #5ad7ff; }
+  .removed { opacity: .55; }
+  .removed .body { text-decoration: line-through; text-decoration-color: rgba(255,255,255,.5); }
+
+  .typing { align-self: flex-start; background: #202d35; padding: 11px 13px; border-radius: 11px; border-top-left-radius: 3px; display: inline-flex; gap: 4px; }
+  .typing span { width: 7px; height: 7px; border-radius: 999px; background: #6b7d88; animation: blink 1.2s infinite both; }
+  .typing span:nth-child(2){ animation-delay: .2s; } .typing span:nth-child(3){ animation-delay: .4s; }
+
+  .wa-input {
+    background: #1f2c34; padding: 9px 12px; display: flex; align-items: center; gap: 10px;
+  }
+  .wa-input .box { flex: 1; background: #2a3942; border-radius: 999px; padding: 9px 14px; font-size: 12.5px; color: #6b7d88; }
+  .wa-input .send { width: 38px; height: 38px; border-radius: 999px; background: var(--emerald); display: grid; place-items: center; font-size: 17px; color:#05140d; }
+
+  /* arrow + resulting card */
+  .flow-arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--muted); }
+  .flow-arrow .ar { font-size: 30px; color: var(--emerald); animation: nudge 1.8s ease-in-out infinite; }
+  .flow-arrow .cap { font-size: 11px; max-width: 130px; text-align: center; line-height: 1.5; }
+  .flow-arrow .cap b { color: var(--ink); }
+
+  .card-stage { display: flex; flex-direction: column; gap: 14px; width: 280px; }
+  .card-stage > .lbl { font-size: 11px; text-transform: uppercase; letter-spacing: 1.4px; color: var(--faint); font-weight: 600; }
+  .ecard {
+    background: #ffffff; color: #1b2430; border-radius: 16px; padding: 16px; position: relative;
+    box-shadow: var(--shadow); border: 1px solid rgba(0,0,0,.06); overflow: hidden;
+    animation: cardin .5s cubic-bezier(.2,.85,.25,1) both;
+  }
+  .ecard.gone { animation: cardout .45s ease forwards; }
+  .ecard .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; }
+  .ecard .kind { display: inline-flex; align-items: center; gap: 6px; font-size: 10.5px; font-weight: 700; letter-spacing: .3px; color: #6a7686; text-transform: uppercase; }
+  .ecard h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
+  .ecard .row { display: flex; align-items: center; gap: 8px; font-size: 13px; color: #38424f; margin-top: 6px; }
+  .ecard .row .gl { font-size: 14px; width: 18px; text-align: center; }
+  .ecard .foot { margin-top: 13px; padding-top: 12px; border-top: 1px dashed #e2e6ec; display: flex; align-items: center; justify-content: space-between; }
+  .ecard .added { font-size: 11px; color: var(--emerald-deep); font-weight: 700; display:flex; gap:5px; align-items:center;}
+  .pill-cap {
+    background: linear-gradient(180deg,#2a1408,#1a0d05); border:1px solid rgba(245,166,35,.4); color:#ffd9a0;
+    border-radius: 14px; padding: 14px 16px; font-size: 12.5px; line-height:1.6; width: 280px; box-shadow: var(--shadow);
+    animation: cardin .5s cubic-bezier(.2,.85,.25,1) both;
+  }
+  .pill-cap b { color: var(--amber); }
+
+  /* ── Kitchen tablet dashboard ─────────────────────────────────── */
+  .tablet {
+    width: min(940px, 100%); aspect-ratio: 16 / 10; border-radius: 26px; padding: 14px;
+    background: linear-gradient(160deg, #20262e, #0a0d11);
+    box-shadow: var(--shadow), inset 0 0 0 2px rgba(255,255,255,.05); flex: none;
+  }
+  .tboard {
+    height: 100%; border-radius: 16px; overflow: hidden; color: #20262e;
+    background: linear-gradient(180deg, #fbf7f0, #f1ece2);
+    display: grid; grid-template-rows: auto 1fr auto; gap: 0;
+    font-size: 13px;
+  }
+  .tbar { display: flex; align-items: center; gap: 16px; padding: 16px 20px 13px; border-bottom: 1px solid #e7e0d4; }
+  .tbar .greet { font-size: 21px; font-weight: 750; letter-spacing: -.4px; }
+  .tbar .greet small { display:block; font-size: 12px; font-weight: 600; color: #8a8276; letter-spacing: 0; margin-top: 2px; }
+  .tbar .hcal {
+    margin-inline-start: auto; text-align: end; font-size: 12.5px; color: #6f6757; line-height: 1.5;
+  }
+  .tbar .hcal b { color: #2c5e4f; }
+  .tbar .clock { font-size: 30px; font-weight: 800; letter-spacing: -1px; color:#20262e; font-variant-numeric: tabular-nums; }
+
+  .tgrid { display: grid; grid-template-columns: 1.25fr 1fr; gap: 0; min-height: 0; }
+  .col { padding: 14px 18px; overflow: auto; }
+  .col + .col { border-inline-start: 1px solid #e7e0d4; background: rgba(255,255,255,.4); }
+  .col h4 { margin: 0 0 10px; font-size: 12px; text-transform: uppercase; letter-spacing: 1.2px; color: #9a917f; display:flex; align-items:center; gap:7px; }
+  .col h4 .n { background:#e7e0d4; color:#6f6757; border-radius:999px; font-size:10px; padding:1px 7px; font-weight:700; letter-spacing:0;}
+
+  .appt { display: flex; gap: 12px; align-items: stretch; padding: 9px 0; }
+  .appt .time { font-size: 13px; font-weight: 800; color: #2c5e4f; width: 46px; flex: none; font-variant-numeric: tabular-nums; padding-top:2px; }
+  .appt .bar { width: 3px; border-radius: 3px; flex: none; background: #cfc8ba; }
+  .appt .ct { flex: 1; }
+  .appt .ct .t { font-weight: 650; font-size: 14px; }
+  .appt .ct .m { font-size: 11.5px; color: #897f6e; margin-top: 2px; display:flex; gap:8px; align-items:center; flex-wrap:wrap;}
+  .appt.glow .ct { position: relative; }
+  .appt.glow { background: linear-gradient(90deg, rgba(37,211,102,.16), transparent); border-radius: 10px; margin: 0 -8px; padding: 9px 8px; box-shadow: inset 0 0 0 1px rgba(37,211,102,.3); }
+  .justadded { font-size: 9.5px; font-weight: 800; color: #0c1014; background: var(--emerald); border-radius: 999px; padding: 1px 7px; letter-spacing:.3px;}
+
+  .mini-av { width: 19px; height: 19px; border-radius:999px; display:inline-grid; place-items:center; font-size:9.5px; font-weight:800; color:#0c1014; }
+  .tag { font-size: 10.5px; color:#6f6757; background:#efe9dd; border-radius:6px; padding:1px 7px; }
+
+  .remind { display:flex; gap:9px; align-items:center; padding:7px 0; font-size:13px; }
+  .remind .bx { width:16px; height:16px; border-radius:5px; border:2px solid #c3bbac; flex:none; }
+  .remind.done .bx { background:#2c5e4f; border-color:#2c5e4f; position:relative; }
+  .remind.done .bx::after { content:"✓"; color:#fff; font-size:11px; position:absolute; inset:0; display:grid; place-items:center; }
+  .remind.done span { text-decoration: line-through; color:#a59c8b; }
+
+  .tfoot { padding: 11px 20px; background: linear-gradient(90deg, #2c5e4f, #21483c); color: #eafff4; display:flex; align-items:center; gap:12px; font-size: 13px; }
+  .tfoot .shab { margin-inline-start:auto; font-size:12.5px; opacity:.92; }
+  .tfoot .weather { display:flex; align-items:center; gap:7px; opacity:.95; }
+
+  /* ── Task board (monday-style) ────────────────────────────────── */
+  .kanban { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; width: min(960px, 100%); }
+  .kcol { background: var(--glass); border: 1px solid var(--line); border-radius: 16px; padding: 14px; min-height: 320px; }
+  .kcol .kh { display:flex; align-items:center; gap:8px; margin-bottom: 12px; font-size: 13px; font-weight: 700; }
+  .kcol .kh .dot { width:9px; height:9px; border-radius:999px; }
+  .kcol .kh .n { margin-inline-start:auto; font-size:11px; color: var(--faint); background: rgba(0,0,0,.25); border-radius:999px; padding:1px 8px; }
+  .task { background: #fff; color:#1b2430; border-radius:12px; padding: 12px; margin-bottom: 10px; box-shadow: 0 8px 22px -16px rgba(0,0,0,.8); border:1px solid rgba(0,0,0,.05); cursor: default; transition: transform .15s; animation: cardin .4s both; }
+  .task:hover { transform: translateY(-2px); }
+  .task .tt { font-size: 13.5px; font-weight: 650; }
+  .task .tm { display:flex; align-items:center; justify-content: space-between; margin-top: 10px; }
+  .task .status { font-size: 10px; font-weight: 700; border-radius: 6px; padding: 2px 8px; }
+
+  /* ── Prompt bar ───────────────────────────────────────────────── */
+  .promptbar {
+    background: var(--glass); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 14px 16px; display: flex; align-items: center; gap: 14px;
+  }
+  .promptbar .pt {
+    flex: 1; font-family: var(--mono); font-size: 12px; line-height: 1.6; color: #c7d2da;
+    max-height: 84px; overflow-y: auto;
+  }
+  .promptbar .pt b { color: var(--emerald); font-weight: 600; }
+  .copy {
+    flex: none; cursor: pointer; font-family: inherit; font-weight: 650; font-size: 12.5px;
+    border-radius: 11px; padding: 11px 16px; border: 1px solid transparent; color: #05140d;
+    background: linear-gradient(145deg, var(--emerald), var(--emerald-deep));
+    box-shadow: 0 10px 26px -12px rgba(37,211,102,.8); transition: .16s;
+  }
+  .copy:hover { transform: translateY(-1px); }
+  .copy.done { background: var(--glass-2); color: var(--ink); box-shadow:none; border-color: var(--line); }
+
+  /* ── animations ───────────────────────────────────────────────── */
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.96); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(14px) scale(.94); } to { opacity: 1; transform: none; } }
+  @keyframes cardout { to { opacity: 0; transform: translateY(8px) scale(.9); } }
+  @keyframes blink { 0%, 60%, 100% { opacity: .3; transform: translateY(0);} 30% { opacity: 1; transform: translateY(-3px);} }
+  @keyframes nudge { 0%,100% { transform: translateY(0);} 50% { transform: translateY(6px);} }
+
+  @media (max-width: 1080px) {
+    .app { grid-template-columns: 1fr; grid-template-rows: auto 1fr; overflow:auto; height:auto; min-height:100vh; }
+    body { overflow: auto; }
+    .view-switch { width: auto; }
+  }
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- ── CONTROLS ─────────────────────────────────────────────── -->
+  <aside class="panel controls">
+    <div class="brand">
+      <div class="logo">🏠</div>
+      <div>
+        <h1>HomeOS · מגרש משחקים</h1>
+        <p>סיפורי משתמש + תצוגת UI · WhatsApp-first · עברית RTL</p>
+      </div>
+    </div>
+
+    <div class="group">
+      <div class="label"><span>סיפור משתמש</span><span>User story</span></div>
+      <div id="scnList"></div>
+    </div>
+
+    <div class="group">
+      <div class="label"><span>תצוגה</span><span>View</span></div>
+      <div class="seg" id="viewSeg">
+        <button data-view="whatsapp" aria-pressed="true">💬 WhatsApp</button>
+        <button data-view="tablet" aria-pressed="false">📺 לוח מטבח</button>
+        <button data-view="tasks" aria-pressed="false">✅ משימות</button>
+      </div>
+    </div>
+
+    <div class="group" id="transportGroup">
+      <div class="label"><span>הדגמת השיחה</span><span>Playback</span></div>
+      <div class="transport">
+        <button class="btn" id="prevBtn">‹ אחורה</button>
+        <button class="btn primary" id="playBtn">▶ הדגמה</button>
+        <button class="btn" id="nextBtn">קדימה ›</button>
+      </div>
+      <div class="hint" id="stepHint"></div>
+    </div>
+
+    <div class="group">
+      <div class="label"><span>בני המשפחה</span><span>Family</span></div>
+      <div class="fam" id="famChips"></div>
+    </div>
+
+    <div class="hint" style="margin-top:auto">
+      💡 בחרו סיפור, נגנו את ההדגמה, והחליפו ל<b>לוח המטבח</b> כדי לראות איך הפריט נוחת על הלוח.
+      העתיקו את ההנחיה למטה כדי לבנות את ה‑UI האמיתי.
+    </div>
+  </aside>
+
+  <!-- ── STAGE ────────────────────────────────────────────────── -->
+  <main class="stage">
+    <div class="stage-head">
+      <div class="stage-title">
+        <h2 id="stTitle"></h2>
+        <p id="stSub"></p>
+      </div>
+      <div class="view-switch"></div>
+    </div>
+
+    <section class="stage-body" id="stage"></section>
+
+    <div class="promptbar">
+      <div class="pt" id="promptOut"></div>
+      <button class="copy" id="copyBtn">📋 העתק הנחיה</button>
+    </div>
+  </main>
+</div>
+
+<script>
+/* ── Family roster ─────────────────────────────────────────────── */
+const FAM = {
+  aba:  { he:"אבא",  init:"א", color:"#5aa9e6" },
+  ima:  { he:"אמא",  init:"א", color:"#e8748a" },
+  yoav: { he:"יואב", init:"י", color:"#f5a623" },
+  noa:  { he:"נועה", init:"נ", color:"#2dd4bf" },
+};
+const av = (k, big) => {
+  const f = FAM[k]; if (!f) return "";
+  const cls = big ? "mini-av" : "mini-av";
+  return `<span class="${cls}" style="background:${f.color}">${f.init}</span>`;
+};
+
+/* ── Scenarios ─────────────────────────────────────────────────── */
+const SCN = {
+  "forward-school": {
+    ico:"🏫", tt:"העברת הודעה מבית הספר", sb:"הורה מעביר הודעת WhatsApp מהגן → אירוע על הלוח",
+    title:"מעבירים הודעה — היא הופכת לאירוע",
+    sub:"הזרימה היחידה שצריך ללמד את המשפחה: forward → אישור בעברית.",
+    chat:[
+      { kind:"out", fwd:"הועבר", body:"הורים יקרים 🌿 אסיפת הורים תתקיים ביום חמישי 18/6 בשעה 17:00 בגן רימון. נא לאשר הגעה. תודה, צוות הגן", time:"21:34" },
+      { kind:"typing" },
+      { kind:"bot", body:"הוספתי ליומן ✓\nאסיפת הורים · יום חמישי, 18 ביוני · 17:00 — גן רימון", time:"21:34" },
+    ],
+    cardAtStep:2,
+    card:{ kindHe:"אירוע", glyph:"📅", color:"#5aa9e6", title:"אסיפת הורים",
+      rows:[["📍","גן רימון"],["🗓️","יום חמישי, 18 ביוני"],["⏰","17:00"]], who:"ima" },
+  },
+  "direct-command": {
+    ico:"🗣️", tt:"פקודה בשפה חופשית", sb:"לא רק העברה — לכתוב ישירות לבוט בגוף ראשון",
+    title:"פקודה ישירה — גוף ראשון הופך לאחראי",
+    sub:"\"יש לי…\" → ה‑assignee הוא השולח (מתוך מפת MEMBERS, server-supplied).",
+    chat:[
+      { kind:"out", body:"יש לי פיזיותרפיה ביום שני, תכניס ליומן", time:"08:12" },
+      { kind:"typing" },
+      { kind:"bot", body:"הוספתי ליומן ✓\nפיזיותרפיה · יום שני, 22 ביוני — אבא", time:"08:12" },
+    ],
+    cardAtStep:2,
+    card:{ kindHe:"משימה", glyph:"🩺", color:"#f5a623", title:"פיזיותרפיה",
+      rows:[["🗓️","יום שני, 22 ביוני"],["👤","אבא (השולח)"]], who:"aba" },
+  },
+  "undo": {
+    ico:"↩️", tt:"ביטול (Undo)", sb:"טעות בפענוח? מילה אחת מחזירה את המצב",
+    title:"ביטול — שחזור מטעות בלחיצה אחת",
+    sub:"\"ביטול\" נתפס לפני המודל — מוחק את אירועי ההודעה האחרונה.",
+    chat:[
+      { kind:"out", body:"אסיפת הורים מחר ב-17:00", time:"21:40" },
+      { kind:"bot", body:"הוספתי ליומן ✓\nאסיפת הורים · יום חמישי, 18 ביוני · 17:00", time:"21:40" },
+      { kind:"out", body:"ביטול", time:"21:41" },
+      { kind:"bot", body:"בוטל ✓", time:"21:41" },
+    ],
+    cardAtStep:1, cardRemovedAtStep:3,
+    card:{ kindHe:"אירוע", glyph:"📅", color:"#5aa9e6", title:"אסיפת הורים",
+      rows:[["🗓️","יום חמישי, 18 ביוני"],["⏰","17:00"]], who:"ima" },
+  },
+  "daily-cap": {
+    ico:"🛡️", tt:"מכסת הודעות יומית (G16)", sb:"גבול עלות לכל שולח — שומר על ≤$100 לחודש",
+    title:"מכסה יומית לכל שולח — בלם עלות",
+    sub:"allowlist מגביל מי, גבול אורך מגביל גודל, וזה מגביל קצב — לפני כל קריאה ל‑Claude.",
+    chat:[
+      { kind:"out", body:"תזכורת לחלב 🥛", time:"23:01" },
+      { kind:"out", body:"וגם ביצים", time:"23:01" },
+      { kind:"out", body:"... (הודעה 51 היום)", time:"23:02" },
+      { kind:"typing" },
+      { kind:"bot", body:"הגעת למכסת ההודעות היומית 🙏 נמשיך מחר.", time:"23:02" },
+    ],
+    cardAtStep:4, capCard:true,
+  },
+  "gmail-calendar": {
+    ico:"📧", ph:"5", tt:"סנכרון Gmail + יומן Google", sb:"מקורות נוספים מעבר ל‑WhatsApp",
+    title:"Phase 5 — Gmail + Google Calendar",
+    sub:"מייל מהגן → אירוע; סנכרון דו‑כיווני ליומן Google. כלי נוסף שמתחבר ל‑registry של הסוכן.",
+    chat:[
+      { kind:"in", body:"✉️ Gmail · גן רימון\nנושא: טיול שנתי — יום ג׳ 23/6, להביא כובע ומים", time:"09:00" },
+      { kind:"typing" },
+      { kind:"bot", body:"הוספתי ליומן ✓ (מ‑Gmail)\nטיול שנתי · יום שלישי, 23 ביוני 🎒\nסונכרן ל‑Google Calendar ↗", time:"09:00" },
+    ],
+    cardAtStep:2, soon:true,
+    card:{ kindHe:"אירוע · Gmail", glyph:"🎒", color:"#2dd4bf", title:"טיול שנתי",
+      rows:[["🗓️","יום שלישי, 23 ביוני"],["🎒","כובע + מים"],["↗","סונכרן ליומן Google"]], who:"yoav" },
+  },
+};
+const SCN_ORDER = ["forward-school","direct-command","undo","daily-cap","gmail-calendar"];
+
+/* ── Board data (kitchen tablet) ───────────────────────────────── */
+const APPTS = [
+  { time:"08:00", t:"הסעה לבית הספר", who:["yoav"], tag:"אבא מסיע", color:"#5aa9e6" },
+  { time:"14:30", t:"איסוף מהצהרון", who:["noa"], tag:"אמא אוספת", color:"#e8748a" },
+  { time:"17:00", t:"אסיפת הורים", who:["ima"], tag:"גן רימון", color:"#5aa9e6", scn:"forward-school" },
+  { time:"18:00", t:"פיזיותרפיה", who:["aba"], tag:"", color:"#f5a623", scn:"direct-command" },
+  { time:"19:00", t:"חוג כדורגל", who:["yoav"], tag:"", color:"#2dd4bf" },
+];
+const REMIND = [
+  { t:"לשלם תשלום לבית הספר", done:false, who:["aba"] },
+  { t:"לחדש מרשם לרופא", done:false, who:["ima"] },
+  { t:"לקנות מתנה ליום הולדת של נועה", done:true, who:["ima"] },
+];
+const TASKS = {
+  todo:[ {t:"קניות לשבת", who:"ima"}, {t:"תשלום ארנונה", who:"aba"} ],
+  doing:[ {t:"לתאם רופא שיניים ליואב", who:"ima"} ],
+  done:[ {t:"להזמין שולחן למסעדה", who:"aba"} ],
+};
+
+/* ── State ─────────────────────────────────────────────────────── */
+const state = {
+  scn: "forward-school",
+  view: "whatsapp",
+  step: 0,
+  fam: { aba:true, ima:true, yoav:true, noa:true },
+  playing: false,
+};
+let playTimer = null;
+
+/* ── Build controls ────────────────────────────────────────────── */
+const scnList = document.getElementById("scnList");
+scnList.innerHTML = SCN_ORDER.map(id => {
+  const s = SCN[id];
+  return `<button class="scn" data-scn="${id}" aria-pressed="${id===state.scn}" style="margin-bottom:8px">
+    <span class="ico">${s.ico}</span>
+    <span style="flex:1">
+      <span class="tt">${s.tt}</span>
+      <span class="sb">${s.sb}</span>
+    </span>
+    ${s.soon ? '<span class="soon">בקרוב</span>' : ''}
+  </button>`;
+}).join("");
+
+const famChips = document.getElementById("famChips");
+famChips.innerHTML = Object.keys(FAM).map(k =>
+  `<button class="chip" data-fam="${k}" aria-pressed="true">
+    <span class="av" style="background:${FAM[k].color}">${FAM[k].init}</span>${FAM[k].he}
+  </button>`
+).join("");
+
+/* ── Renderers ─────────────────────────────────────────────────── */
+const stage = document.getElementById("stage");
+
+function maxStep() { return SCN[state.scn].chat.length - 1; }
+
+function renderHead() {
+  const s = SCN[state.scn];
+  document.getElementById("stTitle").textContent = s.title;
+  document.getElementById("stSub").textContent = s.sub;
+  document.getElementById("transportGroup").style.display = state.view === "whatsapp" ? "" : "none";
+  const last = maxStep();
+  document.getElementById("stepHint").innerHTML =
+    `שלב <b>${Math.min(state.step+1, last+1)}</b> מתוך <b>${last+1}</b>`;
+  document.getElementById("prevBtn").disabled = state.step <= 0;
+  document.getElementById("nextBtn").disabled = state.step >= last;
+}
+
+function chatBubble(m) {
+  if (m.kind === "typing") return `<div class="typing"><span></span><span></span><span></span></div>`;
+  if (m.kind === "bot") return `<div class="bubble bot">
+      <div class="botbadge">🏠 HomeOS</div><div class="body">${esc(m.body)}</div>
+      <div class="meta">${m.time||""} ✓✓</div></div>`;
+  if (m.kind === "in") return `<div class="bubble in"><div class="body">${esc(m.body)}</div><div class="meta">${m.time||""}</div></div>`;
+  // out
+  return `<div class="bubble out">
+    ${m.fwd ? `<div class="fwd">↪ ${m.fwd}</div>` : ""}
+    <div class="body">${esc(m.body)}</div>
+    <div class="meta">${m.time||""} <span class="tick">✓✓</span></div></div>`;
+}
+
+function renderWhatsApp() {
+  const s = SCN[state.scn];
+  const shown = s.chat.slice(0, state.step + 1);
+  const bubbles = shown.map(chatBubble).join("");
+
+  // resulting card logic
+  let cardHtml = `<div class="flow-arrow" style="opacity:.4"><div class="cap">נגנו את ההדגמה כדי לראות את התוצאה ◀</div></div>`;
+  const reached = state.step >= (s.cardAtStep ?? 99);
+  if (reached && s.capCard) {
+    cardHtml = `<div class="pill-cap">🛡️ <b>מכסת הודעות יומית (G16)</b><br>
+      ה‑allowlist מגביל <b>מי</b>, גבול האורך מגביל <b>גודל</b>, וזה מגביל <b>קצב</b>.<br>
+      ההודעה ה‑51 לא נשלחת ל‑Claude — מענה שקט בעברית, ואיפוס בחצות (Asia/Jerusalem).</div>`;
+  } else if (reached && s.card) {
+    const c = s.card;
+    const removed = s.cardRemovedAtStep != null && state.step >= s.cardRemovedAtStep;
+    cardHtml = `<div class="card-stage">
+      <div class="lbl">הכרטיס שנוצר על הלוח</div>
+      <div class="ecard ${removed ? 'gone' : ''}">
+        <div class="stripe" style="background:${c.color}"></div>
+        <div class="kind">${c.glyph} ${c.kindHe}</div>
+        <h3>${c.title}</h3>
+        ${c.rows.map(r=>`<div class="row"><span class="gl">${r[0]}</span>${esc(r[1])}</div>`).join("")}
+        <div class="foot">
+          <span class="added">${removed ? '↩️ בוטל' : '✓ נוסף ליומן'}</span>
+          ${c.who ? `<span style="display:flex;gap:6px;align-items:center;font-size:12px;color:#56616f">${av(c.who)} ${FAM[c.who].he}</span>`:''}
+        </div>
+      </div>
+      ${removed ? `<div class="hint" style="color:#e8748a">מילת ה‑"ביטול" מחקה את אירועי ההודעה האחרונה — לפני שהיא נשלחת ל‑Claude.</div>`:''}
+    </div>`;
+  }
+
+  stage.innerHTML = `<div class="wa-wrap">
+    <div class="phone"><div class="screen">
+      <div class="wa-head">
+        <div class="bot-av">🏠</div>
+        <div><div class="nm">HomeOS</div><div class="st">בוט משפחתי · מקוון</div></div>
+        <div class="dots">⋮</div>
+      </div>
+      <div class="wa-body" id="waBody">
+        <div class="day-pill">היום</div>
+        ${bubbles}
+      </div>
+      <div class="wa-input">
+        <div class="box">הקלידו הודעה…</div>
+        <div class="send">➤</div>
+      </div>
+    </div></div>
+    ${cardHtml}
+  </div>`;
+  const body = document.getElementById("waBody");
+  if (body) body.scrollTop = body.scrollHeight;
+}
+
+function famOn(list){ return !list || list.some(k => state.fam[k]); }
+
+function renderTablet() {
+  const activeScn = SCN[state.scn];
+  const justAdded = activeScn && activeScn.card ? state.scn : null;
+
+  const appts = APPTS.filter(a => famOn(a.who)).map(a => {
+    const glow = a.scn && a.scn === justAdded;
+    return `<div class="appt ${glow?'glow':''}">
+      <div class="time">${a.time}</div>
+      <div class="bar" style="background:${a.color}"></div>
+      <div class="ct">
+        <div class="t">${a.t}</div>
+        <div class="m">
+          ${a.who.map(w=>`<span style="display:inline-flex;gap:5px;align-items:center">${av(w)}${FAM[w].he}</span>`).join("")}
+          ${a.tag?`<span class="tag">${a.tag}</span>`:""}
+          ${glow?`<span class="justadded">נוסף עכשיו</span>`:""}
+        </div>
+      </div>
+    </div>`;
+  }).join("") || `<div class="hint" style="color:#a59c8b">אין פריטים לבני המשפחה שנבחרו</div>`;
+
+  const reminders = REMIND.filter(r=>famOn(r.who)).map(r =>
+    `<div class="remind ${r.done?'done':''}"><div class="bx"></div><span>${r.t}</span></div>`
+  ).join("");
+
+  stage.innerHTML = `<div class="tablet"><div class="tboard">
+    <div class="tbar">
+      <div class="greet">בוקר טוב, משפחת לוי 🌅<small>יום רביעי, 17 ביוני 2026</small></div>
+      <div class="clock">07:42</div>
+      <div class="hcal"><b>כ״ב בְּסִיוָן תשפ״ו</b><br>פרשת שלח · 3 ימים לשבת</div>
+    </div>
+    <div class="tgrid">
+      <div class="col">
+        <h4>📅 היום <span class="n">${APPTS.filter(a=>famOn(a.who)).length}</span></h4>
+        ${appts}
+      </div>
+      <div class="col">
+        <h4>🔔 תזכורות <span class="n">${REMIND.filter(r=>famOn(r.who)).length}</span></h4>
+        ${reminders}
+        <h4 style="margin-top:18px">👨‍👩‍👧‍👦 מי אוסף</h4>
+        <div class="remind"><span style="display:inline-flex;gap:6px;align-items:center">${av('aba')} אבא</span> <span class="tag">יואב · 08:00</span></div>
+        <div class="remind"><span style="display:inline-flex;gap:6px;align-items:center">${av('ima')} אמא</span> <span class="tag">נועה · 14:30</span></div>
+      </div>
+    </div>
+    <div class="tfoot">
+      <span class="weather">☀️ 29°C · תל אביב</span>
+      <span class="shab">🕯️ כניסת שבת 19:34 · שבת שלום</span>
+    </div>
+  </div></div>`;
+}
+
+function renderTasks() {
+  const justTitle = SCN[state.scn]?.card?.title;
+  const colDef = [
+    { key:"todo",  he:"לעשות",   dot:"#f5a623", st:"#fff7ec", stc:"#b97e12" },
+    { key:"doing", he:"בתהליך",  dot:"#5aa9e6", st:"#eaf4ff", stc:"#2f6fb0" },
+    { key:"done",  he:"הושלם",   dot:"#2c5e4f", st:"#e9f7f0", stc:"#1f7a5e" },
+  ];
+  const cols = colDef.map(c => {
+    const items = TASKS[c.key].filter(t => state.fam[t.who]);
+    return `<div class="kcol">
+      <div class="kh"><span class="dot" style="background:${c.dot}"></span>${c.he}<span class="n">${items.length}</span></div>
+      ${items.map(t=>`<div class="task">
+        <div class="tt">${t.t}</div>
+        <div class="tm">
+          <span style="display:flex;gap:6px;align-items:center;font-size:12px;color:#56616f">${av(t.who)} ${FAM[t.who].he}</span>
+          <span class="status" style="background:${c.st};color:${c.stc}">${c.he}</span>
+        </div>
+      </div>`).join("") || `<div class="hint" style="opacity:.5">—</div>`}
+    </div>`;
+  }).join("");
+  stage.innerHTML = `<div style="width:100%;max-width:980px">
+    <div class="hint" style="margin-bottom:14px">לוח משימות משפחתי — "monday.com לבית": משימה לכל אחד, סטטוס, אחראי. כל פריט שנוצר בוואטסאפ נוחת כאן או בלוח "היום".</div>
+    <div class="kanban">${cols}</div>
+  </div>`;
+}
+
+function render() {
+  renderHead();
+  if (state.view === "whatsapp") renderWhatsApp();
+  else if (state.view === "tablet") renderTablet();
+  else renderTasks();
+  updatePrompt();
+}
+
+/* ── Playback ──────────────────────────────────────────────────── */
+function stopPlay(){ state.playing=false; clearTimeout(playTimer); document.getElementById("playBtn").innerHTML="▶ הדגמה"; }
+function play() {
+  if (state.playing) { stopPlay(); return; }
+  state.playing = true;
+  document.getElementById("playBtn").innerHTML = "⏸ עצור";
+  state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) { stopPlay(); return; }
+    state.step++;
+    render();
+    const cur = SCN[state.scn].chat[state.step];
+    playTimer = setTimeout(tick, cur && cur.kind === "typing" ? 1100 : 1500);
+  };
+  tick();
+}
+
+/* ── Prompt output ─────────────────────────────────────────────── */
+function updatePrompt() {
+  const s = SCN[state.scn];
+  const viewHe = { whatsapp:"מסך WhatsApp (טלפון) עם כרטיס האירוע שנוצר",
+                   tablet:"לוח המטבח האמביינטי (טאבלט נחיתה) — תצוגת 'היום'",
+                   tasks:"לוח המשימות המשפחתי (קנבן בסגנון monday.com)" }[state.view];
+  const on = Object.keys(state.fam).filter(k=>state.fam[k]).map(k=>FAM[k].he);
+  const famTxt = on.length === 4 ? "כל המשפחה" : on.join(", ") || "אף אחד";
+  const parts = [];
+  parts.push(`בנה את ה‑UI של <b>HomeOS</b> — ${viewHe}`);
+  parts.push(`עבור סיפור המשתמש "<b>${s.tt}</b>": ${s.sub}`);
+  if (state.view === "whatsapp") parts.push(`הצג את שרשור ה‑WhatsApp (RTL) ולצדו את כרטיס האירוע שנוצר, עם אנימציית הופעה`);
+  if (state.view !== "whatsapp") parts.push(`מסונן ל: ${famTxt}`);
+  parts.push(`עברית RTL כשפה ראשונה, הקשר משפחה ישראלית (אבא/אמא/ילדים), אסתטיקה חמה (אמרלד+ענבר), זכוכית/צללים רכים, ≤$100 לחודש (Haiku), מובייל‑first`);
+  document.getElementById("promptOut").innerHTML = parts.join(". ") + ".";
+}
+
+/* ── Events ────────────────────────────────────────────────────── */
+scnList.addEventListener("click", e => {
+  const b = e.target.closest("[data-scn]"); if (!b) return;
+  stopPlay();
+  state.scn = b.dataset.scn; state.step = 0;
+  scnList.querySelectorAll(".scn").forEach(x => x.setAttribute("aria-pressed", x.dataset.scn === state.scn));
+  render();
+});
+document.getElementById("viewSeg").addEventListener("click", e => {
+  const b = e.target.closest("[data-view]"); if (!b) return;
+  state.view = b.dataset.view;
+  document.querySelectorAll("#viewSeg button").forEach(x => x.setAttribute("aria-pressed", x.dataset.view === state.view));
+  render();
+});
+famChips.addEventListener("click", e => {
+  const b = e.target.closest("[data-fam]"); if (!b) return;
+  const k = b.dataset.fam; state.fam[k] = !state.fam[k];
+  b.setAttribute("aria-pressed", state.fam[k]);
+  render();
+});
+document.getElementById("playBtn").addEventListener("click", play);
+document.getElementById("prevBtn").addEventListener("click", () => { stopPlay(); state.step = Math.max(0, state.step-1); render(); });
+document.getElementById("nextBtn").addEventListener("click", () => { stopPlay(); state.step = Math.min(maxStep(), state.step+1); render(); });
+
+document.getElementById("copyBtn").addEventListener("click", () => {
+  const txt = document.getElementById("promptOut").textContent;
+  navigator.clipboard.writeText(txt).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "✓ הועתק!"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 העתק הנחיה"; b.classList.remove("done"); }, 1600);
+  });
+});
+
+function esc(s){ return String(s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c])); }
+
+/* ── Boot ──────────────────────────────────────────────────────── */
+render();
+</script>
+</body>
+</html>

--- a/src/skills/shared/assets/playground-exemplars/user-story-player.template.html
+++ b/src/skills/shared/assets/playground-exemplars/user-story-player.template.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  USER-STORY PLAYER · generalized scaffold
+  OrchestKit playground exemplar — the "user-story-player" archetype.
+
+  Conforms to: skills/shared/rules/playground-visual-standard.md
+  Persona: warm-glass. Zero dependencies. Single file. LTR with RTL-ready
+  CSS logical properties (toggle dir="rtl" on <html> and it mirrors).
+
+  WHAT THIS IS
+  ------------
+  A clean-room, de-branded version of the HomeOS gold standard
+  (homeos-arieh.html). It plays a user story inside a high-fidelity device
+  mockup, draws a cause→effect flow arrow to the resulting card, and emits a
+  copy-prompt. Replace STORY + the device chrome with your product's and keep
+  the engine.
+
+  THREE MOVES that make it a "player", not a screenshot:
+    1. DEVICE MOCKUP   — a real phone frame (notch, bezel, screen radius).
+    2. TRANSPORT       — ▶ play / ‹ prev / next › steps through the story.
+    3. FLOW ARROW      — connects the trigger to the effect it produces.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>User-Story Player · Playground</title>
+<style>
+  /* ── §2 tokens (warm-glass persona, HSL) ────────────────────────────── */
+  :root {
+    --pg-bg: hsl(20 14% 7%);
+    --pg-ink: hsl(28 20% 94%);
+    --pg-muted: hsl(28 10% 64%);
+    --pg-faint: hsl(28 8% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(160 68% 45%);     /* emerald primary */
+    --pg-accent-deep: hsl(166 70% 30%);
+    --pg-warm: hsl(38 95% 60%);        /* amber secondary */
+    --pg-shadow: 0 20px 60px -22px hsl(20 40% 2% / 0.7), 0 4px 12px -6px hsl(20 40% 2% / 0.5);
+    --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(160 68% 45% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(38 95% 60% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+  .head { display: flex; align-items: flex-start; gap: 14px; }
+  .logo { width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: 0 8px 22px -8px hsl(160 68% 40% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 62ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+
+  /* transport */
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 11px; padding: 10px 14px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink); transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent; color: hsl(160 40% 8%); box-shadow: 0 10px 26px -12px hsl(160 68% 40% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; }
+  .hint b { color: var(--pg-muted); }
+
+  /* stage: phone + flow arrow + result card */
+  .stage { padding: 26px; display: flex; gap: 30px; align-items: center; justify-content: center; flex-wrap: wrap; }
+
+  .phone { width: 300px; height: 600px; border-radius: 54px; padding: 12px; flex: none; position: relative;
+    background: linear-gradient(160deg, hsl(20 12% 16%), hsl(20 16% 7%)); box-shadow: var(--pg-shadow), inset 0 0 0 2px hsl(0 0% 100% / 0.06); }
+  .phone::after { content: ""; position: absolute; top: 16px; left: 50%; transform: translateX(-50%); width: 110px; height: 24px; background: hsl(20 30% 3%); border-radius: 0 0 16px 16px; z-index: 5; }
+  .screen { height: 100%; border-radius: 42px; overflow: hidden; display: flex; flex-direction: column; background: hsl(195 30% 8%); }
+  .app-head { padding: 16px 14px 12px; display: flex; align-items: center; gap: 11px; background: hsl(195 24% 13%); }
+  .app-head .av { width: 38px; height: 38px; border-radius: 999px; flex: none; display: grid; place-items: center; font-size: 18px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .app-head .nm { font-size: 14px; font-weight: 650; }
+  .app-head .st { font-size: 11px; color: hsl(195 14% 60%); margin-top: 1px; }
+  .body { flex: 1; overflow-y: auto; padding: 16px 12px; display: flex; flex-direction: column; gap: 8px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .bubble { max-width: 82%; padding: 8px 11px; border-radius: 12px; font-size: 13px; line-height: 1.45; animation: pop var(--pg-dur-normal) var(--pg-ease) both; }
+  .bubble.out { align-self: flex-end; background: hsl(160 50% 22%); color: hsl(150 60% 92%); border-end-end-radius: 4px; }
+  .bubble.bot { align-self: flex-start; background: hsl(195 20% 16%); border: 1px solid hsl(160 68% 45% / 0.3); border-end-start-radius: 4px; }
+  .bubble .who { font-size: 9px; font-weight: 800; letter-spacing: .4px; color: var(--pg-accent); margin-bottom: 3px; }
+  .typing { align-self: flex-start; background: hsl(195 20% 16%); padding: 11px 13px; border-radius: 12px; border-end-start-radius: 4px; display: inline-flex; gap: 4px; }
+  .typing span { width: 7px; height: 7px; border-radius: 999px; background: hsl(195 14% 50%); animation: blink 1.2s infinite both; }
+  .typing span:nth-child(2) { animation-delay: .2s; } .typing span:nth-child(3) { animation-delay: .4s; }
+
+  /* flow arrow (RTL-sensitive — flips via scaleX) */
+  .arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--pg-muted); }
+  .arrow .ar { font-size: 30px; color: var(--pg-accent); }
+  [dir="rtl"] .arrow .ar { transform: scaleX(-1); }
+  .arrow .cap { font-size: 11px; max-width: 120px; text-align: center; line-height: 1.5; }
+
+  .card { width: 250px; background: #fff; color: hsl(215 25% 16%); border-radius: var(--pg-r-md); padding: 16px; position: relative; overflow: hidden; box-shadow: var(--pg-shadow); animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .card .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; background: var(--pg-accent); }
+  .card .kind { font-size: 10.5px; font-weight: 700; letter-spacing: .3px; color: hsl(215 12% 45%); text-transform: uppercase; }
+  .card h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
+  .card .row { display: flex; gap: 8px; font-size: 13px; color: hsl(215 16% 28%); margin-top: 6px; }
+  .card .added { margin-top: 13px; padding-top: 12px; border-top: 1px dashed hsl(215 16% 88%); font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+  .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
+
+  /* copy-prompt bar */
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
+  .promptbar .pt b { color: var(--pg-accent); }
+  .copy { flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(160 40% 8%); border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: 0 10px 26px -12px hsl(160 68% 40% / 0.8); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.96); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(14px) scale(.94); } to { opacity: 1; transform: none; } }
+  @keyframes blink { 0%,60%,100% { opacity: .3; } 30% { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  }
+  @media (max-width: 720px) { .arrow .ar { transform: rotate(90deg); } [dir="rtl"] .arrow .ar { transform: rotate(90deg) scaleX(-1); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="head">
+    <div class="logo">▶️</div>
+    <div>
+      <h1>User-Story Player</h1>
+      <p>Press <b>Play</b> to watch the story unfold inside the device, then see the
+         <b>result card</b> it produces. This is the scaffold for any feature demo — swap the
+         <code>STORY</code> data and the device chrome for your product.</p>
+    </div>
+    <div class="right"><button class="toggle" id="dirToggle" aria-pressed="false">⇄ RTL</button></div>
+  </header>
+
+  <div class="panel transport">
+    <button class="btn" id="prev">‹ Back</button>
+    <button class="btn primary" id="play">▶ Play</button>
+    <button class="btn" id="next">Next ›</button>
+    <span class="hint" id="stepHint"></span>
+  </div>
+
+  <main class="panel stage" id="stage"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">📋 Copy prompt</button>
+  </div>
+</div>
+
+<script>
+/* ═══════════ STORY — replace with your product's flow ═══════════════════
+   Each step is one chat turn. `cardAtStep` is when the result card appears. */
+const STORY = {
+  appName: "Acme Assistant",
+  appStatus: "online",
+  title: "Forward a message → it becomes a scheduled task",
+  steps: [
+    { kind: "out", who: "", body: "Forwarded: \"Team offsite next Thursday 2pm at the rooftop. RSVP please.\"" },
+    { kind: "typing" },
+    { kind: "bot", who: "Acme Assistant", body: "Added to your calendar ✓\nTeam offsite · Thursday · 2:00 PM — Rooftop" },
+  ],
+  cardAtStep: 2,
+  card: { kind: "Event", title: "Team offsite", rows: ["🗓️ Thursday, 2:00 PM", "📍 Rooftop", "👥 RSVP requested"] },
+};
+
+const state = { step: 0, playing: false, rtl: false };
+let timer = null;
+const stage = document.getElementById("stage");
+const esc = s => String(s).replace(/[&<>]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+const maxStep = () => STORY.steps.length - 1;
+
+function bubble(m) {
+  if (m.kind === "typing") return `<div class="typing"><span></span><span></span><span></span></div>`;
+  if (m.kind === "bot") return `<div class="bubble bot"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`;
+  return `<div class="bubble out">${esc(m.body)}</div>`;
+}
+
+function render() {
+  const shown = STORY.steps.slice(0, state.step + 1).map(bubble).join("");
+  const reached = state.step >= STORY.cardAtStep;
+  const c = STORY.card;
+  const result = reached
+    ? `<div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
+         <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
+         <div class="added">✓ Added</div></div>`
+    : `<div class="placeholder">Play the story to see the card it creates ◀</div>`;
+
+  stage.innerHTML = `
+    <div class="phone"><div class="screen">
+      <div class="app-head"><div class="av">🤖</div>
+        <div><div class="nm">${esc(STORY.appName)}</div><div class="st">${esc(STORY.appStatus)}</div></div></div>
+      <div class="body" id="body">${shown}</div>
+    </div></div>
+    <div class="arrow"><div class="ar">➜</div><div class="cap">the message becomes a card</div></div>
+    ${result}`;
+  const b = document.getElementById("body"); if (b) b.scrollTop = b.scrollHeight;
+
+  document.getElementById("stepHint").innerHTML = `Step <b>${state.step + 1}</b> of <b>${maxStep() + 1}</b>`;
+  document.getElementById("prev").disabled = state.step <= 0;
+  document.getElementById("next").disabled = state.step >= maxStep();
+  updatePrompt();
+}
+
+function updatePrompt() {
+  document.getElementById("promptOut").innerHTML =
+    `Build the <b>${esc(STORY.appName)}</b> UI for the user story "<b>${esc(STORY.title)}</b>": show the `
+    + `chat thread inside a phone mockup, and animate the resulting <b>${esc(STORY.card.kind)}</b> card appearing beside it.`;
+}
+
+function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }
+function play() {
+  if (state.playing) return stop();
+  state.playing = true; document.getElementById("play").innerHTML = "⏸ Pause"; state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) return stop();
+    state.step++; render();
+    const cur = STORY.steps[state.step];
+    timer = setTimeout(tick, cur && cur.kind === "typing" ? 1000 : 1400);
+  };
+  tick();
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => { stop(); state.step = Math.max(0, state.step - 1); render(); });
+document.getElementById("next").addEventListener("click", () => { stop(); state.step = Math.min(maxStep(), state.step + 1); render(); });
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl; document.documentElement.dir = state.rtl ? "rtl" : "ltr"; e.currentTarget.setAttribute("aria-pressed", state.rtl);
+});
+document.getElementById("copyBtn").addEventListener("click", () => {
+  navigator.clipboard.writeText(document.getElementById("promptOut").textContent).then(() => {
+    const b = document.getElementById("copyBtn"); b.textContent = "✓ Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 Copy prompt"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+render();
+</script>
+</body>
+</html>

--- a/src/skills/shared/rules/_sections.md
+++ b/src/skills/shared/rules/_sections.md
@@ -30,3 +30,11 @@ Prompt-injection defense for skills that read untrusted GitHub/CI content (ci-se
 fix-issue, review-pr) — separate the agent that reads untrusted text from the one that acts.
 
 - `untrusted-input-quarantine.md` — reader/actor split, structured-facts contract, per-skill bindings
+
+## 5. Playground Visual Quality (playground) — HIGH — 1 rule
+
+Falsifiable design standard for the *visual* playgrounds OrchestKit emits (create-pr gate,
+visualize-plan) — device-mockup user-story players and drag-and-drop decision boards. Exemplars
+live in `../assets/playground-exemplars/`.
+
+- `playground-visual-standard.md` — §0 archetype routing, HSL tokens, glass do/don't, motion budget, drag-and-drop accessibility, RTL, anti-generic checklist

--- a/src/skills/shared/rules/playground-visual-standard.md
+++ b/src/skills/shared/rules/playground-visual-standard.md
@@ -1,0 +1,193 @@
+---
+title: "Playground Visual Standard"
+impact: HIGH
+impactDescription: "Governs the visual quality of every playground OrchestKit emits. The difference between a considered product demo and a generic AI dashboard is the specific values in this file."
+tags: [playground, design, visual, frontend, ui, drag-and-drop, glassmorphism, rtl]
+---
+
+# Playground Visual Standard
+
+<!-- Sync rule: edit this standard and its exemplars in assets/playground-exemplars/ in the SAME PR (colocation). -->
+
+> **Load when:** generating a single-file HTML playground that demonstrates a feature, user story,
+> flow, or decision — i.e. a *visual* playground.
+> **Skip for:** plan/config/data/architecture dashboards (their current card layout is fine).
+
+A playground is not a slide. It is a thing the viewer can *operate*: play a user story, or make a
+decision by dragging. This standard makes that quality reproducible. Every rule carries a concrete,
+falsifiable value — a rule without a measurable threshold is not shippable.
+
+Reference exemplars (read the one matching your archetype before building):
+`${CLAUDE_PLUGIN_ROOT}/skills/shared/assets/playground-exemplars/`
+- `homeos-arieh.html` — canonical gold standard (user-story player, RTL Hebrew). Study the bar.
+- `user-story-player.template.html` — generalized player scaffold (device mockup + transport + flow).
+- `decision-board.template.html` — drag-and-drop prioritization toolkit (the decision archetype).
+
+---
+
+## §0 Routing rule — does this standard apply?
+
+Decision, not vibe. Count the signals:
+
+```
+PLAYGROUND (apply this standard) if ≥2 are true:
+  □ device mockup (phone/tablet/app frame)     □ playback / step controls (▶ prev next)
+  □ cause→effect flow arrows                    □ narrative user-story copy
+  □ drag-and-drop decision surface              □ copy-prompt bar ("build / decide" affordance)
+
+Then pick ONE archetype:
+  • USER-STORY PLAYER  → the playground plays a flow over ≥2 steps/screens
+  • DECISION BOARD     → the core is prioritization/management via drag-and-drop
+  • (neither, <2 signals) → DASHBOARD → this standard does NOT apply; keep today's behavior
+```
+
+---
+
+## §1 Persona — pick one, up front, and don't mix
+
+Aesthetic primes emotion in <100ms, before content is read. The frame's persona is the first
+*functional* decision.
+
+- **warm-glass** ("warm intelligence") — amber/emerald accents, frosted surfaces, rounded. Default
+  for consumer/family/approachable products. Matches the HomeOS reference.
+- **cool-glass** ("technical precision") — indigo/violet/teal accents, tighter radii. For
+  developer/enterprise/data products.
+
+**Don't** mix warm and cool accents in one playground. **Don't** spend your one bold move on more
+than one place (§3).
+
+---
+
+## §2 Design tokens
+
+Define as CSS custom properties prefixed `--pg-`. **Use HSL, not hex** — you can derive a lighter
+shade from `hsl(248 84% 68%)` by hand; you cannot from `#7c6cf0`. Every color carries a **role**.
+
+| Token | Example (cool) | Role |
+|---|---|---|
+| `--pg-bg` | `hsl(232 26% 7%)` | Page background (rich + dark, ≤8% L — never `#000`) |
+| `--pg-ink` | `hsl(220 18% 93%)` | Primary text (never pure white) |
+| `--pg-muted` / `--pg-faint` | `…64%` / `…46%` | Secondary / tertiary text |
+| `--pg-glass` / `--pg-glass-2` | `hsl(0 0% 100% / .05)` / `.08` | Glass fill (see §5) |
+| `--pg-glass-edge` | `hsl(0 0% 100% / .18)` | Glass border |
+| `--pg-accent` (+`-deep`) | `hsl(248 84% 68%)` | Primary action / active state / flow arrow |
+| `--pg-warm` | `hsl(38 95% 60%)` | Secondary accent |
+
+- **Spacing:** only `4 · 8 · 12 · 16 · 24 · 48 · 96`. No `13px`, no `22px`.
+- **Radius:** `sm 9px · md 16px · lg 24px · device-bezel 40px · device-outer 54px`. Glass cards ≥16px.
+- **Shadow (two-part, §5):** ambient `0 20px 60px -22px hsl(… / .7)` + tight `0 4px 12px -6px hsl(… / .5)`.
+- **Motion:** exactly four durations — `100 / 200 / 300 / 500ms`, ease `cubic-bezier(.2,.8,.25,1)` (§6).
+- **Gradient mesh background:** 2–3 radial-gradients in accent hues over `--pg-bg`, with
+  `background-attachment: fixed`. **Hue span ≤30°** across the mesh — wider reads as garish.
+
+---
+
+## §3 Visual hierarchy — emphasize by de-emphasizing
+
+The most-violated rule in generic AI playgrounds: everything competes at full strength.
+
+- **Do** assign every element a tier before styling: Primary (the mockup / the board), Secondary
+  (transport / controls), Tertiary (copy-prompt bar / metadata).
+- **Values:** competing elements drop to ~60% opacity or `--pg-faint`; remove their borders. Primary
+  text weight 600–700; tertiary 400.
+- **Don't** give two elements the same visual weight and expect one to read as primary.
+
+---
+
+## §4 Typography
+
+- **Do** set roles: a display face used with restraint, a body face, a mono utility face for
+  values/code. Letter-spacing `-.2px…-.3px` on headings; tabular-nums on any live numbers.
+- **Don't** treat type as a neutral delivery vehicle — it carries the persona.
+
+---
+
+## §5 Glass system
+
+Glass reads as glass only against a dark, contrasted backdrop with a visible edge.
+
+- **Do:** fill `rgba(255,255,255, .05–.12)`; 1px border `rgba(255,255,255, .15–.25)`;
+  `backdrop-filter: blur(12–20px)` (+ `-webkit-` prefix); top-left light source
+  (inset `0 1px 0 rgba(255,255,255,.1–.2)`); the §2 two-part shadow.
+- **Don't:** glass on a light background (invisible); >2 stacked glass layers; radius <16px; a glow
+  halo (`box-shadow: 0 0 40px accent` = the "generic AI glowing card"); glass as a hierarchy signal.
+
+---
+
+## §6 Motion budget
+
+- **Values:** step/screen transition `300ms`; panel/arrow appear `200ms`; button press/highlight
+  `100ms`; device slide-in on load `500ms`. **Everything else animates `0`.**
+- **Do** allow exactly **one signature moment** (usually the step transition or the drop-settle).
+- **Do** ship the reduced-motion gate verbatim:
+  ```css
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  }
+  ```
+- **Don't** animate every element — animation everywhere is the fastest path to "AI-generated".
+
+---
+
+## §7 Component specs
+
+- **Device frame:** outer radius 54px, bezel 12–16px, inner screen radius 40px (`overflow:hidden`,
+  content never escapes the bezel), shadow level 4. Phone notch optional but consistent.
+- **Transport bar:** ▶ play / ‹ prev / next ›; primary button = `--pg-accent`; disabled at ends; a
+  "step N of M" hint.
+- **Flow arrow:** connects cause→effect; uses `--pg-accent`; **RTL-sensitive** — flip with
+  `transform: scaleX(-1)` when `dir="rtl"`.
+- **Copy-prompt bar:** mono text + one `<button>`; **1 click to clipboard** (no modal/toast to
+  dismiss); on copy, icon→✓ for 1500ms then revert. The prompt is a natural-language instruction
+  that only mentions non-default choices — not a value dump.
+- **Drag-and-drop decision surface** (the decision-board archetype):
+  - **Do NOT use native HTML5 DnD** — it is mouse-only and inaccessible.
+  - **Do** implement with **Pointer Events** (covers mouse + touch + pen): a floating ghost clone,
+    a dimmed source, a drop indicator, hit-test via `elementFromPoint`.
+  - **Keyboard is mandatory:** cards `tabindex="0"`; arrow keys move the focused card (reorder /
+    nudge axis / change bucket); `:focus-visible` ring; re-focus the card after re-render.
+  - **ARIA:** `role="button"`, `aria-roledescription="draggable card"`, and an `aria-live="polite"`
+    region that announces every move ("X moved to Should").
+  - `touch-action: none` on cards so touch-drag doesn't scroll the page.
+  - Supported patterns: Impact×Effort 2×2 · ranked-list reorder · MoSCoW / Now-Next-Later buckets ·
+    live score (RICE/WSJF) + copy-prompt. Copy `decision-board.template.html` and swap the data.
+
+---
+
+## §8 RTL / i18n
+
+- **Do** use CSS **logical properties everywhere**: `margin-inline-start`, `padding-inline-end`,
+  `inset-inline-start`, `inset-block-end` — never `left`/`right`/`margin-left`.
+- **Do** flag flow arrows and any directional position math as RTL-sensitive (flip / invert the
+  pointer-X→value mapping when `dir="rtl"`).
+- **Do** reserve +50% width for labels (text expands in other languages); never truncate the prompt bar.
+
+---
+
+## §9 Anti-"generic AI aesthetic" checklist (falsifiable DO-NOTs)
+
+1. No pure black `#000` background or text.
+2. No gradient with >30° hue span.
+3. No two elements at equal visual weight (§3).
+4. No glow-halo cards (§5).
+5. More than one signature animation → cut to one (§6).
+6. Arbitrary spacing (`13px`, `22px`) → snap to the §2 scale.
+7. Hex colors in tokens → convert to HSL.
+8. Native `draggable="true"` DnD → replace with the §7 pointer+keyboard engine.
+9. Physical `left`/`right` CSS in a playground that may be RTL → logical properties.
+10. Copy-prompt that dumps values instead of a natural-language instruction.
+
+---
+
+## §10 Self-audit (run before declaring done)
+
+- [ ] Routing (§0): correct archetype chosen; this standard actually applies.
+- [ ] One persona, no warm/cool mix (§1).
+- [ ] Tokens are HSL with roles; spacing/radius/motion on the scales (§2, §6).
+- [ ] Hierarchy: primary element is unmistakably dominant (§3).
+- [ ] Glass passes the do/don't (§5); no glow halos.
+- [ ] Motion ≤4 durations, one signature moment, reduced-motion gate present (§6).
+- [ ] If a decision surface exists: mouse **and** keyboard work, live region announces, touch ok (§7).
+- [ ] RTL: toggle `dir="rtl"` — layout + arrows mirror correctly (§8).
+- [ ] Single file, zero external deps; copy-prompt is 1-click and natural-language.
+- [ ] Ran the §9 checklist; zero hits.

--- a/src/skills/visualize-plan/SKILL.md
+++ b/src/skills/visualize-plan/SKILL.md
@@ -239,11 +239,17 @@ Render the selected sections into the `FORMATS` chosen in STEP 0.5. **ASCII alwa
 | Format | Action |
 |--------|--------|
 | ASCII | Native render (above) — always, the floor |
-| Playground | Hand the plan brief to the `playground` skill → write `docs/<branch-dir>/plan-viz.html`, link it |
+| Playground | Classify the archetype (below), then hand the plan brief to the `playground` skill → write `docs/<branch-dir>/plan-viz.html`, link it |
 | Infographic | Run the `notebooklm` `studio_create(artifact_type=infographic\|slides)` flow — **fire-and-notify**, poll `studio_status`, never await |
 | All | ASCII inline now + the rest linked as they finish |
 
 `<branch-dir>` = branch with `/` → `--` (same path the PR Playground gate checks).
+
+> **Playground archetype:** a plan visualization is usually a **DASHBOARD** (current behavior — fine).
+> But if the plan demonstrates a *user-facing flow* or a *prioritization/decision*, route to the
+> **user-story-player** or **decision-board** archetype instead of a flat card grid. Apply the §0 routing
+> rule in `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")` and adapt the
+> matching exemplar under `skills/shared/assets/playground-exemplars/`.
 
 ---
 

--- a/src/skills/visualize-plan/references/format-dispatch.md
+++ b/src/skills/visualize-plan/references/format-dispatch.md
@@ -35,11 +35,17 @@ Hide unavailable options from the AskUserQuestion list and add a one-line instal
 | Format | How | Output | Blocks? |
 |--------|-----|--------|---------|
 | ASCII + emojis | Native — render sections per `rules/section-rendering.md` | In chat | n/a (always first) |
-| Interactive playground | Build the plan brief, hand to the `playground` skill | `docs/<branch-dir>/plan-viz.html` | No — write then link |
+| Interactive playground | Classify archetype (§0 of the visual standard), build the plan brief, hand to the `playground` skill | `docs/<branch-dir>/plan-viz.html` | No — write then link |
 | NotebookLM infographic/slides | Build a source doc, run the notebooklm `studio_create(artifact_type=infographic\|slides)` flow | `.png`/slides artifact | **No — fire-and-notify** |
 | All available | Fan out: ASCII inline now + the others as they finish | all of the above | No |
 
 `<branch-dir>` = current branch with `/` → `--` (matches the PR Playground CI gate path, so the playground also satisfies that gate for free).
+
+> **Archetype before generation.** Most plan visualizations are a **DASHBOARD** (the default card grid).
+> But a plan that demonstrates a *user-facing flow* or a *prioritization/decision* should be a
+> **user-story-player** or **decision-board** — `Read("${CLAUDE_PLUGIN_ROOT}/skills/shared/rules/playground-visual-standard.md")`
+> for the §0 routing rule, the token/glass/motion spec, and the exemplars to adapt
+> (`skills/shared/assets/playground-exemplars/`). Brief the `playground` skill with archetype + persona, not raw HTML.
 
 ## The plan brief (shared interchange, v1)
 


### PR DESCRIPTION
## Context

OrchestKit requires every non-bot PR to ship an interactive HTML **playground**, and `visualize-plan` can emit one too. In practice they came out as flat plan/info dashboards. A designer (Arieh) shared a reference — `HomeOS · App UI Explorer` — that is a different, far better archetype: a live **product-demo / user-story player** (device mockups, a play/prev/next transport, cause-to-effect flow arrows, a warm glass aesthetic, a copy-prompt bar).

This PR captures that archetype as a durable standard and routes the playground emitters to it, plus adds a **drag-and-drop decision board** for the prioritization/management parts of a playground.

## The shift

```
BEFORE (dashboard)              AFTER (this PR, for visual playgrounds)
------------------              ---------------------------------------
flat token cards                device-mockup user-story player (play/prev/next)
"shows the plan"                "plays the story" + cause-to-effect flow arrows
static                          drag-and-drop decision board (prioritize/manage)
```

Routing is archetype-aware: plan/config/architecture playgrounds stay dashboards; only feature / user-story / decision playgrounds get the high-fidelity treatment.

## What ships

- **Standard** — `src/skills/shared/rules/playground-visual-standard.md`: section 0 archetype routing through section 10 self-audit. Falsifiable rules — HSL design tokens, glass do/don't, a 4-tier motion budget, drag-and-drop accessibility (pointer + keyboard + ARIA), RTL via logical properties, an anti-"generic AI aesthetic" checklist.
- **Exemplars** — `src/skills/shared/assets/playground-exemplars/`:
  - `homeos-arieh.html` — the canonical gold standard, designed by **Arieh**, committed verbatim with credit.
  - `user-story-player.template.html` — generalized player (device mockup + transport + flow arrow), zero-dep, RTL-ready.
  - `decision-board.template.html` — **drag-and-drop prioritization toolkit**: Impact x Effort matrix, ranked-list reorder, MoSCoW / Now-Next-Later buckets, live RICE score + copy-prompt. Pointer + full keyboard control + `aria-live` + reduced-motion.
- **Wiring** — `create-pr` (PR-gate) and `visualize-plan` (dispatch) now classify the archetype and build to the standard for visual playgrounds. Dashboards unchanged.

## Live Preview

**[Open the drag-and-drop decision board playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/playground-visual-standard/docs/feat--playground-visual-standard/decision-board.html)**

## Verification

- ✅ `npm run build` clean; `plugins/` mirror staged (drift gate).
- ✅ `npm run test:skills` pass (rule frontmatter/validation green; warnings only).
- ✅ `npm run test:manifests` pass — 0 drift, 0 orphans.
- ✅ Browser-verified via agent-browser: all three decision-board views render; keyboard reorder mutates state with live-region announcements; user-story player plays through to the result card.
- Design rules grounded in the design library (UI/UX Principles, Awesome Design.md, Vercel FE guidelines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
