### PR TITLE
test(hooks): hermetic session-title tests + deps preflight

### DIFF
--- a/plugins/ork/hooks/package.json
+++ b/plugins/ork/hooks/package.json
@@ -20,7 +20,9 @@
     "lint:biome": "biome check src/",
     "lint:biome:fix": "biome check --write src/",
     "clean": "rm -rf dist coverage",
-    "validate": "node scripts/validate-registry.mjs"
+    "validate": "node scripts/validate-registry.mjs",
+    "prebuild": "node scripts/preflight-deps.mjs",
+    "pretest": "node scripts/preflight-deps.mjs"
   },
   "engines": {
     "node": ">=22.5.0"

--- a/plugins/ork/hooks/scripts/preflight-deps.mjs
+++ b/plugins/ork/hooks/scripts/preflight-deps.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * preflight-deps.mjs — friendly guard for the direct hooks build/test path.
+ *
+ * src/hooks is NOT a root npm workspace (workspaces = packages/*), and its
+ * node_modules is gitignored (#2645 — a tracked symlink broke 8.60.0). CI
+ * installs these deps via the checkout action (install-hooks-deps: true, #2003),
+ * and the root `npm run build` degrades gracefully (build-plugins.sh skips the
+ * hooks rebuild and ships the tracked dist). But a contributor running
+ * `cd src/hooks && npm run build` (or `npm test`) on a fresh clone would
+ * otherwise hit a raw `Cannot find package 'esbuild'` stack trace with no hint.
+ *
+ * This prints the one-line fix and exits non-zero before that happens.
+ */
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const hooksRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+// esbuild (build) and vitest (test) both live under the same node_modules.
+const sentinels = ['esbuild', 'vitest'];
+const missing = sentinels.filter((p) => !existsSync(join(hooksRoot, 'node_modules', p)));
+
+if (missing.length > 0) {
+  process.stderr.write(
+    `\n✗ src/hooks dependencies are missing (${missing.join(', ')}).\n` +
+      `  src/hooks is not a root workspace — install its deps directly:\n\n` +
+      `    cd src/hooks && npm ci\n\n` +
+      `  (CI does this automatically; the root \`npm run build\` skips the hooks\n` +
+      `   rebuild and ships the committed dist when these are absent.)\n\n`,
+  );
+  process.exit(1);
+}

--- a/src/hooks/package.json
+++ b/src/hooks/package.json
@@ -20,7 +20,9 @@
     "lint:biome": "biome check src/",
     "lint:biome:fix": "biome check --write src/",
     "clean": "rm -rf dist coverage",
-    "validate": "node scripts/validate-registry.mjs"
+    "validate": "node scripts/validate-registry.mjs",
+    "prebuild": "node scripts/preflight-deps.mjs",
+    "pretest": "node scripts/preflight-deps.mjs"
   },
   "engines": {
     "node": ">=22.5.0"

--- a/src/hooks/scripts/preflight-deps.mjs
+++ b/src/hooks/scripts/preflight-deps.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/**
+ * preflight-deps.mjs — friendly guard for the direct hooks build/test path.
+ *
+ * src/hooks is NOT a root npm workspace (workspaces = packages/*), and its
+ * node_modules is gitignored (#2645 — a tracked symlink broke 8.60.0). CI
+ * installs these deps via the checkout action (install-hooks-deps: true, #2003),
+ * and the root `npm run build` degrades gracefully (build-plugins.sh skips the
+ * hooks rebuild and ships the tracked dist). But a contributor running
+ * `cd src/hooks && npm run build` (or `npm test`) on a fresh clone would
+ * otherwise hit a raw `Cannot find package 'esbuild'` stack trace with no hint.
+ *
+ * This prints the one-line fix and exits non-zero before that happens.
+ */
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const hooksRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+// esbuild (build) and vitest (test) both live under the same node_modules.
+const sentinels = ['esbuild', 'vitest'];
+const missing = sentinels.filter((p) => !existsSync(join(hooksRoot, 'node_modules', p)));
+
+if (missing.length > 0) {
+  process.stderr.write(
+    `\n✗ src/hooks dependencies are missing (${missing.join(', ')}).\n` +
+      `  src/hooks is not a root workspace — install its deps directly:\n\n` +
+      `    cd src/hooks && npm ci\n\n` +
+      `  (CI does this automatically; the root \`npm run build\` skips the hooks\n` +
+      `   rebuild and ships the committed dist when these are absent.)\n\n`,
+  );
+  process.exit(1);
+}

--- a/src/hooks/src/__tests__/integration/session-title-bundle.test.ts
+++ b/src/hooks/src/__tests__/integration/session-title-bundle.test.ts
@@ -30,8 +30,18 @@ describe('integration — sessionTitle delta-detect (built bundle)', () => {
   let dispatch: DispatchFn;
   let tmpProj: string;
   const sessionId = 'integration-smoke-001';
+  // The title's effort suffix derives from process.env.CLAUDE_EFFORT (via the
+  // bundled effort-detector). An ambient `CLAUDE_EFFORT=low` in a dev shell
+  // would append ` · low` and break the 'feature-auth' assertions — CI runs it
+  // unset. Neutralize for hermeticity; restore afterward.
+  const savedEnv = {
+    CLAUDE_EFFORT: process.env.CLAUDE_EFFORT,
+    CLAUDE_MODEL: process.env.CLAUDE_MODEL,
+  };
 
   beforeEach(async () => {
+    delete process.env.CLAUDE_EFFORT;
+    delete process.env.CLAUDE_MODEL;
     if (!existsSync(BUNDLE)) {
       throw new Error(
         `Built bundle missing at ${BUNDLE}. Run \`npm run build\` in src/hooks/ first.`,
@@ -51,6 +61,10 @@ describe('integration — sessionTitle delta-detect (built bundle)', () => {
 
   afterEach(() => {
     if (tmpProj) rmSync(tmpProj, { recursive: true, force: true });
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
   });
 
   function input(prompt: string) {

--- a/src/hooks/src/__tests__/prompt/session-title.test.ts
+++ b/src/hooks/src/__tests__/prompt/session-title.test.ts
@@ -13,7 +13,7 @@
  * - Empty branch → no title → falls back to outputSilentSuccess/outputPromptContext
  */
 
-import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mockCommonReal } from '../fixtures/mock-common.js';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
@@ -50,6 +50,26 @@ function createPromptInput(prompt: string, overrides: Partial<HookInput> = {}): 
     ...overrides,
   };
 }
+
+// Hermetic env — the session-title effort suffix comes from detectEffortLevel(),
+// which falls back to process.env.CLAUDE_EFFORT. An ambient `CLAUDE_EFFORT=low`
+// in a dev shell appends a ` · low` suffix and breaks the title assertions
+// (CI runs with it unset, so this only bit locally). Neutralize effort/model
+// env for every test in this file; restore afterward.
+const SAVED_TITLE_ENV = {
+  CLAUDE_EFFORT: process.env.CLAUDE_EFFORT,
+  CLAUDE_MODEL: process.env.CLAUDE_MODEL,
+};
+beforeEach(() => {
+  delete process.env.CLAUDE_EFFORT;
+  delete process.env.CLAUDE_MODEL;
+});
+afterEach(() => {
+  for (const [k, v] of Object.entries(SAVED_TITLE_ENV)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+});
 
 describe('lib/output — outputPromptContextWithTitle (CC 2.1.94)', () => {
   test('sets both additionalContext and sessionTitle when ctx + title provided', () => {


### PR DESCRIPTION
## Summary

Two dev-friction fixes surfaced by the Sonnet 5 / CC 2.1.197 `/ork:assess` pass.

### ① session-title tests weren't hermetic (14 local failures)
The session title's effort suffix comes from `detectEffortLevel()`, which falls back to `process.env.CLAUDE_EFFORT`. A dev shell with `CLAUDE_EFFORT=low` exported appended ` · low` to titles and failed 14 assertions like `expected 'feature-auth · low' to be 'feature-auth'`. CI runs with it unset, so **main was always green — the failures only bit locally**, quietly eroding trust in `npm test`.

Fix: both `session-title.test.ts` and `session-title-bundle.test.ts` now save → clear → restore `CLAUDE_EFFORT` (and `CLAUDE_MODEL`) around every test. Verified: full hook suite **8869 passed** with `CLAUDE_EFFORT=low` still exported.

### ② raw esbuild crash on the direct hooks-build path
`src/hooks` is not a root workspace and its `node_modules` is gitignored (#2645). CI installs its deps (#2003) and the root `npm run build` degrades gracefully (skips the hooks rebuild, ships tracked `dist`). But `cd src/hooks && npm run build|test` on a fresh clone hit a raw `Cannot find package 'esbuild'` with no guidance — the exact wall I hit this session after the #2709 merge removed the old `node_modules` symlink.

Fix: `scripts/preflight-deps.mjs` wired to `prebuild` + `pretest` prints the one-line fix (`cd src/hooks && npm ci`) and exits non-zero. No-op when deps are present (verified both paths).

### Verification
- 8869 hook tests pass (with `CLAUDE_EFFORT=low` set) · Biome clean · `tsconfig.test.json` typecheck clean · hooks + plugin build clean.
- `src/hooks/package.json` is not the root-governed path, so the Release-Please guard doesn't fire (and #2711's merge-base fix is already in).

ci/ branch → workflow/test tooling, no playground required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)