### PR TITLE
fix(counts): stamp pyproject description so component counts can't drift

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "orchestkit"
 version = "8.56.0" # x-release-please-version
-description = "OrchestKit Complete - AI-assisted development toolkit for Claude Code with 105 skills, 37 agents, and 180 hooks"
+description = "OrchestKit Complete - AI-assisted development toolkit for Claude Code with 111 skills, 37 agents, and 211 hooks"
 requires-python = ">=3.11"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/stamp-counts.sh
+++ b/scripts/stamp-counts.sh
@@ -107,6 +107,28 @@ stamp_marketplace_json() {
     "s/[0-9]+ skills, [0-9]+ agents, [0-9]+ hooks/${SKILLS} skills, ${AGENTS} agents, ${HOOKS} hooks/g" "$file"
 }
 
+# ── pyproject.toml description (count tuple, pattern-based) ──────────────────
+# sync_versions() owns the `version = "..."` line; this owns the component-count
+# tuple in the `description` string. It was the one count string no stamper
+# touched, so it silently drifted (105/180 vs actual). The build runs this, and
+# the plugins/ drift gate transitively enforces it: any count change also
+# changes plugins/, forcing a rebuild that re-stamps this. Single phrasing only.
+stamp_pyproject_description() {
+  local file="$PROJECT_ROOT/pyproject.toml"
+  if [[ ! -f "$file" ]]; then return; fi
+
+  local sed_in
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed_in=(sed -i '' -E)
+  else
+    sed_in=(sed -i -E)
+  fi
+
+  # "with N skills, M agents, and K hooks"
+  "${sed_in[@]}" \
+    "s/[0-9]+ skills, [0-9]+ agents, and [0-9]+ hooks/${SKILLS} skills, ${AGENTS} agents, and ${HOOKS} hooks/g" "$file"
+}
+
 # ── docs/site MDX (pattern-based, no markers) ───────────────────────────────
 # MDX renders HTML comments literally, so the marker approach used for
 # README/CLAUDE.md doesn't work here. Instead we replace explicit, safe
@@ -281,6 +303,23 @@ if [[ "${1:-}" == "--check" ]]; then
     rm "$TMP"
   fi
 
+  # Check pyproject.toml description count tuple
+  PYPROJECT="$PROJECT_ROOT/pyproject.toml"
+  if [[ -f "$PYPROJECT" ]]; then
+    TMP=$(mktemp)
+    cp "$PYPROJECT" "$TMP"
+    if [[ "$(uname)" == "Darwin" ]]; then
+      sed -i '' -E "s/[0-9]+ skills, [0-9]+ agents, and [0-9]+ hooks/${SKILLS} skills, ${AGENTS} agents, and ${HOOKS} hooks/g" "$TMP"
+    else
+      sed -i -E "s/[0-9]+ skills, [0-9]+ agents, and [0-9]+ hooks/${SKILLS} skills, ${AGENTS} agents, and ${HOOKS} hooks/g" "$TMP"
+    fi
+    if ! diff -q "$PYPROJECT" "$TMP" >/dev/null 2>&1; then
+      echo "STALE: $PYPROJECT"
+      STALE=1
+    fi
+    rm "$TMP"
+  fi
+
   # Check docs/site MDX
   DOCS_DIR="$PROJECT_ROOT/docs/site/content"
   if [[ -d "$DOCS_DIR" ]]; then
@@ -312,6 +351,8 @@ for file in "${MARKER_FILES[@]}"; do
 done
 
 stamp_marketplace_json
+
+stamp_pyproject_description
 
 stamp_docs_mdx
 


### PR DESCRIPTION
## What

`pyproject.toml`'s `description` advertised **105 skills, 37 agents, 180 hooks** — stale vs the actual **111 / 37 / 211**. It was the one component-count string no stamper owned: `scripts/stamp-counts.sh` synced pyproject's *version* but never its description count tuple, so it drifted silently while every other surface (CLAUDE.md, README, marketplace.json, docs MDX) stayed fresh.

## Root cause

`scripts/stamp-counts.sh` is the build-wired single source of truth for counts. Its `sync_versions()` touched `pyproject.toml` for the `version` line only. No function ever stamped the count tuple in the `description`, so it had no enforcement and drifted.

## Fix

- `scripts/stamp-counts.sh`: add `stamp_pyproject_description()`, wired into both **stamp** mode and **--check** mode.
- `pyproject.toml`: `105/180` to `111/211` (current canonical counts).

Enforcement is transitive and needs no new CI job: any count change also changes `plugins/`, and the existing build-drift gate (`ci.yml`) forces a rebuild that re-runs the stamper. This string can no longer go stale.

## Verification

| Check | Result |
|---|---|
| `stamp-counts.sh --check` | passes; now flags pyproject drift (regression-proven) |
| `bin/validate-counts.sh` | exit 0 — all counts + versions match |
| `test-sync-versions` Test 1 | 6/6 — `sync_versions` unaffected |
| shellcheck (added lines) | clean |

This is a `ci/` branch: build tooling + package metadata only, no user-facing surface, so the playground gate is N/A by design.
