### PR TITLE
feat(prd-to-goal): loop recipe library of 8 pre-built /goal loops

### DIFF
--- a/docs/feat--loop-recipes-2539/index.html
+++ b/docs/feat--loop-recipes-2539/index.html
@@ -1,0 +1,624 @@
+<!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════
+  LOOP LIBRARY × ORCHESTKIT · assessment explorer
+  Decision-board playground — conforms to
+  src/skills/shared/rules/playground-visual-standard.md
+  Persona: cool-glass (technical precision, indigo). Zero deps. Single file.
+
+  Four lenses on one assessment:
+    1. 🧭 Orthogonality — the loop ENVELOPE wraps the WORK (the thesis)
+    2. 🗺️ Theme map     — 17 Loop-Library themes → ork equivalent (direct/partial/gap)
+    3. 🎯 Adoption board — drag the 5 recommendations across Adopt now / Later / Skip
+    4. 📊 Scorecard      — 6 dimensions, composite 7.3 / B
+
+  Accessibility: the adoption board uses Pointer Events (mouse+touch+pen)
+  PLUS full keyboard (Tab a card, ← → move buckets), every move announced
+  via aria-live. Honors prefers-reduced-motion. RTL via logical props + toggle.
+  ════════════════════════════════════════════════════════════════════════
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Loop Library × OrchestKit · Assessment Explorer</title>
+<style>
+  /* ── §2 Design tokens (HSL so shades are derivable) ─────────────────── */
+  :root {
+    --pg-bg:            hsl(232 26% 7%);
+    --pg-ink:           hsl(220 18% 93%);
+    --pg-muted:         hsl(220 12% 64%);
+    --pg-faint:         hsl(220 10% 46%);
+    --pg-line:          hsl(0 0% 100% / 0.10);
+    --pg-glass:         hsl(0 0% 100% / 0.05);
+    --pg-glass-2:       hsl(0 0% 100% / 0.08);
+    --pg-glass-edge:    hsl(0 0% 100% / 0.18);
+
+    --pg-accent:        hsl(248 84% 68%);   /* indigo — primary action / active / envelope */
+    --pg-accent-deep:   hsl(248 60% 52%);
+    --pg-warm:          hsl(38 95% 60%);    /* amber — "later" / secondary accent */
+    --pg-emerald:       hsl(160 68% 45%);   /* direct / adopt-now / success */
+    --pg-sky:           hsl(206 85% 62%);   /* partial / the work-core */
+    --pg-rose:          hsl(345 76% 63%);   /* gap / attention */
+
+    /* two-part shadow (§5) — ambient + tight */
+    --pg-shadow: 0 20px 60px -22px hsl(232 40% 2% / 0.7), 0 4px 12px -6px hsl(232 40% 2% / 0.5);
+
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+
+    /* §6 motion budget — four tiers, nothing else animates */
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 88% -8%, hsl(248 84% 68% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 4% 110%, hsl(206 85% 62% / 0.12), transparent 58%),
+      radial-gradient(700px 520px at 50% 50%, hsl(160 68% 45% / 0.05), transparent 70%),
+      var(--pg-bg);
+    background-attachment: fixed;
+    -webkit-font-smoothing: antialiased; min-height: 100vh;
+  }
+
+  .wrap { max-width: 1120px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+
+  /* ── header / explainer ─────────────────────────────────────────────── */
+  .head { display: flex; align-items: flex-start; gap: 14px; flex-wrap: wrap; }
+  .logo {
+    width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 22px -8px hsl(248 84% 60% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4);
+  }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head h1 .sub { color: var(--pg-faint); font-weight: 600; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 66ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; display: flex; gap: 8px; align-items: center; }
+  .grade-pill {
+    display: inline-flex; align-items: baseline; gap: 6px; font-family: var(--pg-mono);
+    background: hsl(38 95% 60% / 0.14); border: 1px solid hsl(38 95% 60% / 0.3); color: hsl(38 95% 76%);
+    border-radius: 999px; padding: 7px 13px; font-size: 12px; font-weight: 700;
+  }
+  .grade-pill b { font-size: 15px; }
+
+  .toggle {
+    cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px;
+    transition: color var(--pg-dur-fast), border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); background: var(--pg-glass-2); border-color: var(--pg-glass-edge); }
+
+  /* ── glass panel ────────────────────────────────────────────────────── */
+  .panel {
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow);
+  }
+
+  /* ── §7 segmented view switch ───────────────────────────────────────── */
+  .views { display: flex; gap: 4px; padding: 5px; background: hsl(0 0% 0% / 0.28); border: 1px solid var(--pg-line); border-radius: 13px; flex-wrap: wrap; }
+  .views button {
+    flex: 1 1 auto; min-width: 150px; border: 0; background: transparent; color: var(--pg-muted); cursor: pointer;
+    font: inherit; font-size: 13px; font-weight: 600; padding: 10px 12px; border-radius: 9px; letter-spacing: -.1px;
+    transition: color var(--pg-dur-fast), background var(--pg-dur-fast); display: inline-flex; align-items: center; justify-content: center; gap: 8px;
+  }
+  .views button:hover { color: var(--pg-ink); }
+  .views button[aria-pressed="true"] {
+    color: var(--pg-ink); background: linear-gradient(180deg, var(--pg-glass-2), hsl(0 0% 100% / 0.03));
+    box-shadow: 0 2px 10px -4px hsl(232 40% 2% / 0.6), inset 0 1px 0 hsl(0 0% 100% / 0.12);
+  }
+
+  .stage { padding: 20px; min-height: 460px; position: relative; }
+  .scheme-note { font-size: 12px; color: var(--pg-faint); margin: 0 0 14px; display: flex; gap: 10px; align-items: center; flex-wrap: wrap; line-height: 1.5; }
+  .scheme-note b { color: var(--pg-muted); font-weight: 650; }
+  .kbd { font-family: var(--pg-mono); font-size: 10.5px; color: var(--pg-muted); background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); border-radius: 6px; padding: 1px 6px; }
+
+  /* ── card (shared) ──────────────────────────────────────────────────── */
+  .card {
+    background: hsl(0 0% 100% / 0.045); border: 1px solid var(--pg-line); border-radius: var(--pg-r-md);
+    padding: 11px 12px; user-select: none; position: relative;
+    transition: transform var(--pg-dur-fast) var(--pg-ease), border-color var(--pg-dur-fast), box-shadow var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .card.drag { cursor: grab; touch-action: none; }
+  .card:hover { border-color: var(--pg-glass-edge); background: hsl(0 0% 100% / 0.07); }
+  .card:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .card .ct { font-size: 13.5px; font-weight: 600; letter-spacing: -.1px; line-height: 1.3; padding-inline-end: 18px; }
+  .card .desc { margin-top: 6px; font-size: 11.5px; color: var(--pg-muted); line-height: 1.45; }
+  .card .meta { margin-top: 8px; display: flex; gap: 6px; align-items: center; flex-wrap: wrap; font-size: 10.5px; color: var(--pg-muted); }
+  .chip { font-size: 10px; font-weight: 650; border-radius: 999px; padding: 2px 8px; background: hsl(0 0% 100% / 0.06); color: var(--pg-muted); white-space: nowrap; }
+  .chip.surface { font-family: var(--pg-mono); background: hsl(248 84% 68% / 0.14); color: hsl(248 84% 84%); }
+  .chip.from { background: hsl(206 85% 62% / 0.12); color: hsl(206 85% 78%); }
+  .chip.eff { background: hsl(38 95% 60% / 0.14); color: hsl(38 95% 78%); }
+  .chip.imp { background: hsl(160 68% 45% / 0.16); color: hsl(160 68% 74%); }
+  .card .grip { position: absolute; inset-inline-end: 9px; top: 9px; color: var(--pg-faint); font-size: 13px; letter-spacing: 1px; line-height: 1; }
+
+  /* dragging states */
+  .card.source { opacity: .35; }
+  .ghost {
+    position: fixed; z-index: 999; pointer-events: none; width: var(--ghost-w, 240px);
+    transform: rotate(1.5deg) scale(1.03); box-shadow: 0 26px 60px -18px hsl(232 60% 2% / 0.8); cursor: grabbing;
+  }
+
+  /* ── view: buckets (adoption board) ─────────────────────────────────── */
+  .buckets { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+  .bucket { display: flex; flex-direction: column; min-height: 340px; }
+  .bucket-h { display: flex; align-items: center; gap: 8px; margin-bottom: 11px; font-size: 13px; font-weight: 700; }
+  .bucket-h .dot { width: 9px; height: 9px; border-radius: 999px; flex: none; }
+  .bucket-h .n { margin-inline-start: auto; font-size: 11px; color: var(--pg-faint); background: hsl(0 0% 0% / 0.25); border-radius: 999px; padding: 1px 8px; font-family: var(--pg-mono); }
+  .drop {
+    flex: 1; display: flex; flex-direction: column; gap: 9px; padding: 10px; border-radius: var(--pg-r-md);
+    background: hsl(0 0% 100% / 0.02); border: 1px dashed var(--pg-line);
+    transition: border-color var(--pg-dur-fast), background var(--pg-dur-fast);
+  }
+  .drop.hot { border-color: var(--pg-accent); border-style: solid; background: hsl(248 84% 68% / 0.07); }
+  .drop:empty::after { content: "drop here"; color: var(--pg-faint); font-size: 11px; margin: auto; opacity: .6; }
+
+  /* ── view: theme map ────────────────────────────────────────────────── */
+  .filters { display: flex; gap: 6px; flex-wrap: wrap; margin-inline-start: auto; }
+  .grid17 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; }
+  .tmap {
+    background: hsl(0 0% 100% / 0.03); border: 1px solid var(--pg-line); border-radius: var(--pg-r-md);
+    padding: 11px 13px; border-inline-start: 3px solid var(--pg-faint);
+    transition: opacity var(--pg-dur-fast), border-color var(--pg-dur-fast);
+  }
+  .tmap.s-direct  { border-inline-start-color: var(--pg-emerald); }
+  .tmap.s-partial { border-inline-start-color: var(--pg-warm); }
+  .tmap.s-gap     { border-inline-start-color: var(--pg-rose); }
+  .tmap.dim { opacity: .22; }
+  .tmap .th { font-size: 13px; font-weight: 650; letter-spacing: -.1px; display: flex; align-items: center; gap: 8px; }
+  .tmap .badge { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: .4px; border-radius: 999px; padding: 2px 7px; flex: none; }
+  .badge.s-direct  { background: hsl(160 68% 45% / 0.18); color: hsl(160 68% 72%); }
+  .badge.s-partial { background: hsl(38 95% 60% / 0.16); color: hsl(38 95% 76%); }
+  .badge.s-gap     { background: hsl(345 76% 63% / 0.18); color: hsl(345 76% 78%); }
+  .tmap .ork { margin-top: 6px; font-family: var(--pg-mono); font-size: 11px; color: hsl(248 84% 82%); }
+  .tmap .note { margin-top: 3px; font-size: 11px; color: var(--pg-faint); line-height: 1.4; }
+  .pill-count { font-family: var(--pg-mono); font-size: 11px; }
+
+  /* ── view: scorecard ────────────────────────────────────────────────── */
+  .scores { display: flex; flex-direction: column; gap: 13px; max-width: 720px; margin: 0 auto; }
+  .scorerow { display: grid; grid-template-columns: 230px 1fr 38px; align-items: center; gap: 14px; }
+  .scorerow .lab { font-size: 13px; font-weight: 600; }
+  .scorerow .lab small { display: block; font-weight: 400; color: var(--pg-faint); font-size: 11px; margin-top: 2px; line-height: 1.35; }
+  .meter { height: 12px; border-radius: 999px; background: hsl(0 0% 100% / 0.05); overflow: hidden; position: relative; }
+  .meter > span { position: absolute; inset-block: 0; inset-inline-start: 0; border-radius: 999px; transition: inline-size var(--pg-dur-slow) var(--pg-ease); }
+  .fill-hi  > span { background: linear-gradient(90deg, var(--pg-emerald), hsl(160 68% 58%)); }
+  .fill-mid > span { background: linear-gradient(90deg, var(--pg-accent-deep), var(--pg-accent)); }
+  .fill-lo  > span { background: linear-gradient(90deg, hsl(345 76% 50%), var(--pg-rose)); }
+  .scorerow .val { font-family: var(--pg-mono); font-size: 15px; font-weight: 800; text-align: end; }
+  .composite { display: flex; align-items: center; gap: 16px; margin-top: 20px; padding: 16px 18px; border-radius: var(--pg-r-md); background: hsl(0 0% 100% / 0.03); border: 1px solid var(--pg-line); }
+  .composite .big { font-family: var(--pg-mono); font-size: 38px; font-weight: 800; letter-spacing: -1px; line-height: 1; color: var(--pg-warm); }
+  .composite .cx { font-size: 12.5px; color: var(--pg-muted); line-height: 1.5; }
+  .composite .cx b { color: var(--pg-ink); }
+
+  /* ── view: orthogonality ────────────────────────────────────────────── */
+  .ortho { display: grid; place-items: center; min-height: 420px; padding: 10px; }
+  .envelope {
+    position: relative; width: min(620px, 100%); border-radius: var(--pg-r-lg);
+    border: 1.5px solid hsl(248 84% 68% / 0.55); padding: 16px 16px 18px;
+    background: radial-gradient(140% 120% at 50% -10%, hsl(248 84% 68% / 0.10), transparent 60%), hsl(0 0% 100% / 0.02);
+    transition: transform var(--pg-dur-slow) var(--pg-ease), opacity var(--pg-dur-slow);
+  }
+  .envelope.closed { transform: scale(1.02); }
+  .env-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: hsl(248 84% 82%); display: flex; align-items: center; gap: 8px; }
+  .env-label .tag { font-family: var(--pg-mono); font-weight: 600; text-transform: none; letter-spacing: 0; color: var(--pg-faint); font-size: 10.5px; margin-inline-start: auto; }
+  .env-flow { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; margin: 11px 2px 14px; font-size: 11px; color: var(--pg-muted); }
+  .env-flow .stepf { background: hsl(248 84% 68% / 0.12); border: 1px solid hsl(248 84% 68% / 0.25); border-radius: 999px; padding: 3px 10px; font-weight: 600; }
+  .env-flow .arrow { color: var(--pg-accent); font-weight: 800; }
+  .env-flow .arrow[data-rtl] { display: inline-block; }
+  .core {
+    border-radius: var(--pg-r-md); border: 1px solid hsl(206 85% 62% / 0.4); padding: 14px;
+    background: radial-gradient(120% 120% at 50% 120%, hsl(206 85% 62% / 0.10), transparent 62%), hsl(0 0% 100% / 0.03);
+    transition: transform var(--pg-dur-slow) var(--pg-ease), opacity var(--pg-dur-normal);
+  }
+  .core.tuck { transform: scale(.965); }
+  .core-label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 1px; color: hsl(206 85% 76%); display: flex; align-items: center; gap: 8px; }
+  .core-label .tag { font-family: var(--pg-mono); font-weight: 600; text-transform: none; letter-spacing: 0; color: var(--pg-faint); font-size: 10.5px; margin-inline-start: auto; }
+  .core-grid { margin-top: 11px; display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+  .core-grid div { font-size: 11.5px; color: var(--pg-ink); background: hsl(0 0% 100% / 0.04); border: 1px solid var(--pg-line); border-radius: 9px; padding: 7px 9px; line-height: 1.35; }
+  .core-grid div b { color: hsl(206 85% 80%); font-weight: 650; }
+  .ortho-takeaway { margin-top: 16px; font-size: 12.5px; color: var(--pg-muted); text-align: center; max-width: 60ch; line-height: 1.55; }
+  .ortho-takeaway b { color: var(--pg-ink); }
+
+  /* ── §7 copy-prompt bar ─────────────────────────────────────────────── */
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(220 16% 80%); max-height: 96px; overflow-y: auto; }
+  .promptbar .pt b { color: var(--pg-accent); font-weight: 600; }
+  .promptbar .pt .warm { color: var(--pg-warm); }
+  .promptbar .pt .em { color: var(--pg-emerald); }
+  .copy {
+    flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(248 30% 12%);
+    border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 10px 26px -12px hsl(248 84% 60% / 0.8); transition: transform var(--pg-dur-instant);
+  }
+  .copy:hover { transform: translateY(-1px); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
+
+  /* ── §6 reduced motion ──────────────────────────────────────────────── */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    .ghost { transform: none; }
+  }
+  @media (max-width: 720px) {
+    .buckets { grid-template-columns: 1fr; }
+    .grid17 { grid-template-columns: 1fr; }
+    .scorerow { grid-template-columns: 1fr; gap: 6px; }
+    .scorerow .val { text-align: start; }
+    .core-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header class="head">
+    <div class="logo">🔁</div>
+    <div>
+      <h1>Loop Library <span class="sub">×</span> OrchestKit</h1>
+      <p>An assessment you can <b>operate</b>: see why the two are orthogonal, map all 17 loop themes
+         to their ork equivalent, then <b>drag the five recommendations</b> into Adopt&nbsp;now / Later / Skip
+         and copy the decision out. Mouse, touch, and keyboard all work
+         (<span class="kbd">Tab</span> a card, then <span class="kbd">←</span> <span class="kbd">→</span>).</p>
+    </div>
+    <div class="right">
+      <span class="grade-pill" title="Composite score / grade">verdict <b>7.3</b> · B</span>
+      <button class="toggle" id="dirToggle" aria-pressed="false" title="Toggle text direction">⇄ RTL</button>
+    </div>
+  </header>
+
+  <div class="panel" style="padding:6px">
+    <div class="views" id="views" role="tablist" aria-label="Assessment view">
+      <button data-view="ortho"  aria-pressed="true">🧭 Orthogonality</button>
+      <button data-view="themes" aria-pressed="false">🗺️ Theme map</button>
+      <button data-view="adopt"  aria-pressed="false">🎯 Adoption board</button>
+      <button data-view="score"  aria-pressed="false">📊 Scorecard</button>
+    </div>
+  </div>
+
+  <main class="panel stage" id="stage" aria-live="off"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">📋 Copy takeaway</button>
+  </div>
+
+  <div class="sr-only" id="live" role="status" aria-live="polite"></div>
+</div>
+
+<script>
+/* ═══════════════════════════════════════════════════════════════════════
+   DATA — the assessment content. Swap these blocks to reuse the engine.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+/* The 5 ranked recommendations — the draggable adoption cards. */
+const RECS = [
+  { id:"recipes",   title:"Loop Recipe Book",        surface:"prd-to-goal → skills.sh", from:"all 31 loops",
+    effort:1, impact:5, def:"now",
+    desc:"Ship 6–8 pre-built /goal until…abort-if recipes (coverage, error-sweep, docs-drift, sub-50ms). Publish as ork-loops on skills.sh — interop, not competition. We have the engine; give people the cookbook." },
+  { id:"streak",    title:"Streak gate",             surface:"verify · cover", from:"Quality Streak",
+    effort:2, impact:4, def:"now",
+    desc:"Require N consecutive green runs before \"done\" — flakiness defense our single-shot pass/fail lacks." },
+  { id:"holdout",   title:"Holdout-promotion gate",  surface:"skill-evolution · bare-eval", from:"Self-Improving Champion",
+    effort:4, impact:5, def:"later",
+    desc:"Champion/challenger on FRESH holdouts; promote a skill change only if it wins. Directly serves the recorded \"auto-eval all skills + subagents\" goal." },
+  { id:"crossmodel",title:"Cross-model reviewer",    surface:"review-pr · assess", from:"Clodex Adversarial Review",
+    effort:3, impact:3, def:"later",
+    desc:"Allow a non-Claude skeptic (Codex/GPT) until blockers clear — diversity of failure modes vs today's homogeneous Claude agents. Gated on cost + model access." },
+  { id:"heartbeat", title:"Heartbeat maintainer",    surface:"ci-sentinel (sub-hourly)", from:"Five-Minute Maintainer",
+    effort:4, impact:2, def:"skip",
+    desc:"Wake every 5 min, assign one bounded task without interrupting active agents. Conflicts with the no-paid-background-LLM rule → opt-in only, never default." },
+];
+
+const BUCKETS = [
+  { key:"now",   label:"Adopt now",   dot:"var(--pg-emerald)" },
+  { key:"later", label:"Later",       dot:"var(--pg-warm)" },
+  { key:"skip",  label:"Skip / opt-in", dot:"var(--pg-faint)" },
+];
+
+/* 17 Loop-Library themes → ork equivalent. status: direct | partial | gap */
+const THEMES = [
+  { theme:"100% Test Coverage",       ork:"cover + verify",                status:"direct",  note:"auto-heal ≤3 iterations, coverage-policy gate" },
+  { theme:"Production Error Sweep",   ork:"ci-sentinel",                   status:"direct",  note:"hourly classifier, propose-don't-apply, ledger" },
+  { theme:"Repository Cleanup",       ork:"dream",                         status:"direct",  note:"prune / merge / contradiction, deterministic" },
+  { theme:"Ticket-to-PR-Ready",       ork:"fix-issue",                     status:"direct",  note:"RCA → fix → tests → PR, memory-aware" },
+  { theme:"Devil's-Advocate",         ork:"brainstorm",                    status:"direct",  note:"7-phase + devil's-advocate scoring" },
+  { theme:"Fresh-Clone Onboarding",   ork:"setup",                         status:"direct",  note:"8-phase wizard + readiness score" },
+  { theme:"Builder-Reviewer Loop",    ork:"implement → verify → create-pr", status:"direct", note:"parallel worktree agents, verify-gated" },
+  { theme:"Docs Sweep",               ork:"audit-full + Cron",             status:"partial", note:"full-context scan, but no doc-drift detector" },
+  { theme:"Sub-50ms Page-Load",       ork:"performance rules + /loop",     status:"partial", note:"rules yes, autonomous watcher no" },
+  { theme:"Test-Suite Speed",         ork:"testing-perf",                  status:"partial", note:"patterns yes, regression detector no" },
+  { theme:"Adversarial Review (Codex)",ork:"review-pr",                    status:"partial", note:"multi-agent, but same-model skeptics only" },
+  { theme:"Five-Minute Maintainer",   ork:"ci-sentinel / /loop 5m",        status:"partial", note:"hourly cron is min persistence; /loop dies on exit" },
+  { theme:"Recent-Feedback Sweep",    ork:"memory + Cron",                 status:"partial", note:"search works; no auto feedback ingestion" },
+  { theme:"Nightly Changelog",        ork:"release-sync",                  status:"partial", note:"syncs, but manual trigger post-tag" },
+  { theme:"Post-Release Baseline",    ork:"testing-perf + Cron",           status:"partial", note:"composable, no release-trigger automation" },
+  { theme:"Self-Improving Champion",  ork:"verify + assertion-grader",     status:"gap",     note:"no holdout-promotion / champion-challenger gate" },
+  { theme:"Quality Streak",           ork:"verify + Cron (manual)",        status:"gap",     note:"no native consecutive-pass streak gate" },
+];
+
+/* 6 scored dimensions (OrchestKit's loop/autonomy posture; Loop Library = benchmark) */
+const SCORES = [
+  { dim:"Loop engine (primitives)",     score:9, note:"/goal · /loop · Cron · ScheduleWakeup · self-heal" },
+  { dim:"Safety (unattended runs)",     score:9, note:"211 hooks · egress guard · security gates — their blind spot" },
+  { dim:"Stopping-condition rigor",     score:8, note:"rubric + dimension blockers + fresh-context assertion-grader" },
+  { dim:"Autonomy / persistence",       score:8, note:"CronCreate + ci-sentinel (hourly)" },
+  { dim:"Recipe cookbook (packaging)",  score:5, note:"engine yes; no curated run-until recipe library" },
+  { dim:"Self-improvement discipline",  score:4, note:"skill-evolution exists; no holdout/champion gate" },
+];
+const COMPOSITE = 7.3, GRADE = "B";
+
+/* per-item runtime state */
+const state = { view:"ortho", rtl:false, bucket:{}, themeFilter:"all", envClosed:true };
+RECS.forEach(r => state.bucket[r.id] = r.def);
+
+const byId = id => RECS.find(r => r.id === id);
+const esc = s => String(s).replace(/[&<>]/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;"}[c]));
+const stage = document.getElementById("stage");
+const live  = document.getElementById("live");
+const announce = msg => { live.textContent = ""; requestAnimationFrame(() => live.textContent = msg); };
+const STATUS_LABEL = { direct:"Direct", partial:"Partial", gap:"Gap" };
+
+/* ═══════════════════════════ RENDERERS ════════════════════════════════ */
+function render() {
+  if (state.view === "ortho")  renderOrtho();
+  else if (state.view === "themes") renderThemes();
+  else if (state.view === "adopt")  renderAdopt();
+  else renderScore();
+  updatePrompt();
+}
+
+/* ── orthogonality ──────────────────────────────────────────────────── */
+function renderOrtho() {
+  const arrow = state.rtl ? "‹" : "›";
+  stage.innerHTML = `
+    <p class="scheme-note">The thesis: the two don't compete — they <b>compose</b>.
+      <button class="toggle" id="wrapToggle" aria-pressed="${state.envClosed}">
+        ${state.envClosed ? "◱ Unwrap" : "▶ Wrap the work"}</button>
+      <span style="color:var(--pg-faint)">watch the loop envelope close around the work</span></p>
+    <div class="ortho">
+      <div class="envelope ${state.envClosed ? "closed" : ""}">
+        <div class="env-label">Loop Library — the loop <span style="color:var(--pg-ink)">envelope</span>
+          <span class="tag">npx skills add · 31 recipes</span></div>
+        <div class="env-flow" aria-hidden="true">
+          <span class="stepf">define done</span><span class="arrow">${arrow}</span>
+          <span class="stepf">act (one pass)</span><span class="arrow">${arrow}</span>
+          <span class="stepf">verify</span><span class="arrow">${arrow}</span>
+          <span class="stepf">continue · stop</span>
+          <span style="color:var(--pg-faint); margin-inline-start:6px">+ budget · streak · holdout · heartbeat</span>
+        </div>
+        <div class="core ${state.envClosed ? "tuck" : ""}">
+          <div class="core-label">OrchestKit — the <span style="color:var(--pg-ink)">work</span> each pass does
+            <span class="tag">1 plugin · 111 skills</span></div>
+          <div class="core-grid">
+            <div><b>parallel sub-agents</b> + worktree isolation</div>
+            <div><b>rubric gates</b> + assertion-grader</div>
+            <div><b>211 safety hooks</b> + egress guard</div>
+            <div><b>memory</b> + checkpoint-resume</div>
+            <div><b>111 domain skills</b> back each iteration</div>
+            <div><b>/goal · /loop · Cron</b> loop primitives</div>
+          </div>
+        </div>
+      </div>
+      <p class="ortho-takeaway">They own the <b>temporal envelope</b> (when to stop: streaks, holdouts, heartbeats).
+        We own the <b>task content</b> + the hard parts (safety, orchestration, rigor).
+        <b>Consume their recipes; keep our machinery.</b></p>
+    </div>`;
+  const wt = document.getElementById("wrapToggle");
+  if (wt) wt.addEventListener("click", () => { state.envClosed = !state.envClosed; render();
+    announce(state.envClosed ? "Loop envelope wrapped around the work." : "Loop envelope opened."); });
+}
+
+/* ── theme map ──────────────────────────────────────────────────────── */
+function renderThemes() {
+  const counts = { direct:0, partial:0, gap:0 };
+  THEMES.forEach(t => counts[t.status]++);
+  const f = state.themeFilter;
+  const filt = (k, label, color) =>
+    `<button class="toggle" data-filter="${k}" aria-pressed="${f === k}">
+       <span style="color:${color}">●</span> ${label} <span class="pill-count">${k === "all" ? THEMES.length : counts[k]}</span></button>`;
+  stage.innerHTML = `
+    <p class="scheme-note">Every Loop-Library theme has an ork equivalent — <b>7 direct, 8 partial, 2 true gaps</b>.
+      Filter to see where the work is.
+      <span class="filters">
+        ${filt("all","All","var(--pg-muted)")}
+        ${filt("direct","Direct","var(--pg-emerald)")}
+        ${filt("partial","Partial","var(--pg-warm)")}
+        ${filt("gap","Gap","var(--pg-rose)")}
+      </span></p>
+    <div class="grid17">
+      ${THEMES.map(t => `
+        <div class="tmap s-${t.status} ${f !== "all" && f !== t.status ? "dim" : ""}">
+          <div class="th">${esc(t.theme)}
+            <span class="badge s-${t.status}" style="margin-inline-start:auto">${STATUS_LABEL[t.status]}</span></div>
+          <div class="ork">${esc(t.ork)}</div>
+          <div class="note">${esc(t.note)}</div>
+        </div>`).join("")}
+    </div>`;
+  stage.querySelectorAll("[data-filter]").forEach(b =>
+    b.addEventListener("click", () => { state.themeFilter = b.dataset.filter; render(); }));
+}
+
+/* ── adoption board (buckets, drag+keyboard) ────────────────────────── */
+function adoptCardHTML(r) {
+  return `<div class="card drag" data-id="${r.id}" tabindex="0" role="button"
+            aria-roledescription="draggable card"
+            aria-label="${esc(r.title)}. In ${bucketLabel(state.bucket[r.id])}. Effort ${r.effort} of 5, impact ${r.impact} of 5. Arrow left and right move between Adopt now, Later, and Skip.">
+      <span class="grip" aria-hidden="true">⠿</span>
+      <div class="ct">${esc(r.title)}</div>
+      <div class="desc">${esc(r.desc)}</div>
+      <div class="meta">
+        <span class="chip surface">${esc(r.surface)}</span>
+        <span class="chip from">↩ ${esc(r.from)}</span>
+        <span class="chip eff">effort ${r.effort}</span>
+        <span class="chip imp">impact ${r.impact}</span>
+      </div>
+    </div>`;
+}
+function bucketLabel(k) { return (BUCKETS.find(b => b.key === k) || {}).label || k; }
+function renderAdopt() {
+  stage.innerHTML = `
+    <p class="scheme-note">Drag each recommendation into a bucket — the copy-out prompt updates live.
+      <span class="kbd">←</span><span class="kbd">→</span> move the focused card. Defaults reflect the ranked verdict.</p>
+    <div class="buckets">
+      ${BUCKETS.map(b => `
+        <div class="bucket">
+          <div class="bucket-h"><span class="dot" style="background:${b.dot}"></span>${b.label}
+            <span class="n">${RECS.filter(r => state.bucket[r.id] === b.key).length}</span></div>
+          <div class="drop" data-bucket="${b.key}">
+            ${RECS.filter(r => state.bucket[r.id] === b.key).map(adoptCardHTML).join("")}
+          </div>
+        </div>`).join("")}
+    </div>`;
+}
+
+/* ── scorecard ──────────────────────────────────────────────────────── */
+function renderScore() {
+  const fillClass = s => s >= 7 ? "fill-hi" : s >= 5.5 ? "fill-mid" : "fill-lo";
+  stage.innerHTML = `
+    <p class="scheme-note">OrchestKit's loop/autonomy posture, scored 0–10 (Loop Library = the benchmark).
+      <b>We win on engine, safety, rigor; they win on packaging + two patterns.</b></p>
+    <div class="scores">
+      ${SCORES.map(s => `
+        <div class="scorerow">
+          <div class="lab">${esc(s.dim)}<small>${esc(s.note)}</small></div>
+          <div class="meter ${fillClass(s.score)}"><span style="inline-size:${s.score * 10}%"></span></div>
+          <div class="val">${s.score.toFixed(0)}</div>
+        </div>`).join("")}
+    </div>
+    <div class="composite">
+      <div class="big">${COMPOSITE.toFixed(1)}</div>
+      <div class="cx">Composite — grade <b>${GRADE}</b>. Strong loop <b>engine</b> + <b>safety</b> moat (the
+        Loop Library is just prompts; running them unattended is the exact risk our hooks cover).
+        Weakest on the <b>recipe cookbook</b> (5) and <b>self-improvement</b> discipline (4) — the two adopt-now / later moves.</div>
+    </div>`;
+}
+
+/* ═══════════════════════ POINTER DRAG ENGINE (adopt view only) ═════════ */
+let drag = null;
+stage.addEventListener("pointerdown", e => {
+  if (state.view !== "adopt") return;
+  const card = e.target.closest(".card"); if (!card || e.button !== 0) return;
+  e.preventDefault();
+  const rect = card.getBoundingClientRect();
+  const ghost = card.cloneNode(true);
+  ghost.classList.add("ghost"); ghost.classList.remove("source");
+  ghost.style.setProperty("--ghost-w", rect.width + "px");
+  ghost.style.left = rect.left + "px"; ghost.style.top = rect.top + "px";
+  document.body.appendChild(ghost);
+  card.classList.add("source");
+  drag = { id: card.dataset.id, ghost, card, dx: e.clientX - rect.left, dy: e.clientY - rect.top };
+  window.addEventListener("pointermove", onMove);
+  window.addEventListener("pointerup", onUp, { once: true });
+});
+function onMove(e) {
+  if (!drag) return;
+  drag.ghost.style.left = (e.clientX - drag.dx) + "px";
+  drag.ghost.style.top  = (e.clientY - drag.dy) + "px";
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  drag.ghost.style.display = "";
+  document.querySelectorAll(".drop").forEach(d => d.classList.remove("hot"));
+  const drop = under && under.closest(".drop"); if (drop) drop.classList.add("hot");
+}
+function onUp(e) {
+  if (!drag) return;
+  drag.ghost.style.display = "none";
+  const under = document.elementFromPoint(e.clientX, e.clientY);
+  const drop = under && under.closest(".drop");
+  if (drop) {
+    state.bucket[drag.id] = drop.dataset.bucket;
+    render();
+    announce(`${byId(drag.id).title} moved to ${bucketLabel(drop.dataset.bucket)}.`);
+  }
+  drag.ghost.remove();
+  document.querySelectorAll(".hot").forEach(x => x.classList.remove("hot"));
+  drag = null;
+  window.removeEventListener("pointermove", onMove);
+}
+
+/* ═══════════════════════ KEYBOARD ENGINE (adopt view) ══════════════════ */
+stage.addEventListener("keydown", e => {
+  if (state.view !== "adopt") return;
+  const card = e.target.closest(".card"); if (!card) return;
+  if (!["ArrowLeft","ArrowRight"].includes(e.key)) return;
+  e.preventDefault();
+  const id = card.dataset.id, order = BUCKETS.map(b => b.key);
+  const cur = order.indexOf(state.bucket[id]);
+  const step = (e.key === "ArrowRight" ? 1 : -1) * (state.rtl ? -1 : 1);
+  const nx = cur + step;
+  if (nx >= 0 && nx < order.length) {
+    state.bucket[id] = order[nx];
+    render();
+    const el = stage.querySelector(`.card[data-id="${id}"]`); if (el) el.focus();
+    announce(`${byId(id).title} moved to ${BUCKETS[nx].label}.`);
+  }
+});
+
+/* ═══════════════════════ COPY-PROMPT BAR ══════════════════════════════ */
+function updatePrompt() {
+  let txt = "";
+  if (state.view === "ortho") {
+    txt = `Treat Forward Future's <b>Loop Library</b> and <b>OrchestKit</b> as orthogonal: the Loop Library is the `
+        + `<b>loop envelope</b> (run-until-condition: budgets, streaks, holdouts, heartbeats), ork is the `
+        + `<em class="em">work</em> each pass does (parallel agents, rubric gates, 211 safety hooks, memory). `
+        + `Plan to <b>consume their recipes, keep our machinery</b> — not rebuild either.`;
+  } else if (state.view === "themes") {
+    const c = { direct:0, partial:0, gap:0 }; THEMES.forEach(t => c[t.status]++);
+    const gaps = THEMES.filter(t => t.status === "gap").map(t => t.theme);
+    txt = `Map of 17 Loop-Library themes onto ork: <b class="em">${c.direct} direct</b>, `
+        + `<b class="warm">${c.partial} partial</b>, <b>${c.gap} true gaps</b> (${esc(gaps.join(", "))}). `
+        + `Close the gaps via the adoption board's holdout-promotion + streak-gate moves.`;
+  } else if (state.view === "adopt") {
+    const seg = (key) => {
+      const names = RECS.filter(r => state.bucket[r.id] === key)
+        .sort((a,b) => a.effort - b.effort).map(r => r.title);
+      return names.length ? esc(names.join(", ")) : "—";
+    };
+    const now = RECS.filter(r => state.bucket[r.id] === "now").sort((a,b) => a.effort - b.effort);
+    const first = now[0] ? now[0].title : null;
+    txt = `Adoption plan from the Loop Library assessment. `
+        + `<b class="em">Adopt now:</b> ${seg("now")}  ·  <b class="warm">Later:</b> ${seg("later")}  ·  <b>Skip / opt-in:</b> ${seg("skip")}. `
+        + (first ? `Start with <b>${esc(first)}</b> (lowest effort in Adopt-now). ` : "")
+        + `Open a milestone + issues for the Adopt-now and Later items.`;
+  } else {
+    const lo = SCORES.filter(s => s.score < 5.5).map(s => s.dim);
+    txt = `OrchestKit loop/autonomy posture scores <b>${COMPOSITE.toFixed(1)} / ${GRADE}</b>. `
+        + `Strongest: <b class="em">engine + safety + rigor</b>. `
+        + `Weakest, and where to invest: <b class="warm">${esc(lo.join(" and "))}</b>.`;
+  }
+  document.getElementById("promptOut").innerHTML = txt;
+}
+document.getElementById("copyBtn").addEventListener("click", () => {
+  const txt = document.getElementById("promptOut").textContent;
+  navigator.clipboard.writeText(txt).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "✓ Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "📋 Copy takeaway"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+/* ═══════════════════════ CHROME / EVENTS ══════════════════════════════ */
+document.getElementById("views").addEventListener("click", e => {
+  const b = e.target.closest("[data-view]"); if (!b) return;
+  state.view = b.dataset.view;
+  document.querySelectorAll("#views button").forEach(x => x.setAttribute("aria-pressed", x.dataset.view === state.view));
+  render();
+});
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl;
+  document.documentElement.dir = state.rtl ? "rtl" : "ltr";
+  e.currentTarget.setAttribute("aria-pressed", state.rtl);
+  render();
+});
+
+render();
+</script>
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/prd-to-goal.mdx
+++ b/docs/site/content/docs/reference/skills/prd-to-goal.mdx
@@ -85,7 +85,7 @@ When the user wants graded feedback beyond pass/fail booleans, the skill MAY als
 
 Scores are 0–10 (`min_pass` = soft floor, `min_blocker` = hard blocker regardless of composite); dimension weights MUST sum to 1.0 — see the schema for the full contract.
 
-The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§7) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
+The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§8) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
 
 ## 5. Worked examples
 
@@ -156,7 +156,24 @@ Output:
 
 Rationale: the LOC bound is the convergent signal — without it, `/goal` can keep "improving" forever. File-existence checks pin the structural decomposition; tests + lint guard correctness. Higher budget because refactors run longer than bug fixes.
 
-## 6. Anti-patterns
+## 6. Recipe Library — pre-built loops
+
+Where §3–5 *generate* a custom `/goal` line from a spec, the recipe library *ships* ready-made ones for the recurring autonomous loops. Each is a loop shape wrapped around an ork worker skill, following the same convergent / falsifiable / budgeted rules as a generated line.
+
+| Recipe | Use when | Worker |
+|---|---|---|
+| 🧪 Coverage climb | raise coverage to a target, meaningfully | `/ork:cover` |
+| 🔴 Production error sweep | clear a backlog of actionable errors | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | docs / reference drifted from code | `/ork:audit-full` |
+| ⚡ Page-load budget | a page exceeds its latency budget | `/ork:performance` |
+| 🧹 Repository cleanup | stale memory / state accumulated | `/ork:dream` |
+| ✅ Quality streak | don't trust a single green (flaky suite) | `/ork:verify` |
+| 🎫 Ticket → PR-ready | drive an issue to a CI-green PR | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | clear a type/lint backlog without suppressions | fixer agent |
+
+Full recipes — the exact `/goal until … abort-if …` lines, convergent signal, and per-recipe guardrail: `references/recipe-library.md`. That file is the in-repo source for the `ork-loops` pack published to skills.sh (the channel Forward Future's Loop Library uses), so the loop *recipes* travel while ork supplies the *machinery* each pass runs on.
+
+## 7. Anti-patterns
 
 | Bad | Why it fails | Good |
 |---|---|---|
@@ -164,7 +181,7 @@ Rationale: the LOC bound is the convergent signal — without it, `/goal` can ke
 | `/goal until the code looks clean` | Not falsifiable. The agent cannot check "looks clean" — it will either declare victory immediately or never. | `/goal until pnpm lint passes AND [ $(wc -l &lt; src/auth.ts) -lt 200 ]` |
 | `/goal until done` | Unbounded. There is no terminating condition; combined with a generous `abort-if turns > 50` this is how runs eat 500K tokens overnight. | Pick 3–5 observable assertions. If you cannot, the PRD is not ready — go to `/ork:write-prd`. |
 
-## 7. Post-timeout assertion grader
+## 8. Post-timeout assertion grader
 
 If the `/goal` loop hits `abort-if` (turn/token cap or no-progress stall), do NOT retry the same line and do NOT let the looping agent critique its own assertions. Spawn a FRESH-context grader that audits the assertion set itself:
 
@@ -186,8 +203,155 @@ Grading must happen in an independent context window — never self-critique (ve
 
 Full pattern (prompt template, independence rules, worked example): `chain-patterns/references/assertion-grader.md`.
 
-## 8. Related skills
+## 9. Related skills
 
 - `ork:write-prd` — if the input has no acceptance criteria, run this first.
 - `ork:brainstorm` — useful when the PRD itself is contested and you want options before writing the goal.
 - `ork:audit-full` — after `/goal` exits, run audit-full to confirm the assertions actually held end-to-end (the loop trusts the boolean; audit re-checks the intent).
+
+
+---
+
+## References (1)
+
+### Recipe Library
+
+# Loop Recipe Library — pre-built `/goal` loops
+
+Pre-written, battle-tested `/goal until … abort-if …` recipes for the recurring autonomous loops. Where `prd-to-goal` *generates* a custom goal line from a spec, this library *ships* ready-made lines for jobs you run over and over.
+
+Each recipe is a **loop shape** (when to stop) wrapped around an **ork skill** (the work each pass does). They follow the same rules as a generated line: AND-joined observable assertions in the `until`, a real `abort-if` budget, and a convergent signal so the loop terminates.
+
+> **Distribution:** this library is the in-repo source for the `ork-loops` pack published to skills.sh — the same channel Forward Future's Loop Library uses (`npx skills add`). Interop, not competition: we ship the loop *recipes*; ork supplies the *machinery* (rubric gates, 211 safety hooks, parallel agents) each pass runs on.
+
+## How to use a recipe
+
+1. **Replace the `&lt;TOKENS&gt;`.** Recipes are templates — swap `&lt;TEST_CMD&gt;`, `&lt;COVERAGE_CMD&gt;`, etc. for your project's commands (e.g. `npm test`, `pnpm test`, `pytest`). The `&lt;…&gt;` tokens are the only things you edit.
+2. **Keep the `abort-if` budget.** It is the safety rail, not boilerplate. Tighten it; never delete it.
+3. **Name the worker.** Each recipe lists the ork skill that should run each pass — invoke it as the loop's worker (`/goal … then run /ork:cover each turn`).
+4. **Mind the guardrails.** Every recipe lists the one way the loop gets gamed and how the assertions prevent it.
+
+## Recipe → theme → worker map
+
+| Recipe | Loop-Library theme | ork worker skill |
+|---|---|---|
+| 🧪 Coverage climb | 100% Test Coverage | `/ork:cover` |
+| 🔴 Production error sweep | Production Error Sweep | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | Docs Sweep | `/ork:audit-full` |
+| ⚡ Page-load budget | Sub-50ms Page-Load | `/ork:performance` |
+| 🧹 Repository cleanup | Repository Cleanup | `/ork:dream` |
+| ✅ Quality streak | Quality Streak | `/ork:verify` |
+| 🎫 Ticket → PR-ready | Ticket-to-PR-Ready | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | (static-analysis baseline) | fixer agent |
+
+---
+
+## 🧪 Coverage climb
+
+**Use when:** coverage is below your bar and you want it raised *meaningfully* (not gamed).
+**Backs each pass:** `/ork:cover` · **Convergent signal:** coverage % climbs toward target; no-progress aborts the asymptote.
+
+```
+/goal until <COVERAGE_CMD> reports >= 90 AND <TEST_CMD> passes
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** coverage alone is gameable (assert-free tests bump the number). Keep the full suite green in the AND so tests stay meaningful. Pair with the **streak gate (#2540)** so a flaky green at 90% doesn't end the loop on a fluke.
+
+## 🔴 Production error sweep
+
+**Use when:** an error tracker / log has a backlog of *actionable, reproducible* errors.
+**Backs each pass:** `/ork:fix-issue` · **Convergent signal:** open actionable-error count shrinks toward 0.
+
+```
+/goal until [ $(<ERROR_COUNT_CMD>) -eq 0 ] AND <TEST_CMD> passes
+/goal abort-if turns > 25 OR tokens > 250000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** scope `&lt;ERROR_COUNT_CMD&gt;` to *actionable + reproducible* errors only — filter third-party noise, or the loop chases unfixable errors forever. Never point this at destructive remediation; `/goal` retries, and you don't want retries on data deletion.
+
+## 📚 Docs-drift sweep
+
+**Use when:** generated reference, links, or examples drift from the code.
+**Backs each pass:** `/ork:audit-full` (docs lens) or your docs checker · **Convergent signal:** drift checks → all pass.
+
+```
+/goal until <DOCS_DRIFT_CMD> passes AND <LINK_CHECK_CMD> passes
+/goal abort-if turns > 15 OR tokens > 120000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** `&lt;DOCS_DRIFT_CMD&gt;` must be deterministic (e.g. "regenerated reference == committed reference"), never an LLM "are the docs good?" judgement — subjective checks never converge.
+
+## ⚡ Page-load budget
+
+**Use when:** a page exceeds your latency budget (LCP / load time).
+**Backs each pass:** `/ork:performance` · **Convergent signal:** metric descends toward budget; the no-progress detector is essential (perf has diminishing returns).
+
+```
+/goal until [ $(<LCP_MS_CMD>) -le 2000 ] AND <TEST_CMD> passes
+/goal abort-if turns > 12 OR tokens > 150000 OR no_progress_for_2_turns
+```
+
+**Guardrail:** keep `no_progress_for_2_turns` tight — perf loops plateau, and you want to stop *at* the plateau, not grind tokens past it. Always AND the test suite so an "optimization" that breaks behavior can't satisfy the budget.
+
+## 🧹 Repository cleanup
+
+**Use when:** memory files, stale branches, or dead state have accumulated.
+**Backs each pass:** `/ork:dream` · **Convergent signal:** the dry-run reports nothing to prune (naturally terminating — each pass strictly reduces the stale set).
+
+```
+/goal until <DREAM_DRYRUN_CMD> reports 0 stale AND 0 duplicate AND 0 contradiction
+/goal abort-if turns > 8 OR tokens > 60000 OR no_progress_for_2_turns
+```
+
+**Guardrail:** run dream in **dry-run** inside the `until`-check; let the pass apply the changes. The safest loop here — it converges fast because the stale set only shrinks.
+
+## ✅ Quality streak
+
+**Use when:** you don't trust a single green (flaky suite, race conditions).
+**Backs each pass:** `/ork:verify` · **Convergent signal:** a consecutive-pass counter reaches N.
+
+```
+/goal until <VERIFY_CMD> passes 3 times in a row
+/goal abort-if turns > 15 OR tokens > 150000 OR no_progress_for_4_turns
+```
+
+**Guardrail:** this recipe needs the **native streak gate (#2540)**. Until that lands, `/goal` can't count consecutive passes — approximate it in the `until`-check with `&lt;VERIFY_CMD&gt; && &lt;VERIFY_CMD&gt; && &lt;VERIFY_CMD&gt;` (slower, but honest). This recipe is exactly *why* #2540 exists.
+
+## 🎫 Ticket → PR-ready
+
+**Use when:** you want an issue taken from open to a CI-green, reviewer-ready PR.
+**Backs each pass:** `/ork:fix-issue` → `/ork:create-pr` · **Convergent signal:** PR exists, CI green, links the issue.
+
+```
+/goal until gh pr list --head <BRANCH> --json number | jq -e 'length>0' AND gh pr checks <BRANCH> --json state | jq -e 'all(.state=="SUCCESS")'
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** do **not** put "merged" in the `until`-clause — merging is a human gate (and ork never auto-closes issues; CI closes them on merge via `Closes #N`). Stop at reviewer-ready.
+
+## 🧼 Type/lint zero
+
+**Use when:** a codebase or migration has a backlog of type/lint errors.
+**Backs each pass:** the relevant fixer agent · **Convergent signal:** error counts → 0.
+
+```
+/goal until <TYPECHECK_CMD> passes AND <LINT_CMD> passes AND [ $(grep -rc "@ts-ignore\|eslint-disable" src | paste -sd+ - | bc) -le <SUPPRESS_BASELINE> ]
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** the suppression-count clause is load-bearing. Without it the loop "wins" by silencing (`@ts-ignore`, `eslint-disable`) instead of fixing — set `&lt;SUPPRESS_BASELINE&gt;` to the current count so it can only go down.
+
+---
+
+## Authoring your own recipe
+
+A recipe is shippable when all four hold (same bar as a `prd-to-goal` line):
+
+- **Convergent** — there is a monotone signal (count → 0, metric → budget, % → target) that the loop drives in one direction. No monotone signal ⇒ no termination.
+- **Falsifiable** — every `until` assertion is a shell-checkable boolean, not a judgement.
+- **Guarded** — you can name the one way the loop gets gamed, and an assertion that blocks it.
+- **Budgeted** — `abort-if` caps turns, tokens, and no-progress. A recipe without a budget is a token fire.
+
+If you can't satisfy all four, the job isn't a loop yet — decompose it with `/ork:prd-to-goal` first.
+

--- a/plugins/ork/.claude-plugin/skill-indexes/product-strategist.md
+++ b/plugins/ork/.claude-plugin/skill-indexes/product-strategist.md
@@ -6,7 +6,7 @@
 |product-frameworks:{SKILL.md,references/{build-buy-partner-decision.md,competitive-analysis-guide.md,interview-guide-template.md,journey-map-workshop.md,okr-workshop-guide.md,output-templates.md,rice-scoring-guide.md,roi-calculation-guide.md,tam-sam-som-guide.md,user-story-workshop-guide.md,value-prop-canvas-guide.md,wsjf-guide.md}}|product,strategy,business-case,market-analysis,prioritization,okr,kpi,persona,requirements,user-research,rice,prd
 |brainstorm:{SKILL.md,references/{common-pitfalls.md,devils-advocate-prompts.md,divergent-techniques.md,effort-scaling.md,evaluation-rubric.md,example-session-auth.md,example-session-dashboard.md,iterative-optimization-mode.md,mcp-probe-resume.md,phase-workflow.md,socratic-questions.md}}|planning,ideation,creativity,design
 |write-prd:{SKILL.md,references/{output-templates.md,prd-template.md,user-stories-guide.md,value-prop-canvas-guide.md}}|prd,requirements,user-story,acceptance-criteria,invest,value-proposition,go-no-go
-|prd-to-goal:{SKILL.md}|/goal,planning,prd,automation,cc-2.1.139
+|prd-to-goal:{SKILL.md,references/{recipe-library.md}}|/goal,planning,prd,automation,cc-2.1.139
 |github-operations:{SKILL.md,references/{cli-vs-api-identifiers.md,graphql-api.md,issue-management.md,milestone-api.md,pr-workflows.md,projects-v2.md}}|github,gh,cli,issues,pr,milestones,projects,api
 |remember:{SKILL.md,references/{category-detection.md,confirmation-templates.md,entity-extraction-workflow.md,examples.md,graph-operations.md}}|memory,decisions,patterns,best-practices,graph-memory
 |memory:{SKILL.md,references/{memory-commands.md,mermaid-patterns.md,session-resume-patterns.md}}|memory,graph,session,context,sync,visualization,history,search

--- a/plugins/ork/agents/product-strategist.md
+++ b/plugins/ork/agents/product-strategist.md
@@ -281,7 +281,7 @@ Read the specific file before advising. Do NOT rely on training data.
 |product-frameworks:{SKILL.md,references/{build-buy-partner-decision.md,competitive-analysis-guide.md,interview-guide-template.md,journey-map-workshop.md,okr-workshop-guide.md,output-templates.md,rice-scoring-guide.md,roi-calculation-guide.md,tam-sam-som-guide.md,user-story-workshop-guide.md,value-prop-canvas-guide.md,wsjf-guide.md}}|product,strategy,business-case,market-analysis,prioritization,okr,kpi,persona,requirements,user-research,rice,prd
 |brainstorm:{SKILL.md,references/{common-pitfalls.md,devils-advocate-prompts.md,divergent-techniques.md,effort-scaling.md,evaluation-rubric.md,example-session-auth.md,example-session-dashboard.md,iterative-optimization-mode.md,mcp-probe-resume.md,phase-workflow.md,socratic-questions.md}}|planning,ideation,creativity,design
 |write-prd:{SKILL.md,references/{output-templates.md,prd-template.md,user-stories-guide.md,value-prop-canvas-guide.md}}|prd,requirements,user-story,acceptance-criteria,invest,value-proposition,go-no-go
-|prd-to-goal:{SKILL.md}|/goal,planning,prd,automation,cc-2.1.139
+|prd-to-goal:{SKILL.md,references/{recipe-library.md}}|/goal,planning,prd,automation,cc-2.1.139
 |github-operations:{SKILL.md,references/{cli-vs-api-identifiers.md,graphql-api.md,issue-management.md,milestone-api.md,pr-workflows.md,projects-v2.md}}|github,gh,cli,issues,pr,milestones,projects,api
 |remember:{SKILL.md,references/{category-detection.md,confirmation-templates.md,entity-extraction-workflow.md,examples.md,graph-operations.md}}|memory,decisions,patterns,best-practices,graph-memory
 |memory:{SKILL.md,references/{memory-commands.md,mermaid-patterns.md,session-resume-patterns.md}}|memory,graph,session,context,sync,visualization,history,search

--- a/plugins/ork/commands/prd-to-goal.md
+++ b/plugins/ork/commands/prd-to-goal.md
@@ -78,7 +78,7 @@ When the user wants graded feedback beyond pass/fail booleans, the skill MAY als
 
 Scores are 0–10 (`min_pass` = soft floor, `min_blocker` = hard blocker regardless of composite); dimension weights MUST sum to 1.0 — see the schema for the full contract.
 
-The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§7) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
+The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§8) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
 
 ## 5. Worked examples
 
@@ -149,7 +149,24 @@ Output:
 
 Rationale: the LOC bound is the convergent signal — without it, `/goal` can keep "improving" forever. File-existence checks pin the structural decomposition; tests + lint guard correctness. Higher budget because refactors run longer than bug fixes.
 
-## 6. Anti-patterns
+## 6. Recipe Library — pre-built loops
+
+Where §3–5 *generate* a custom `/goal` line from a spec, the recipe library *ships* ready-made ones for the recurring autonomous loops. Each is a loop shape wrapped around an ork worker skill, following the same convergent / falsifiable / budgeted rules as a generated line.
+
+| Recipe | Use when | Worker |
+|---|---|---|
+| 🧪 Coverage climb | raise coverage to a target, meaningfully | `/ork:cover` |
+| 🔴 Production error sweep | clear a backlog of actionable errors | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | docs / reference drifted from code | `/ork:audit-full` |
+| ⚡ Page-load budget | a page exceeds its latency budget | `/ork:performance` |
+| 🧹 Repository cleanup | stale memory / state accumulated | `/ork:dream` |
+| ✅ Quality streak | don't trust a single green (flaky suite) | `/ork:verify` |
+| 🎫 Ticket → PR-ready | drive an issue to a CI-green PR | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | clear a type/lint backlog without suppressions | fixer agent |
+
+Full recipes — the exact `/goal until … abort-if …` lines, convergent signal, and per-recipe guardrail: `references/recipe-library.md`. That file is the in-repo source for the `ork-loops` pack published to skills.sh (the channel Forward Future's Loop Library uses), so the loop *recipes* travel while ork supplies the *machinery* each pass runs on.
+
+## 7. Anti-patterns
 
 | Bad | Why it fails | Good |
 |---|---|---|
@@ -157,7 +174,7 @@ Rationale: the LOC bound is the convergent signal — without it, `/goal` can ke
 | `/goal until the code looks clean` | Not falsifiable. The agent cannot check "looks clean" — it will either declare victory immediately or never. | `/goal until pnpm lint passes AND [ $(wc -l < src/auth.ts) -lt 200 ]` |
 | `/goal until done` | Unbounded. There is no terminating condition; combined with a generous `abort-if turns > 50` this is how runs eat 500K tokens overnight. | Pick 3–5 observable assertions. If you cannot, the PRD is not ready — go to `/ork:write-prd`. |
 
-## 7. Post-timeout assertion grader
+## 8. Post-timeout assertion grader
 
 If the `/goal` loop hits `abort-if` (turn/token cap or no-progress stall), do NOT retry the same line and do NOT let the looping agent critique its own assertions. Spawn a FRESH-context grader that audits the assertion set itself:
 
@@ -179,7 +196,7 @@ Grading must happen in an independent context window — never self-critique (ve
 
 Full pattern (prompt template, independence rules, worked example): `chain-patterns/references/assertion-grader.md`.
 
-## 8. Related skills
+## 9. Related skills
 
 - `ork:write-prd` — if the input has no acceptance criteria, run this first.
 - `ork:brainstorm` — useful when the PRD itself is contested and you want options before writing the goal.

--- a/plugins/ork/skills/prd-to-goal/SKILL.md
+++ b/plugins/ork/skills/prd-to-goal/SKILL.md
@@ -95,7 +95,7 @@ When the user wants graded feedback beyond pass/fail booleans, the skill MAY als
 
 Scores are 0–10 (`min_pass` = soft floor, `min_blocker` = hard blocker regardless of composite); dimension weights MUST sum to 1.0 — see the schema for the full contract.
 
-The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§7) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
+The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§8) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
 
 ## 5. Worked examples
 
@@ -166,7 +166,24 @@ Output:
 
 Rationale: the LOC bound is the convergent signal — without it, `/goal` can keep "improving" forever. File-existence checks pin the structural decomposition; tests + lint guard correctness. Higher budget because refactors run longer than bug fixes.
 
-## 6. Anti-patterns
+## 6. Recipe Library — pre-built loops
+
+Where §3–5 *generate* a custom `/goal` line from a spec, the recipe library *ships* ready-made ones for the recurring autonomous loops. Each is a loop shape wrapped around an ork worker skill, following the same convergent / falsifiable / budgeted rules as a generated line.
+
+| Recipe | Use when | Worker |
+|---|---|---|
+| 🧪 Coverage climb | raise coverage to a target, meaningfully | `/ork:cover` |
+| 🔴 Production error sweep | clear a backlog of actionable errors | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | docs / reference drifted from code | `/ork:audit-full` |
+| ⚡ Page-load budget | a page exceeds its latency budget | `/ork:performance` |
+| 🧹 Repository cleanup | stale memory / state accumulated | `/ork:dream` |
+| ✅ Quality streak | don't trust a single green (flaky suite) | `/ork:verify` |
+| 🎫 Ticket → PR-ready | drive an issue to a CI-green PR | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | clear a type/lint backlog without suppressions | fixer agent |
+
+Full recipes — the exact `/goal until … abort-if …` lines, convergent signal, and per-recipe guardrail: `references/recipe-library.md`. That file is the in-repo source for the `ork-loops` pack published to skills.sh (the channel Forward Future's Loop Library uses), so the loop *recipes* travel while ork supplies the *machinery* each pass runs on.
+
+## 7. Anti-patterns
 
 | Bad | Why it fails | Good |
 |---|---|---|
@@ -174,7 +191,7 @@ Rationale: the LOC bound is the convergent signal — without it, `/goal` can ke
 | `/goal until the code looks clean` | Not falsifiable. The agent cannot check "looks clean" — it will either declare victory immediately or never. | `/goal until pnpm lint passes AND [ $(wc -l < src/auth.ts) -lt 200 ]` |
 | `/goal until done` | Unbounded. There is no terminating condition; combined with a generous `abort-if turns > 50` this is how runs eat 500K tokens overnight. | Pick 3–5 observable assertions. If you cannot, the PRD is not ready — go to `/ork:write-prd`. |
 
-## 7. Post-timeout assertion grader
+## 8. Post-timeout assertion grader
 
 If the `/goal` loop hits `abort-if` (turn/token cap or no-progress stall), do NOT retry the same line and do NOT let the looping agent critique its own assertions. Spawn a FRESH-context grader that audits the assertion set itself:
 
@@ -196,7 +213,7 @@ Grading must happen in an independent context window — never self-critique (ve
 
 Full pattern (prompt template, independence rules, worked example): `chain-patterns/references/assertion-grader.md`.
 
-## 8. Related skills
+## 9. Related skills
 
 - `ork:write-prd` — if the input has no acceptance criteria, run this first.
 - `ork:brainstorm` — useful when the PRD itself is contested and you want options before writing the goal.

--- a/plugins/ork/skills/prd-to-goal/references/recipe-library.md
+++ b/plugins/ork/skills/prd-to-goal/references/recipe-library.md
@@ -1,0 +1,138 @@
+# Loop Recipe Library — pre-built `/goal` loops
+
+Pre-written, battle-tested `/goal until … abort-if …` recipes for the recurring autonomous loops. Where `prd-to-goal` *generates* a custom goal line from a spec, this library *ships* ready-made lines for jobs you run over and over.
+
+Each recipe is a **loop shape** (when to stop) wrapped around an **ork skill** (the work each pass does). They follow the same rules as a generated line: AND-joined observable assertions in the `until`, a real `abort-if` budget, and a convergent signal so the loop terminates.
+
+> **Distribution:** this library is the in-repo source for the `ork-loops` pack published to skills.sh — the same channel Forward Future's Loop Library uses (`npx skills add`). Interop, not competition: we ship the loop *recipes*; ork supplies the *machinery* (rubric gates, 211 safety hooks, parallel agents) each pass runs on.
+
+## How to use a recipe
+
+1. **Replace the `<TOKENS>`.** Recipes are templates — swap `<TEST_CMD>`, `<COVERAGE_CMD>`, etc. for your project's commands (e.g. `npm test`, `pnpm test`, `pytest`). The `<…>` tokens are the only things you edit.
+2. **Keep the `abort-if` budget.** It is the safety rail, not boilerplate. Tighten it; never delete it.
+3. **Name the worker.** Each recipe lists the ork skill that should run each pass — invoke it as the loop's worker (`/goal … then run /ork:cover each turn`).
+4. **Mind the guardrails.** Every recipe lists the one way the loop gets gamed and how the assertions prevent it.
+
+## Recipe → theme → worker map
+
+| Recipe | Loop-Library theme | ork worker skill |
+|---|---|---|
+| 🧪 Coverage climb | 100% Test Coverage | `/ork:cover` |
+| 🔴 Production error sweep | Production Error Sweep | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | Docs Sweep | `/ork:audit-full` |
+| ⚡ Page-load budget | Sub-50ms Page-Load | `/ork:performance` |
+| 🧹 Repository cleanup | Repository Cleanup | `/ork:dream` |
+| ✅ Quality streak | Quality Streak | `/ork:verify` |
+| 🎫 Ticket → PR-ready | Ticket-to-PR-Ready | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | (static-analysis baseline) | fixer agent |
+
+---
+
+## 🧪 Coverage climb
+
+**Use when:** coverage is below your bar and you want it raised *meaningfully* (not gamed).
+**Backs each pass:** `/ork:cover` · **Convergent signal:** coverage % climbs toward target; no-progress aborts the asymptote.
+
+```
+/goal until <COVERAGE_CMD> reports >= 90 AND <TEST_CMD> passes
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** coverage alone is gameable (assert-free tests bump the number). Keep the full suite green in the AND so tests stay meaningful. Pair with the **streak gate (#2540)** so a flaky green at 90% doesn't end the loop on a fluke.
+
+## 🔴 Production error sweep
+
+**Use when:** an error tracker / log has a backlog of *actionable, reproducible* errors.
+**Backs each pass:** `/ork:fix-issue` · **Convergent signal:** open actionable-error count shrinks toward 0.
+
+```
+/goal until [ $(<ERROR_COUNT_CMD>) -eq 0 ] AND <TEST_CMD> passes
+/goal abort-if turns > 25 OR tokens > 250000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** scope `<ERROR_COUNT_CMD>` to *actionable + reproducible* errors only — filter third-party noise, or the loop chases unfixable errors forever. Never point this at destructive remediation; `/goal` retries, and you don't want retries on data deletion.
+
+## 📚 Docs-drift sweep
+
+**Use when:** generated reference, links, or examples drift from the code.
+**Backs each pass:** `/ork:audit-full` (docs lens) or your docs checker · **Convergent signal:** drift checks → all pass.
+
+```
+/goal until <DOCS_DRIFT_CMD> passes AND <LINK_CHECK_CMD> passes
+/goal abort-if turns > 15 OR tokens > 120000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** `<DOCS_DRIFT_CMD>` must be deterministic (e.g. "regenerated reference == committed reference"), never an LLM "are the docs good?" judgement — subjective checks never converge.
+
+## ⚡ Page-load budget
+
+**Use when:** a page exceeds your latency budget (LCP / load time).
+**Backs each pass:** `/ork:performance` · **Convergent signal:** metric descends toward budget; the no-progress detector is essential (perf has diminishing returns).
+
+```
+/goal until [ $(<LCP_MS_CMD>) -le 2000 ] AND <TEST_CMD> passes
+/goal abort-if turns > 12 OR tokens > 150000 OR no_progress_for_2_turns
+```
+
+**Guardrail:** keep `no_progress_for_2_turns` tight — perf loops plateau, and you want to stop *at* the plateau, not grind tokens past it. Always AND the test suite so an "optimization" that breaks behavior can't satisfy the budget.
+
+## 🧹 Repository cleanup
+
+**Use when:** memory files, stale branches, or dead state have accumulated.
+**Backs each pass:** `/ork:dream` · **Convergent signal:** the dry-run reports nothing to prune (naturally terminating — each pass strictly reduces the stale set).
+
+```
+/goal until <DREAM_DRYRUN_CMD> reports 0 stale AND 0 duplicate AND 0 contradiction
+/goal abort-if turns > 8 OR tokens > 60000 OR no_progress_for_2_turns
+```
+
+**Guardrail:** run dream in **dry-run** inside the `until`-check; let the pass apply the changes. The safest loop here — it converges fast because the stale set only shrinks.
+
+## ✅ Quality streak
+
+**Use when:** you don't trust a single green (flaky suite, race conditions).
+**Backs each pass:** `/ork:verify` · **Convergent signal:** a consecutive-pass counter reaches N.
+
+```
+/goal until <VERIFY_CMD> passes 3 times in a row
+/goal abort-if turns > 15 OR tokens > 150000 OR no_progress_for_4_turns
+```
+
+**Guardrail:** this recipe needs the **native streak gate (#2540)**. Until that lands, `/goal` can't count consecutive passes — approximate it in the `until`-check with `<VERIFY_CMD> && <VERIFY_CMD> && <VERIFY_CMD>` (slower, but honest). This recipe is exactly *why* #2540 exists.
+
+## 🎫 Ticket → PR-ready
+
+**Use when:** you want an issue taken from open to a CI-green, reviewer-ready PR.
+**Backs each pass:** `/ork:fix-issue` → `/ork:create-pr` · **Convergent signal:** PR exists, CI green, links the issue.
+
+```
+/goal until gh pr list --head <BRANCH> --json number | jq -e 'length>0' AND gh pr checks <BRANCH> --json state | jq -e 'all(.state=="SUCCESS")'
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** do **not** put "merged" in the `until`-clause — merging is a human gate (and ork never auto-closes issues; CI closes them on merge via `Closes #N`). Stop at reviewer-ready.
+
+## 🧼 Type/lint zero
+
+**Use when:** a codebase or migration has a backlog of type/lint errors.
+**Backs each pass:** the relevant fixer agent · **Convergent signal:** error counts → 0.
+
+```
+/goal until <TYPECHECK_CMD> passes AND <LINT_CMD> passes AND [ $(grep -rc "@ts-ignore\|eslint-disable" src | paste -sd+ - | bc) -le <SUPPRESS_BASELINE> ]
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** the suppression-count clause is load-bearing. Without it the loop "wins" by silencing (`@ts-ignore`, `eslint-disable`) instead of fixing — set `<SUPPRESS_BASELINE>` to the current count so it can only go down.
+
+---
+
+## Authoring your own recipe
+
+A recipe is shippable when all four hold (same bar as a `prd-to-goal` line):
+
+- **Convergent** — there is a monotone signal (count → 0, metric → budget, % → target) that the loop drives in one direction. No monotone signal ⇒ no termination.
+- **Falsifiable** — every `until` assertion is a shell-checkable boolean, not a judgement.
+- **Guarded** — you can name the one way the loop gets gamed, and an assertion that blocks it.
+- **Budgeted** — `abort-if` caps turns, tokens, and no-progress. A recipe without a budget is a token fire.
+
+If you can't satisfy all four, the job isn't a loop yet — decompose it with `/ork:prd-to-goal` first.

--- a/src/skills/prd-to-goal/SKILL.md
+++ b/src/skills/prd-to-goal/SKILL.md
@@ -95,7 +95,7 @@ When the user wants graded feedback beyond pass/fail booleans, the skill MAY als
 
 Scores are 0–10 (`min_pass` = soft floor, `min_blocker` = hard blocker regardless of composite); dimension weights MUST sum to 1.0 — see the schema for the full contract.
 
-The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§7) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
+The file is deliberately **user-editable before the `/goal` run** — that is the point. Adjusting weights and `min_pass` thresholds is how the user injects judgement into the loop without rewriting assertions (rubric-as-environment-feedback, Lance Martin 2026-06-09). The post-timeout grader (§8) treats the rubric, if present, as the user's intent — senior to the literal assertion text.
 
 ## 5. Worked examples
 
@@ -166,7 +166,24 @@ Output:
 
 Rationale: the LOC bound is the convergent signal — without it, `/goal` can keep "improving" forever. File-existence checks pin the structural decomposition; tests + lint guard correctness. Higher budget because refactors run longer than bug fixes.
 
-## 6. Anti-patterns
+## 6. Recipe Library — pre-built loops
+
+Where §3–5 *generate* a custom `/goal` line from a spec, the recipe library *ships* ready-made ones for the recurring autonomous loops. Each is a loop shape wrapped around an ork worker skill, following the same convergent / falsifiable / budgeted rules as a generated line.
+
+| Recipe | Use when | Worker |
+|---|---|---|
+| 🧪 Coverage climb | raise coverage to a target, meaningfully | `/ork:cover` |
+| 🔴 Production error sweep | clear a backlog of actionable errors | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | docs / reference drifted from code | `/ork:audit-full` |
+| ⚡ Page-load budget | a page exceeds its latency budget | `/ork:performance` |
+| 🧹 Repository cleanup | stale memory / state accumulated | `/ork:dream` |
+| ✅ Quality streak | don't trust a single green (flaky suite) | `/ork:verify` |
+| 🎫 Ticket → PR-ready | drive an issue to a CI-green PR | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | clear a type/lint backlog without suppressions | fixer agent |
+
+Full recipes — the exact `/goal until … abort-if …` lines, convergent signal, and per-recipe guardrail: `references/recipe-library.md`. That file is the in-repo source for the `ork-loops` pack published to skills.sh (the channel Forward Future's Loop Library uses), so the loop *recipes* travel while ork supplies the *machinery* each pass runs on.
+
+## 7. Anti-patterns
 
 | Bad | Why it fails | Good |
 |---|---|---|
@@ -174,7 +191,7 @@ Rationale: the LOC bound is the convergent signal — without it, `/goal` can ke
 | `/goal until the code looks clean` | Not falsifiable. The agent cannot check "looks clean" — it will either declare victory immediately or never. | `/goal until pnpm lint passes AND [ $(wc -l < src/auth.ts) -lt 200 ]` |
 | `/goal until done` | Unbounded. There is no terminating condition; combined with a generous `abort-if turns > 50` this is how runs eat 500K tokens overnight. | Pick 3–5 observable assertions. If you cannot, the PRD is not ready — go to `/ork:write-prd`. |
 
-## 7. Post-timeout assertion grader
+## 8. Post-timeout assertion grader
 
 If the `/goal` loop hits `abort-if` (turn/token cap or no-progress stall), do NOT retry the same line and do NOT let the looping agent critique its own assertions. Spawn a FRESH-context grader that audits the assertion set itself:
 
@@ -196,7 +213,7 @@ Grading must happen in an independent context window — never self-critique (ve
 
 Full pattern (prompt template, independence rules, worked example): `chain-patterns/references/assertion-grader.md`.
 
-## 8. Related skills
+## 9. Related skills
 
 - `ork:write-prd` — if the input has no acceptance criteria, run this first.
 - `ork:brainstorm` — useful when the PRD itself is contested and you want options before writing the goal.

--- a/src/skills/prd-to-goal/references/recipe-library.md
+++ b/src/skills/prd-to-goal/references/recipe-library.md
@@ -1,0 +1,138 @@
+# Loop Recipe Library — pre-built `/goal` loops
+
+Pre-written, battle-tested `/goal until … abort-if …` recipes for the recurring autonomous loops. Where `prd-to-goal` *generates* a custom goal line from a spec, this library *ships* ready-made lines for jobs you run over and over.
+
+Each recipe is a **loop shape** (when to stop) wrapped around an **ork skill** (the work each pass does). They follow the same rules as a generated line: AND-joined observable assertions in the `until`, a real `abort-if` budget, and a convergent signal so the loop terminates.
+
+> **Distribution:** this library is the in-repo source for the `ork-loops` pack published to skills.sh — the same channel Forward Future's Loop Library uses (`npx skills add`). Interop, not competition: we ship the loop *recipes*; ork supplies the *machinery* (rubric gates, 211 safety hooks, parallel agents) each pass runs on.
+
+## How to use a recipe
+
+1. **Replace the `<TOKENS>`.** Recipes are templates — swap `<TEST_CMD>`, `<COVERAGE_CMD>`, etc. for your project's commands (e.g. `npm test`, `pnpm test`, `pytest`). The `<…>` tokens are the only things you edit.
+2. **Keep the `abort-if` budget.** It is the safety rail, not boilerplate. Tighten it; never delete it.
+3. **Name the worker.** Each recipe lists the ork skill that should run each pass — invoke it as the loop's worker (`/goal … then run /ork:cover each turn`).
+4. **Mind the guardrails.** Every recipe lists the one way the loop gets gamed and how the assertions prevent it.
+
+## Recipe → theme → worker map
+
+| Recipe | Loop-Library theme | ork worker skill |
+|---|---|---|
+| 🧪 Coverage climb | 100% Test Coverage | `/ork:cover` |
+| 🔴 Production error sweep | Production Error Sweep | `/ork:fix-issue` |
+| 📚 Docs-drift sweep | Docs Sweep | `/ork:audit-full` |
+| ⚡ Page-load budget | Sub-50ms Page-Load | `/ork:performance` |
+| 🧹 Repository cleanup | Repository Cleanup | `/ork:dream` |
+| ✅ Quality streak | Quality Streak | `/ork:verify` |
+| 🎫 Ticket → PR-ready | Ticket-to-PR-Ready | `/ork:fix-issue` → `/ork:create-pr` |
+| 🧼 Type/lint zero | (static-analysis baseline) | fixer agent |
+
+---
+
+## 🧪 Coverage climb
+
+**Use when:** coverage is below your bar and you want it raised *meaningfully* (not gamed).
+**Backs each pass:** `/ork:cover` · **Convergent signal:** coverage % climbs toward target; no-progress aborts the asymptote.
+
+```
+/goal until <COVERAGE_CMD> reports >= 90 AND <TEST_CMD> passes
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** coverage alone is gameable (assert-free tests bump the number). Keep the full suite green in the AND so tests stay meaningful. Pair with the **streak gate (#2540)** so a flaky green at 90% doesn't end the loop on a fluke.
+
+## 🔴 Production error sweep
+
+**Use when:** an error tracker / log has a backlog of *actionable, reproducible* errors.
+**Backs each pass:** `/ork:fix-issue` · **Convergent signal:** open actionable-error count shrinks toward 0.
+
+```
+/goal until [ $(<ERROR_COUNT_CMD>) -eq 0 ] AND <TEST_CMD> passes
+/goal abort-if turns > 25 OR tokens > 250000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** scope `<ERROR_COUNT_CMD>` to *actionable + reproducible* errors only — filter third-party noise, or the loop chases unfixable errors forever. Never point this at destructive remediation; `/goal` retries, and you don't want retries on data deletion.
+
+## 📚 Docs-drift sweep
+
+**Use when:** generated reference, links, or examples drift from the code.
+**Backs each pass:** `/ork:audit-full` (docs lens) or your docs checker · **Convergent signal:** drift checks → all pass.
+
+```
+/goal until <DOCS_DRIFT_CMD> passes AND <LINK_CHECK_CMD> passes
+/goal abort-if turns > 15 OR tokens > 120000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** `<DOCS_DRIFT_CMD>` must be deterministic (e.g. "regenerated reference == committed reference"), never an LLM "are the docs good?" judgement — subjective checks never converge.
+
+## ⚡ Page-load budget
+
+**Use when:** a page exceeds your latency budget (LCP / load time).
+**Backs each pass:** `/ork:performance` · **Convergent signal:** metric descends toward budget; the no-progress detector is essential (perf has diminishing returns).
+
+```
+/goal until [ $(<LCP_MS_CMD>) -le 2000 ] AND <TEST_CMD> passes
+/goal abort-if turns > 12 OR tokens > 150000 OR no_progress_for_2_turns
+```
+
+**Guardrail:** keep `no_progress_for_2_turns` tight — perf loops plateau, and you want to stop *at* the plateau, not grind tokens past it. Always AND the test suite so an "optimization" that breaks behavior can't satisfy the budget.
+
+## 🧹 Repository cleanup
+
+**Use when:** memory files, stale branches, or dead state have accumulated.
+**Backs each pass:** `/ork:dream` · **Convergent signal:** the dry-run reports nothing to prune (naturally terminating — each pass strictly reduces the stale set).
+
+```
+/goal until <DREAM_DRYRUN_CMD> reports 0 stale AND 0 duplicate AND 0 contradiction
+/goal abort-if turns > 8 OR tokens > 60000 OR no_progress_for_2_turns
+```
+
+**Guardrail:** run dream in **dry-run** inside the `until`-check; let the pass apply the changes. The safest loop here — it converges fast because the stale set only shrinks.
+
+## ✅ Quality streak
+
+**Use when:** you don't trust a single green (flaky suite, race conditions).
+**Backs each pass:** `/ork:verify` · **Convergent signal:** a consecutive-pass counter reaches N.
+
+```
+/goal until <VERIFY_CMD> passes 3 times in a row
+/goal abort-if turns > 15 OR tokens > 150000 OR no_progress_for_4_turns
+```
+
+**Guardrail:** this recipe needs the **native streak gate (#2540)**. Until that lands, `/goal` can't count consecutive passes — approximate it in the `until`-check with `<VERIFY_CMD> && <VERIFY_CMD> && <VERIFY_CMD>` (slower, but honest). This recipe is exactly *why* #2540 exists.
+
+## 🎫 Ticket → PR-ready
+
+**Use when:** you want an issue taken from open to a CI-green, reviewer-ready PR.
+**Backs each pass:** `/ork:fix-issue` → `/ork:create-pr` · **Convergent signal:** PR exists, CI green, links the issue.
+
+```
+/goal until gh pr list --head <BRANCH> --json number | jq -e 'length>0' AND gh pr checks <BRANCH> --json state | jq -e 'all(.state=="SUCCESS")'
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** do **not** put "merged" in the `until`-clause — merging is a human gate (and ork never auto-closes issues; CI closes them on merge via `Closes #N`). Stop at reviewer-ready.
+
+## 🧼 Type/lint zero
+
+**Use when:** a codebase or migration has a backlog of type/lint errors.
+**Backs each pass:** the relevant fixer agent · **Convergent signal:** error counts → 0.
+
+```
+/goal until <TYPECHECK_CMD> passes AND <LINT_CMD> passes AND [ $(grep -rc "@ts-ignore\|eslint-disable" src | paste -sd+ - | bc) -le <SUPPRESS_BASELINE> ]
+/goal abort-if turns > 20 OR tokens > 200000 OR no_progress_for_3_turns
+```
+
+**Guardrail:** the suppression-count clause is load-bearing. Without it the loop "wins" by silencing (`@ts-ignore`, `eslint-disable`) instead of fixing — set `<SUPPRESS_BASELINE>` to the current count so it can only go down.
+
+---
+
+## Authoring your own recipe
+
+A recipe is shippable when all four hold (same bar as a `prd-to-goal` line):
+
+- **Convergent** — there is a monotone signal (count → 0, metric → budget, % → target) that the loop drives in one direction. No monotone signal ⇒ no termination.
+- **Falsifiable** — every `until` assertion is a shell-checkable boolean, not a judgement.
+- **Guarded** — you can name the one way the loop gets gamed, and an assertion that blocks it.
+- **Budgeted** — `abort-if` caps turns, tokens, and no-progress. A recipe without a budget is a token fire.
+
+If you can't satisfy all four, the job isn't a loop yet — decompose it with `/ork:prd-to-goal` first.


### PR DESCRIPTION
## Summary

Ships the **Loop Recipe Library** — 8 pre-built `/goal until ... abort-if ...` loops — as the first adopt-now item from the Forward Future "Loop Library" assessment (milestone #161).

`prd-to-goal` already *generates* a custom `/goal` line from a spec; this adds the complementary *pre-built* recipes for the loops you run over and over. Each recipe is a loop shape wrapped around an ork worker skill, following the same convergent / falsifiable / budgeted rules as a generated line.

## What's in it

`src/skills/prd-to-goal/references/recipe-library.md` — the 8 recipes:

| Recipe | Loop-Library theme | ork worker |
|---|---|---|
| Coverage climb | 100% Test Coverage | `/ork:cover` |
| Production error sweep | Production Error Sweep | `/ork:fix-issue` |
| Docs-drift sweep | Docs Sweep | `/ork:audit-full` |
| Page-load budget | Sub-50ms Page-Load | `/ork:performance` |
| Repository cleanup | Repository Cleanup | `/ork:dream` |
| Quality streak | Quality Streak | `/ork:verify` |
| Ticket to PR-ready | Ticket-to-PR-Ready | `/ork:fix-issue` then `/ork:create-pr` |
| Type/lint zero | static-analysis baseline | fixer agent |

Plus a catalog table in `prd-to-goal/SKILL.md` (sections renumbered), the regenerated reference page, and the embedded skill-index in `product-strategist`.

Each recipe carries an **anti-gaming guardrail** — e.g. type/lint-zero blocks satisfying the loop by suppressing (`@ts-ignore`) instead of fixing; coverage keeps the full suite green in the AND so tests stay meaningful.

## Design notes

- Housed under `prd-to-goal` (no new skill) so there is **zero component-count cascade**. The recipes are the in-repo source for the `ork-loops` pack on skills.sh — interop with the same audience the Loop Library targets, not competition.
- The **Quality streak** recipe is honest about needing the native streak gate (#2540) and shows the manual approximation until that lands.

## Playground

The assessment that motivated this — orthogonality thesis, theme map, adoption decision board, and the 7.3/B scorecard — is an interactive playground at `docs/feat-loop-recipes-2539/index.html`, conforming to the playground visual standard (cool-glass decision board, pointer + keyboard + aria-live).

## Verification

- `npm run build` clean; pre-commit validations pass (component counts OK — no drift; frontmatter OK; quick lint OK).
- `tests/skills/structure/test-skill-md.sh`: 0 failed.
- Reverted unrelated ungated `docs/site/lib/generated/*.ts` churn (pre-existing main drift, e.g. a 555-line changelog-data lag); kept the gated `reference/skills/prd-to-goal.mdx`.

Part of milestone #161 (Loop autonomy). Closes #2539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
