### PR TITLE
ci(cc-watch): move release-watch cron to 06:00 IL (03:00 UTC)

### DIFF
--- a/.github/workflows/claude-release-watch.yml
+++ b/.github/workflows/claude-release-watch.yml
@@ -11,7 +11,10 @@ on:
         required: false
         default: ''
   schedule:
-    - cron: '0 14 * * *'
+    # 03:00 UTC = 06:00 Israel (IDT, UTC+3) — triage ready at the start of the IL workday.
+    # CC releases cluster in the evening UTC, so 03:00 catches them ~8-11h sooner than 14:00.
+    # GitHub cron is fixed UTC; revisit to 04:00 UTC if IL switches to standard time (UTC+2).
+    - cron: '0 3 * * *'
 
 # Serialize so two cron fires (or cron + manual) can't race on the snapshot commit.
 concurrency:


### PR DESCRIPTION
## What

Move the **Claude Release Watch** daily cron from `0 14 * * *` to `0 3 * * *`.

`03:00 UTC = 06:00 Israel` (IDT, UTC+3) — the watcher's triage now lands at the start of the IL workday.

## Why

The 14:00 UTC tick sat *before* CC's typical evening-UTC publish window, so afternoon releases waited a full cycle:

| version | published (UTC) | old 14:00 run caught it | new 03:00 run would catch it |
|---|---|---|---|
| 2.1.183 | 06-19 00:02 | same-day 14:00 (~14h) | same-day 03:00 (~3h) |
| 2.1.185 | 06-20 16:54 | next-day 14:00 (~21h) | next-day 03:00 (~10h) |
| 2.1.182 | 06-18 22:06 | next-day 14:00 (~16h) | next-day 03:00 (~5h) |

Recent CC releases cluster in the evening/night UTC, so 03:00 UTC catches them ~8-11h sooner than 14:00. (2.1.185 is what surfaced this — it published ~2h after that day's 14:46 run.)

## Scope

- One-line cron change + explanatory comments. No logic, permission, or action changes.
- `ci/`-prefixed branch: config-only, exempt from the playground gate and the version-bump pre-push check by design.
- GitHub cron is fixed UTC; the comment notes to revisit to `04:00 UTC` if IL returns to standard time (UTC+2).

## Verification

- `actionlint .github/workflows/claude-release-watch.yml` — clean.
- Pre-commit (component counts + workflow lint) — passed.
