### PR TITLE
ci(release): exclude docs/ from plugin version bumps

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -14,6 +14,7 @@
   "bootstrap-sha": "c5fbeca5028a6cb309cef3bb1f2d6cc7c2f2ddfa",
   "packages": {
     ".": {
+      "exclude-paths": ["docs"],
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Summary

Stops **docs-only changes from bumping the installed-plugin version**. `docs/` is entirely the marketing website (`docs/site/`, Vercel-deployed) + per-branch PR playgrounds + repo docs — **none of it ships in the plugin** (the build copies nothing from `docs/`). But release-please bumps on commit **type**, not **scope**, so `feat(site):` #2681 (orank docs-site fixes) cut a **phantom v8.64.0 with zero plugin changes**.

Fix: add `"exclude-paths": ["docs"]` to the `.` package — a commit whose files are **all** under `docs/` no longer counts toward a release.

## Why `["docs"]`, not `["docs/site"]`

`docs/site` alone wouldn't fix it: #2681's commit also added a playground under `docs/<slug>/` (not `docs/site`), so it wouldn't be "all-excluded." `["docs"]` covers the website + playgrounds + repo docs — the whole non-plugin tree.

## Verification (simulated release-please exclude logic on commits since v8.63.1)

```
abdac493 feat(site) #2681 → SKIPPED  (all 11 files under docs/ — the commit that caused 8.64.0)
754c986b chore       #2686 → counted, but chore → no bump
→ no bumping commit remains since v8.63.1
```

- Config still valid JSON; `exclude-paths` is a schema-confirmed per-package key (release-please v5 action).
- Plugin paths (`src/ plugins/ shared/ manifests/ .claude-plugin/`) are **not** under `docs/` → still bump normally.
- Risk is bounded: `exclude-paths` can only *prevent* a bump, never break the pipeline.

## Effect on the pending release

After this merges, release-please re-evaluates main and finds nothing to release since v8.63.1 → **the phantom `chore(main): release 8.64.0` PR (#2682) closes**. The orank docs-site work keeps its Vercel deploy; it just won't inflate the version users install.

Branch uses the `ci/` lane (config-only, no user-facing surface → playground-gate exempt by design).
