### PR TITLE
ci(cc-triage): exclude presentational rewords from the now-<verb>s feature hint

### DIFF
--- a/scripts/cc-triage.mjs
+++ b/scripts/cc-triage.mjs
@@ -337,8 +337,17 @@ function parseSnapshotBullets(snapshotText) {
 // correctly returned [], tripping the M134 empty-array guard into a permanent
 // parse_failed loop. Active announcements ("enabled by default", "enables X")
 // still match.
+// `now \w+s` excludes pure presentational/message verbs (reads|shows|displays|
+// renders|says|prints) — "the stream-stall hint now READS 'X' instead of 'Y'"
+// (2.1.185, a one-line message reword) is not an adoptable surface, but tripped
+// `now \w+s` via "now reads" → routed to the LLM, whose correct [] hit the M134
+// empty-array guard and filed a spurious "manual triage needed" issue (#2568).
+// This denylist is incomplete on purpose: a reword using a verb NOT listed (e.g.
+// "now wraps") simply falls through to the LLM — the status-quo conservative
+// path, never a regression. Capability "now <verb>s" forms ("now ACCEPTS --scope",
+// "now CACHES results") are not presentational, so they still hint.
 const FEATURE_HINT_RE =
-  /\b(add(?:ed|s)?|new|introduc\w*|you can now|can now|now \w+s|support(?:s|ed)?|(?<!\b(?:was|is|are|were|been)\s)enabl\w*|deprecat\w*)\b/i;
+  /\b(add(?:ed|s)?|new|introduc\w*|you can now|can now|now (?!(?:reads|shows|displays|renders|says|prints)\b)\w+s|support(?:s|ed)?|(?<!\b(?:was|is|are|were|been)\s)enabl\w*|deprecat\w*)\b/i;
 
 // #2267: true when a snapshot describes no adoptable surface (no bullet matches
 // FEATURE_HINT_RE). Empty bullet list also counts as featureless.

--- a/tests/integration/test-cc-triage.sh
+++ b/tests/integration/test-cc-triage.sh
@@ -809,6 +809,47 @@ else
 fi
 
 # ============================================================================
+# Test 15c: presentational reword "now reads '<msg>' instead of '<msg>'" is NOT a
+# feature hint (the 2.1.185 trap, #2568). CC 2.1.185 shipped a single bullet — a
+# stream-stall hint message reword — that tripped FEATURE_HINT_RE via the `now
+# \w+s` branch ("now reads"), routing a featureless snapshot to the LLM; the LLM's
+# correct [] hit the M134 empty-array guard and filed a spurious "manual triage
+# needed" issue. The presentational-verb carve-out (reads|shows|displays|renders|
+# says|prints) graduates this shape deterministically, no LLM call. A capability
+# "now <verb>s" ("now accepts --scope") is not presentational and still hints.
+# ============================================================================
+cat > shared/cc-snapshots/2.1.996.md <<'EOF'
+# Claude Code 2.1.996
+
+- The stream-stall hint now reads "Waiting for API response · will retry in …" instead of "No response from API · Retrying in …", and triggers after 20s of silence instead of 10s
+EOF
+cat > shared/cc-adoption-gaps.json <<'EOF'
+[
+  { "version": "2.1.996", "parse_failed": true, "failed_at": "2026-06-21T07:39:37.234Z", "features": [], "raw_bullets_count": 1 }
+]
+EOF
+
+EXIT=0
+CLAUDE_CODE_OAUTH_TOKEN=fake-token \
+CC_TRIAGE_FIXTURE="$FIXTURE" \
+  node scripts/cc-triage.mjs > /tmp/cc-triage-out.txt 2>&1 || EXIT=$?
+
+REWORD_FL=$(jq -r '.[0].featureless' shared/cc-adoption-gaps.json)
+REWORD_PF=$(jq -r '.[0].parse_failed // false' shared/cc-adoption-gaps.json)
+if [ "$EXIT" = "0" ] && [ "$REWORD_FL" = "true" ] && [ "$REWORD_PF" = "false" ]; then
+  log_pass "#2568 15c: presentational 'now reads … instead of …' reword graduates featureless + clears stuck parse_failed"
+else
+  log_fail "#2568 15c reword hint" "expected featureless=true parse_failed=false exit=0, got featureless='$REWORD_FL' parse_failed='$REWORD_PF' exit=$EXIT"
+fi
+
+# Prove the LLM was bypassed (deterministic graduation, not an LLM round-trip).
+if grep -qF "extracting features from 2.1.996" /tmp/cc-triage-out.txt; then
+  log_fail "#2568 15c LLM bypass" "LLM was called for a presentational-reword snapshot (cat /tmp/cc-triage-out.txt)"
+else
+  log_pass "#2568 15c: reword graduates without an LLM call"
+fi
+
+# ============================================================================
 # Test 16: #2267 — a STUCK parse_failed featureless sentinel SELF-HEALS on a
 # normal run (no --retry-failed). This is the exact state of 2.1.156/159/165/167:
 # previously marked parse_failed by the empty-array overload, they must clear


### PR DESCRIPTION
## What

Harden `cc-triage.mjs`'s `FEATURE_HINT_RE` so **presentational message rewords** don't get misclassified as needing manual triage.

Closes #2568.

## Why

CC **2.1.185** shipped a single changelog bullet — a stream-stall hint reword:

> *"The stream-stall hint now reads 'Waiting for API response · will retry in …' instead of 'No response from API · Retrying in …', and triggers after 20s of silence instead of 10s"*

No adoptable surface (no tool/setting/hook/capability). But it tripped `FEATURE_HINT_RE` via the broad `now \w+s` branch (**"now reads"**), so the snapshot routed to the LLM. The LLM correctly returned `[]`, which hit the M134 empty-array guard → `parse_failed` sentinel → spurious **"manual triage needed" issue #2568**. This is a recurrence of the empty-array-overload class (#2267 / #2415).

## Fix

A presentational-verb carve-out on the `now \w+s` branch, mirroring the existing `enabl\w*` passive-voice exception precedent:

```diff
- now \w+s
+ now (?!(?:reads|shows|displays|renders|says|prints)\b)\w+s
```

**Trade-off, stated honestly:** this shifts one narrow class (display/message rewords) from "route-to-LLM → sentinel" to "graduate featureless". The denylist is **incomplete on purpose** — a reword using an unlisted verb (e.g. "now wraps") falls through to the LLM, which is the existing conservative path. So an incomplete list degrades to *status quo*, never a regression. Capability `now <verb>s` forms ("now **accepts** --scope", "now **caches** results") are not presentational and still hint.

The load-bearing invariants are untouched: the M134 empty-array→`parse_failed` guard and #2267 featureless graduation are unchanged.

## Verification

| Suite | Result |
|---|---|
| `node --check scripts/cc-triage.mjs` | OK |
| `tests/integration/test-cc-triage.sh` | **57/57** (incl. new Test 15c) |
| `tests/integration/test-cc-release-watch.sh` | 34/34 |
| `tests/integration/test-cc-release-watch-step3.sh` | 17/17 |

**Test 15c** asserts the 2.1.185 shape graduates `featureless=true`, `parse_failed` cleared, and **no LLM call** — and that the real-feature "now accepts --scope" case still hints (existing dedup test, unchanged).

## Scope

`ci/` branch — internal release-watch automation, no user-facing surface (playground gate exempt by design). One regex carve-out + one test.
