### PR TITLE
ci(security): gate docs.yml NPM_TOKEN to push events (#2536)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,12 +91,14 @@ jobs:
       - name: Install docs dependencies
         working-directory: docs/site
         shell: bash
-        # NPM_TOKEN grants access to private @yonatan-hq GitHub Packages. On
-        # push to main/dev the token has full scope. On pull_request from
-        # other branches the secret is substituted but with reduced scope —
-        # npm ci hits 401 Unauthorized. Detect that specific failure and fall
-        # back to the local stub under docs/stubs/analytics-stub/. Production
-        # builds on main still use the real package (npm ci succeeds there).
+        # NPM_TOKEN grants access to private @yonatan-hq GitHub Packages, so it is
+        # gated to `push` events (env below, #2536) — NEVER present on a
+        # pull_request run, fork OR same-repo. Previously same-repo PRs ran
+        # PR-author code (npm ci + a postinstall) with the token live in env; that
+        # exposure is now removed. On push to main/dev the token has full scope and
+        # npm ci installs the real package; on every PR the token is '' → npm ci
+        # hits 401 Unauthorized, which we detect and fall back to the local stub
+        # under docs/stubs/analytics-stub/.
         #
         # Use PIPESTATUS to capture npm's real exit code — `npm ci | tee`
         # would otherwise return tee's exit (always 0), masking npm failures
@@ -134,7 +136,9 @@ jobs:
             exit $npm_exit
           fi
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Gated to `push` (#2536): NEVER present on a pull_request run, fork OR
+          # same-repo. On PRs this resolves to '' → npm ci hits 401 → stub fallback.
+          NPM_TOKEN: ${{ github.event_name == 'push' && secrets.NPM_TOKEN || '' }}
       - name: Build docs site
         working-directory: docs/site
         run: npm run build


### PR DESCRIPTION
## What

Gates `docs.yml`'s `NPM_TOKEN` (private `@yonatan-hq` packages) to **push events only** — dropping it from all `pull_request` runs.

```diff
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ github.event_name == 'push' && secrets.NPM_TOKEN || '' }}
```

## Why

The CI-audit residual from milestone #160. **Fork-exfil was never possible** here — `docs.yml` triggers on `pull_request` (not `_target`), so fork PRs get no secret. But on a **same-repo** PR the token was live in env while `npm ci` ran PR-author code (including a `postinstall`) — an insider / compromised-dependency surface. This removes it.

## No breakage

On PRs the token now resolves to `''` → `npm ci` hits 401 → the **existing local-stub fallback** (`docs/stubs/analytics-stub/`, already exercised by fork / other-branch PRs) handles it. `push` to `main`/`dev` keeps the real package. The comment is updated to match.

## Notes

- ⚠️ This PR's CI doesn't exercise `docs.yml` itself (that workflow triggers on `src/skills`, `src/agents`, `docs/site` paths — not on a `.github/workflows/` change). The change routes same-repo PRs through the same proven stub path forks already use; low-risk. `actionlint` confirms the workflow is clean, and the new **zizmor gate** audits it.
- No playground: `.github/`-only change on a `ci/` branch (playground gate skips by design).

Closes #2536 — **closes out milestone #160** (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
