### PR TITLE
fix(git-hooks): pre-push mirrors dependabot/release-please skip

### DIFF
--- a/bin/git-hooks/pre-push
+++ b/bin/git-hooks/pre-push
@@ -25,6 +25,18 @@ if [[ "$BRANCH" =~ ^(docs|chore|ci|style|test|feat|fix|perf|refactor|issue|bug)/
   exit 0
 fi
 
+# Skip release-please PRs (automated versioning) — mirrors version-check.yml L67-72
+if [[ "$BRANCH" =~ ^release-please ]]; then
+  echo "  ✓ Skipping version check for release-please PR (automated)"
+  exit 0
+fi
+
+# Skip Dependabot PRs (dependency updates, no version bump needed) — mirrors version-check.yml L74-79
+if [[ "$BRANCH" =~ ^dependabot/ ]]; then
+  echo "  ✓ Skipping version check for Dependabot PR (automated dependency update)"
+  exit 0
+fi
+
 # ===== Check if only non-code files changed =====
 CHANGED_FILES=$(git diff --name-only origin/main...HEAD 2>/dev/null || git diff --name-only HEAD~1...HEAD)
 CODE_CHANGES=$(echo "$CHANGED_FILES" | grep -vE '\.(md|txt)$|^docs/' || true)


### PR DESCRIPTION
## What

`bin/git-hooks/pre-push` is documented as mirroring `.github/workflows/version-check.yml`, but was missing two skip blocks that CI's real check already has (`^release-please`, `^dependabot/` branch prefixes) — the CI-side comment even says "Must stay in lock-step with bin/git-hooks/pre-push L23", and it had drifted.

## Why

Discovered live: rebasing a dependabot demos-tree dependency PR (package.json + package-lock.json only) failed the local version-bump check, even though the identical diff already passes the equivalent CI check. The local hook was blocking a push that CI itself would accept.

## Verification

Diff mirrors version-check.yml L67-79 exactly. No user-facing surface (a 12-line git-hook branch-skip regex) — the PR Playground check is expected to show non-required-red for this PR; nothing to demo.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>