### PR TITLE
feat(doctor): add auto-memory MEMORY.md index budget check

### DIFF
--- a/docs/site/content/docs/reference/skills/doctor.mdx
+++ b/docs/site/content/docs/reference/skills/doctor.mdx
@@ -116,7 +116,7 @@ The `/ork:doctor` command performs comprehensive health checks on your OrchestKi
 
 | Category | What It Checks | Reference |
 |----------|---------------|-----------|
-| **4. Memory** | .claude/memory/ exists, decisions.jsonl integrity, queue depth | load `$\{CLAUDE_SKILL_DIR\}/references/memory-health.md` |
+| **4. Memory** | .claude/memory/ graph integrity + queue depth; **auto-memory MEMORY.md index budget (≤24.4 KB; warns + recommends /ork:dream on re-bloat)** | load `$\{CLAUDE_SKILL_DIR\}/references/memory-health.md` |
 | **5. Build** | plugins/ sync with src/, manifest counts, orphans | load `$\{CLAUDE_SKILL_DIR\}/rules/diagnostic-checks.md` |
 
 ### Categories 6-9: Infrastructure
@@ -1229,6 +1229,43 @@ done < .claude/memory/decisions.jsonl
 - **Corrupt lines**: One or more JSONL lines fail to parse
 - **High queue depth**: >50 pending graph operations (sync backlog)
 - **Missing directory**: Graph memory never initialized
+
+## Auto-Memory Index Budget
+
+Separate from the graph store above: the harness injects a per-project
+**auto-memory index** (`MEMORY.md`) into context every session. If its index
+lines grow unbounded it both wastes tokens and — because it changes when
+memories are written — busts the prompt cache. CC ships a generic over-budget
+warning; this check makes it actionable by pointing at the fix (`/ork:dream`).
+
+The index lives under `~/.claude/projects/&lt;encoded-cwd&gt;/memory/MEMORY.md`
+(the harness encodes the project path by replacing `/` with `-`).
+
+```bash
+# Auto-memory index budget check
+MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory"
+MEM_INDEX="$MEM_DIR/MEMORY.md"
+BUDGET=24986   # 24.4 KB — the harness's index budget
+
+if [ -f "$MEM_INDEX" ]; then
+  bytes=$(wc -c < "$MEM_INDEX" | tr -d ' ')
+  # index lines over ~200 chars are the usual re-bloat cause
+  long=$(awk 'length > 200 && /^- \[/' "$MEM_INDEX" | wc -l | tr -d ' ')
+  if [ "$bytes" -gt "$BUDGET" ]; then
+    echo "WARN: MEMORY.md index ${bytes}B > ${BUDGET}B budget — run /ork:dream to consolidate"
+  elif [ "$long" -gt 0 ]; then
+    echo "WARN: ${long} index line(s) > 200 chars — run /ork:dream (re-bloat risk)"
+  else
+    echo "OK: MEMORY.md index within budget (${bytes}B)"
+  fi
+fi
+```
+
+### Health Indicators
+
+- Index size ≤ 24.4 KB (the harness budget)
+- Every index line ≤ ~200 chars (detail belongs in the linked topic file, not the index)
+- Fix for both: `/ork:dream` rebuilds the index, capping line length and pruning stale entries
 
 ## Troubleshooting
 

--- a/plugins/ork/commands/doctor.md
+++ b/plugins/ork/commands/doctor.md
@@ -109,7 +109,7 @@ The `/ork:doctor` command performs comprehensive health checks on your OrchestKi
 
 | Category | What It Checks | Reference |
 |----------|---------------|-----------|
-| **4. Memory** | .claude/memory/ exists, decisions.jsonl integrity, queue depth | load `${CLAUDE_SKILL_DIR}/references/memory-health.md` |
+| **4. Memory** | .claude/memory/ graph integrity + queue depth; **auto-memory MEMORY.md index budget (≤24.4 KB; warns + recommends /ork:dream on re-bloat)** | load `${CLAUDE_SKILL_DIR}/references/memory-health.md` |
 | **5. Build** | plugins/ sync with src/, manifest counts, orphans | load `${CLAUDE_SKILL_DIR}/rules/diagnostic-checks.md` |
 
 ### Categories 6-9: Infrastructure

--- a/plugins/ork/skills/doctor/SKILL.md
+++ b/plugins/ork/skills/doctor/SKILL.md
@@ -134,7 +134,7 @@ The `/ork:doctor` command performs comprehensive health checks on your OrchestKi
 
 | Category | What It Checks | Reference |
 |----------|---------------|-----------|
-| **4. Memory** | .claude/memory/ exists, decisions.jsonl integrity, queue depth | load `${CLAUDE_SKILL_DIR}/references/memory-health.md` |
+| **4. Memory** | .claude/memory/ graph integrity + queue depth; **auto-memory MEMORY.md index budget (≤24.4 KB; warns + recommends /ork:dream on re-bloat)** | load `${CLAUDE_SKILL_DIR}/references/memory-health.md` |
 | **5. Build** | plugins/ sync with src/, manifest counts, orphans | load `${CLAUDE_SKILL_DIR}/rules/diagnostic-checks.md` |
 
 ### Categories 6-9: Infrastructure

--- a/plugins/ork/skills/doctor/references/memory-health.md
+++ b/plugins/ork/skills/doctor/references/memory-health.md
@@ -66,6 +66,43 @@ done < .claude/memory/decisions.jsonl
 - **High queue depth**: >50 pending graph operations (sync backlog)
 - **Missing directory**: Graph memory never initialized
 
+## Auto-Memory Index Budget
+
+Separate from the graph store above: the harness injects a per-project
+**auto-memory index** (`MEMORY.md`) into context every session. If its index
+lines grow unbounded it both wastes tokens and — because it changes when
+memories are written — busts the prompt cache. CC ships a generic over-budget
+warning; this check makes it actionable by pointing at the fix (`/ork:dream`).
+
+The index lives under `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md`
+(the harness encodes the project path by replacing `/` with `-`).
+
+```bash
+# Auto-memory index budget check
+MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory"
+MEM_INDEX="$MEM_DIR/MEMORY.md"
+BUDGET=24986   # 24.4 KB — the harness's index budget
+
+if [ -f "$MEM_INDEX" ]; then
+  bytes=$(wc -c < "$MEM_INDEX" | tr -d ' ')
+  # index lines over ~200 chars are the usual re-bloat cause
+  long=$(awk 'length > 200 && /^- \[/' "$MEM_INDEX" | wc -l | tr -d ' ')
+  if [ "$bytes" -gt "$BUDGET" ]; then
+    echo "WARN: MEMORY.md index ${bytes}B > ${BUDGET}B budget — run /ork:dream to consolidate"
+  elif [ "$long" -gt 0 ]; then
+    echo "WARN: ${long} index line(s) > 200 chars — run /ork:dream (re-bloat risk)"
+  else
+    echo "OK: MEMORY.md index within budget (${bytes}B)"
+  fi
+fi
+```
+
+### Health Indicators
+
+- Index size ≤ 24.4 KB (the harness budget)
+- Every index line ≤ ~200 chars (detail belongs in the linked topic file, not the index)
+- Fix for both: `/ork:dream` rebuilds the index, capping line length and pruning stale entries
+
 ## Troubleshooting
 
 ### Graph memory missing

--- a/src/skills/doctor/SKILL.md
+++ b/src/skills/doctor/SKILL.md
@@ -134,7 +134,7 @@ The `/ork:doctor` command performs comprehensive health checks on your OrchestKi
 
 | Category | What It Checks | Reference |
 |----------|---------------|-----------|
-| **4. Memory** | .claude/memory/ exists, decisions.jsonl integrity, queue depth | load `${CLAUDE_SKILL_DIR}/references/memory-health.md` |
+| **4. Memory** | .claude/memory/ graph integrity + queue depth; **auto-memory MEMORY.md index budget (≤24.4 KB; warns + recommends /ork:dream on re-bloat)** | load `${CLAUDE_SKILL_DIR}/references/memory-health.md` |
 | **5. Build** | plugins/ sync with src/, manifest counts, orphans | load `${CLAUDE_SKILL_DIR}/rules/diagnostic-checks.md` |
 
 ### Categories 6-9: Infrastructure

--- a/src/skills/doctor/references/memory-health.md
+++ b/src/skills/doctor/references/memory-health.md
@@ -66,6 +66,43 @@ done < .claude/memory/decisions.jsonl
 - **High queue depth**: >50 pending graph operations (sync backlog)
 - **Missing directory**: Graph memory never initialized
 
+## Auto-Memory Index Budget
+
+Separate from the graph store above: the harness injects a per-project
+**auto-memory index** (`MEMORY.md`) into context every session. If its index
+lines grow unbounded it both wastes tokens and — because it changes when
+memories are written — busts the prompt cache. CC ships a generic over-budget
+warning; this check makes it actionable by pointing at the fix (`/ork:dream`).
+
+The index lives under `~/.claude/projects/<encoded-cwd>/memory/MEMORY.md`
+(the harness encodes the project path by replacing `/` with `-`).
+
+```bash
+# Auto-memory index budget check
+MEM_DIR="$HOME/.claude/projects/$(echo "$PWD" | sed 's|/|-|g')/memory"
+MEM_INDEX="$MEM_DIR/MEMORY.md"
+BUDGET=24986   # 24.4 KB — the harness's index budget
+
+if [ -f "$MEM_INDEX" ]; then
+  bytes=$(wc -c < "$MEM_INDEX" | tr -d ' ')
+  # index lines over ~200 chars are the usual re-bloat cause
+  long=$(awk 'length > 200 && /^- \[/' "$MEM_INDEX" | wc -l | tr -d ' ')
+  if [ "$bytes" -gt "$BUDGET" ]; then
+    echo "WARN: MEMORY.md index ${bytes}B > ${BUDGET}B budget — run /ork:dream to consolidate"
+  elif [ "$long" -gt 0 ]; then
+    echo "WARN: ${long} index line(s) > 200 chars — run /ork:dream (re-bloat risk)"
+  else
+    echo "OK: MEMORY.md index within budget (${bytes}B)"
+  fi
+fi
+```
+
+### Health Indicators
+
+- Index size ≤ 24.4 KB (the harness budget)
+- Every index line ≤ ~200 chars (detail belongs in the linked topic file, not the index)
+- Fix for both: `/ork:dream` rebuilds the index, capping line length and pruning stale entries
+
 ## Troubleshooting
 
 ### Graph memory missing


### PR DESCRIPTION
## What

Add an **auto-memory index budget** check to `ork:doctor` Category 4 (Memory).

## Why

Doctor's memory check only validated the `.claude/memory/` graph store. The harness *also* injects a per-project auto-memory index — `~/.claude/projects/<cwd>/memory/MEMORY.md` — into context every session. When its index lines grow unbounded it wastes tokens **and**, because it changes when memories are written, **busts the prompt cache** (the expensive failure mode — cache stability, not raw size).

This is the systematic gate that was missing: it makes CC's generic over-budget warning actionable by pointing at the fix.

## How

A read-only check in the doctor skill:
- warns when `MEMORY.md` > 24.4 KB, or any index line > 200 chars
- recommends `/ork:dream` (which rebuilds the index, capping line length + pruning)

**On-demand only** (it's the doctor skill, not a hook): $0 idle, no new hook, **no count cascade**. `test:skills` green.

`ci/` branch: skill + docs only, no user-facing surface — playground gate N/A.
