### PR TITLE
fix(docs): heal stale CC floor + fact rot, add docs-facts freshness gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -71,6 +71,8 @@ jobs:
             echo "$errors MDX files missing frontmatter"
             exit 1
           fi
+      - name: Check docs facts (CC floor + component counts)
+        run: node scripts/check-docs-facts.mjs
 
   build:
     name: Docs Site Build

--- a/docs/feat--docs-freshness/index.html
+++ b/docs/feat--docs-freshness/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Docs Freshness Pipeline — feat/docs-freshness playground</title>
+<style>
+  :root {
+    --bg: #0d1117; --panel: #161b22; --border: #30363d;
+    --text: #e6edf3; --muted: #8b949e;
+    --green: #3fb950; --red: #f85149; --yellow: #d29922; --blue: #58a6ff; --purple: #bc8cff;
+    font-size: 16px;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg); color: var(--text);
+    font-family: ui-sans-serif, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.55; padding: 2.5rem 1.25rem 4rem; max-width: 1080px; margin: 0 auto;
+  }
+  code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+  h1 { font-size: 1.7rem; margin-bottom: .4rem; }
+  h2 { font-size: 1.15rem; margin: 2.2rem 0 .8rem; color: var(--blue); }
+  .sub { color: var(--muted); margin-bottom: 1.6rem; }
+  .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+  .card { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 1rem 1.1rem; }
+  .stat { font-size: 1.9rem; font-weight: 700; }
+  .stat.green { color: var(--green); } .stat.red { color: var(--red); }
+  .stat.yellow { color: var(--yellow); } .stat.purple { color: var(--purple); }
+  .label { color: var(--muted); font-size: .82rem; text-transform: uppercase; letter-spacing: .06em; }
+  .toggle { display: inline-flex; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; margin-bottom: 1rem; }
+  .toggle button {
+    background: var(--panel); color: var(--muted); border: 0; padding: .5rem 1.1rem;
+    font-size: .9rem; cursor: pointer;
+  }
+  .toggle button.active { background: var(--blue); color: #0d1117; font-weight: 600; }
+  table { width: 100%; border-collapse: collapse; font-size: .9rem; }
+  th, td { text-align: left; padding: .5rem .65rem; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { color: var(--muted); font-weight: 600; }
+  .ok { color: var(--green); font-weight: 600; }
+  .bad { color: var(--red); font-weight: 600; }
+  .warn { color: var(--yellow); font-weight: 600; }
+  pre {
+    background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
+    padding: 1rem; overflow-x: auto; font-size: .82rem;
+  }
+  .lane { display: grid; grid-template-columns: 160px 1fr; gap: .6rem .9rem; align-items: start; margin: .35rem 0; }
+  .lane .name { color: var(--muted); font-size: .85rem; padding-top: .15rem; }
+  .bar { border-radius: 6px; padding: .35rem .6rem; font-size: .82rem; border: 1px solid var(--border); }
+  .bar.covered { background: rgba(63,185,80,.12); border-color: rgba(63,185,80,.5); }
+  .bar.naked { background: rgba(248,81,73,.12); border-color: rgba(248,81,73,.5); }
+  .pill { display: inline-block; border-radius: 999px; padding: .05rem .55rem; font-size: .75rem; margin-left: .4rem; }
+  .pill.new { background: rgba(188,140,255,.15); color: var(--purple); border: 1px solid rgba(188,140,255,.5); }
+  footer { margin-top: 3rem; color: var(--muted); font-size: .8rem; }
+</style>
+</head>
+<body>
+  <h1>📚 Docs Freshness Pipeline</h1>
+  <p class="sub">Playground for <code>feat/docs-freshness</code> — why hand-written docs facts rotted, what was actually stale (and what wasn't), and the three layers that now keep them honest.</p>
+
+  <div class="grid">
+    <div class="card"><div class="stat red">7</div><div class="label">stale CC-floor instances fixed (2.1.148 → 2.1.183)</div></div>
+    <div class="card"><div class="stat yellow">10+</div><div class="label">111-era &amp; derived-count strings refreshed</div></div>
+    <div class="card"><div class="stat purple">12</div><div class="label">pages now render facts via &lt;Count/&gt; / &lt;MinCC/&gt;</div></div>
+    <div class="card"><div class="stat green">1</div><div class="label">new CI gate: check-docs-facts.mjs</div></div>
+  </div>
+
+  <h2>Coverage: before → after</h2>
+  <div class="toggle" role="tablist">
+    <button id="btn-before" class="active" onclick="show('before')">Before</button>
+    <button id="btn-after" onclick="show('after')">After</button>
+  </div>
+
+  <div id="view-before">
+    <div class="lane"><div class="name">Generated pages<br>(reference/, by-category/)</div><div class="bar covered">✅ regenerated every <code>npm run build</code> + CI drift gate diffs them</div></div>
+    <div class="lane"><div class="name">CLAUDE.md / README floor</div><div class="bar covered">✅ stamped by <code>stamp-cc-support.mjs</code></div></div>
+    <div class="lane"><div class="name">Hand-written MDX facts<br>(floors, counts)</div><div class="bar naked">❌ nothing — literals rot silently (floor missed the 2026-06-20 bump for 10+ days)</div></div>
+  </div>
+
+  <div id="view-after" style="display:none">
+    <div class="lane"><div class="name">Generated pages</div><div class="bar covered">✅ unchanged — build + drift gate</div></div>
+    <div class="lane"><div class="name">Hand-written prose</div><div class="bar covered">✅ <code>&lt;Count k="skills|commands|references|agents|hooks"/&gt;</code> + <code>&lt;MinCC/&gt;</code> render from generated data — rot impossible<span class="pill new">new</span></div></div>
+    <div class="lane"><div class="name">Code blocks</div><div class="bar covered">✅ can't interpolate → stamped by <code>stamp-cc-support.mjs</code> docs target<span class="pill new">new</span></div></div>
+    <div class="lane"><div class="name">Frontmatter + leftovers</div><div class="bar covered">✅ <code>check-docs-facts.mjs</code> CI gate: floor-claim shapes + "N skills, M agents[, K hooks]" triples vs computed truth<span class="pill new">new</span></div></div>
+  </div>
+
+  <h2>The counting trap 🪤</h2>
+  <p class="sub" style="margin-bottom:.8rem">Four independent auditors (assessor, two blind refuters, the auto-router) all "verified" the docs counts as stale — using the same wrong method.</p>
+  <table>
+    <thead><tr><th>Method</th><th>Result</th><th>Verdict</th></tr></thead>
+    <tbody>
+      <tr><td><code>ls src/skills | wc -l</code></td><td>114</td><td class="bad">wrong — includes shared/ (no SKILL.md)</td></tr>
+      <tr><td><code>ls src/agents/*.md | wc -l</code></td><td>38</td><td class="bad">wrong — includes README.md</td></tr>
+      <tr><td>SKILL.md files / agent files with <code>name:</code></td><td>113 / 37</td><td class="ok">matches manifest + shared-data.ts TOTALS</td></tr>
+    </tbody>
+  </table>
+  <p class="sub" style="margin-top:.8rem">Lesson: agent independence ≠ method diversity. The gate now encodes the generator's semantics, not raw filesystem counts.</p>
+
+  <h2>What was actually stale</h2>
+  <table>
+    <thead><tr><th>Claim</th><th>Where</th><th>Status</th></tr></thead>
+    <tbody>
+      <tr><td>Claude Code floor 2.1.148</td><td>installation, FAQ, release-channels, troubleshooting, cookbook</td><td class="bad">stale — and security-relevant (skipped range includes the 2.1.163 Bash $HOME secrets-read fix)</td></tr>
+      <tr><td>"111 skills" era strings</td><td>faq, skills-agents-hooks, writing-skills, doctor refs, skill-fitness.mjs</td><td class="bad">stale (two releases of sweeps missed them)</td></tr>
+      <tr><td>"27 user-invocable / 22 listed / 47 hidden"</td><td>skills/overview</td><td class="bad">stale → 32 / 23 / 48</td></tr>
+      <tr><td>"113 skills, 37 agents, 212 hooks"</td><td>~12 pages</td><td class="ok">current — manually swept 2026-06-24 (#2645)</td></tr>
+      <tr><td>"81 reference skills"</td><td>reference-skills</td><td class="ok">current — flagged as stale by the first audit pass, refuted on verification</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Gate contract</h2>
+  <pre>node scripts/check-docs-facts.mjs
+# floor claims:  />= 2.x.x/, /Claude Code 2.x.x or later/, /below 2.x.x/  → must equal shared/cc-support.json supported_floor
+# count triples: /(\d+) skills, (\d+) agents[, (\d+) hooks]/               → must equal computed 113 / 37 / 212
+# scope:   docs/site/content/docs/**/*.mdx  minus generated (reference/, skills/by-category/)
+# escape:  line containing "docs-facts-ignore"
+check-docs-facts: OK (floor 2.1.183, 113 skills, 37 agents, 212 hooks)</pre>
+
+  <footer>feat/docs-freshness · OrchestKit v8.63.2 · 2026-07-02 · assessment artifacts in .claude/chain/ (rev 2: PASS 6.09/C)</footer>
+
+<script>
+function show(which) {
+  document.getElementById('view-before').style.display = which === 'before' ? '' : 'none';
+  document.getElementById('view-after').style.display = which === 'after' ? '' : 'none';
+  document.getElementById('btn-before').classList.toggle('active', which === 'before');
+  document.getElementById('btn-after').classList.toggle('active', which === 'after');
+}
+</script>
+</body>
+</html>

--- a/docs/site/components/count.tsx
+++ b/docs/site/components/count.tsx
@@ -1,4 +1,4 @@
-import { TOTALS } from "@/lib/generated/shared-data";
+import { MIN_CC_VERSION, TOTALS } from "@/lib/generated/shared-data";
 import { PLUGINS } from "@/lib/generated/plugins-data";
 
 const counts: Record<string, number> = {
@@ -12,4 +12,8 @@ const counts: Record<string, number> = {
 
 export function Count({ k }: { k: keyof typeof counts }) {
   return <>{counts[k]}</>;
+}
+
+export function MinCC() {
+  return <>{MIN_CC_VERSION}</>;
 }

--- a/docs/site/content/docs/cookbook/claude-design-handoff.mdx
+++ b/docs/site/content/docs/cookbook/claude-design-handoff.mdx
@@ -5,6 +5,7 @@ description: Turn a claude.ai/design handoff bundle into a reviewable GitHub PR 
 
 import { Callout } from 'fumadocs-ui/components/callout';
 import { Files, Folder, File } from 'fumadocs-ui/components/files';
+import { MinCC } from '@/components/count';
 
 [Claude Design](https://claude.ai/design) generates prototypes, mockups, slides, and one-pagers from natural-language prompts. Once a design is ready to build, it ships a **handoff bundle** that Claude Code can consume directly. OrchestKit's `/ork:design-ship` workflow turns that bundle into a reviewable pull request — with components scaffolded against your existing codebase, Storybook stories generated, browser verification run, and a PR opened with screenshots embedded.
 
@@ -32,7 +33,7 @@ Claude Design is in research preview. The handoff bundle schema is provisional �
 ## Prerequisites
 
 1. **Connect your repo to Claude Design** — in claude.ai/design, link the GitHub repo so Claude reads your design tokens, Tailwind config, and existing components. Generated visuals will then stay on-brand automatically.
-2. **OrchestKit installed** — `ork` plugin enabled in Claude Code 2.1.148 or later.
+2. **OrchestKit installed** — `ork` plugin enabled in Claude Code <MinCC /> or later.
 3. **`gh` CLI authenticated** — required for the PR-opening step.
 
 ---

--- a/docs/site/content/docs/foundations/choosing-a-plugin.mdx
+++ b/docs/site/content/docs/foundations/choosing-a-plugin.mdx
@@ -3,6 +3,8 @@ title: Plugin Architecture
 description: "OrchestKit ships as one unified plugin — everything loads on-demand with zero overhead."
 ---
 
+import { Count } from '@/components/count';
+
 ## One Plugin, Everything Included
 
 OrchestKit ships as a single plugin: **ork**.
@@ -11,7 +13,7 @@ OrchestKit ships as a single plugin: **ork**.
 claude install orchestkit/ork
 ```
 
-No choices, no configuration required. All 113 skills, 37 agents, and 212 hooks install together.
+No choices, no configuration required. All <Count k="skills" /> skills, <Count k="agents" /> agents, and <Count k="hooks" /> hooks install together.
 
 ## What Loads When
 

--- a/docs/site/content/docs/foundations/overview.mdx
+++ b/docs/site/content/docs/foundations/overview.mdx
@@ -5,6 +5,7 @@ description: The complete AI development toolkit for Claude Code — 113 skills,
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { Steps, Step } from 'fumadocs-ui/components/steps';
+import { Count } from '@/components/count';
 
 OrchestKit is a **Claude Code plugin** that gives your AI assistant deep expertise in software engineering. Instead of explaining your stack on every prompt, OrchestKit injects the right knowledge at the right time.
 
@@ -42,7 +43,7 @@ When you type a prompt, OrchestKit works in three layers:
 
 ## One Plugin
 
-OrchestKit ships as a single plugin: **ork** — 113 skills, 37 agents, 212 hooks.
+OrchestKit ships as a single plugin: **ork** — <Count k="skills" /> skills, <Count k="agents" /> agents, <Count k="hooks" /> hooks.
 
 ## Next Steps
 

--- a/docs/site/content/docs/foundations/skills-agents-hooks.mdx
+++ b/docs/site/content/docs/foundations/skills-agents-hooks.mdx
@@ -4,6 +4,7 @@ description: Skills are knowledge, agents are specialists, hooks are automation.
 ---
 
 import { Steps, Step } from 'fumadocs-ui/components/steps';
+import { Count } from '@/components/count';
 
 OrchestKit has three types of components. Understanding how they connect is the key to using the toolkit effectively.
 
@@ -15,14 +16,14 @@ A skill is a markdown file containing expert knowledge about a specific topic. T
 src/skills/python-backend/SKILL.md
 ```
 
-**111 skills** covering: FastAPI, React, SQLAlchemy, RAG, LangGraph, OWASP, Terraform, and more.
+**<Count k="skills" /> skills** covering: FastAPI, React, SQLAlchemy, RAG, LangGraph, OWASP, Terraform, and more.
 
 ### Two Types
 
 | Type | Count | How It Works | Example |
 |---|---|---|---|
-| **Command** | 23 | You invoke directly: `/ork:commit` | `/ork:verify`, `/ork:implement` |
-| **Reference** | 80 | Auto-injected into agents | `python-backend`, `security-patterns` |
+| **Command** | <Count k="commands" /> | You invoke directly: `/ork:commit` | `/ork:verify`, `/ork:implement` |
+| **Reference** | <Count k="references" /> | Auto-injected into agents | `python-backend`, `security-patterns` |
 
 Command skills are what you type. Reference skills are what agents read. You never need to invoke a reference skill — the right agent loads the right skills automatically.
 
@@ -45,7 +46,7 @@ agent: backend-system-architect  # Which agent uses this
 
 An agent is a **specialized Claude instance** with a specific role, tools, and injected skills. When you say "design a database schema", OrchestKit spawns the `database-engineer` agent — pre-loaded with schema design skills, migration patterns, and normalization knowledge.
 
-**37 agents** covering: backend architecture, frontend UI, security auditing, test generation, debugging, deployment, and more.
+**<Count k="agents" /> agents** covering: backend architecture, frontend UI, security auditing, test generation, debugging, deployment, and more.
 
 ### How Agents Activate
 

--- a/docs/site/content/docs/getting-started/first-10-minutes.mdx
+++ b/docs/site/content/docs/getting-started/first-10-minutes.mdx
@@ -4,6 +4,7 @@ description: From install to your first AI-assisted commit — a guided walkthro
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Count } from '@/components/count';
 
 This guide walks you through your first OrchestKit session. By the end, you'll understand how skills, agents, and hooks work together.
 
@@ -15,7 +16,7 @@ After installing, verify everything is working:
 /ork:doctor
 ```
 
-This runs diagnostics on all 113 skills, 37 agents, and 212 hooks. If anything is misconfigured, it tells you exactly what to fix.
+This runs diagnostics on all <Count k="skills" /> skills, <Count k="agents" /> agents, and <Count k="hooks" /> hooks. If anything is misconfigured, it tells you exactly what to fix.
 
 ## Step 2: Your First Command Skill
 

--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -6,6 +6,7 @@ description: Install OrchestKit in Claude Code — marketplace, CLI, or manual s
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
 import { LazySetupWizard } from '@/components/lazy';
+import { Count, MinCC } from '@/components/count';
 
 ## From Claude Code Marketplace (Recommended)
 
@@ -13,7 +14,7 @@ import { LazySetupWizard } from '@/components/lazy';
 claude install orchestkit/ork
 ```
 
-This installs all 113 skills, 37 agents, and 212 hooks.
+This installs all <Count k="skills" /> skills, <Count k="agents" /> agents, and <Count k="hooks" /> hooks.
 
 ## Interactive Setup
 
@@ -32,8 +33,8 @@ Expected output:
 ```
 OrchestKit Health Check
 =======================
-Plugin:     ork v7.43.0
-Skills:     111 loaded (31 commands, 80 reference)
+Plugin:     ork v8.63.2
+Skills:     113 loaded (32 commands, 81 reference)
 Agents:     37 registered
 Hooks:      212 active (144 global, 46 agent, 22 skill-scoped)
 Memory:     Graph ✓  Local ✓  CC Native ✓
@@ -84,7 +85,7 @@ Without Tavily, web research falls back to WebFetch → agent-browser automatica
 
 ## Requirements
 
-- **Claude Code** >= 2.1.148
+- **Claude Code** >= <MinCC />
 - **Node.js** >= 18 (for hooks)
 - **Git** (for commit/PR workflows)
 

--- a/docs/site/content/docs/getting-started/navigating.mdx
+++ b/docs/site/content/docs/getting-started/navigating.mdx
@@ -4,8 +4,9 @@ description: Hub-and-spoke navigation — find the right skills and agents for y
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
+import { Count } from '@/components/count';
 
-OrchestKit has 113 skills and 37 agents. You don't need to memorize them — this page helps you find exactly what you need.
+OrchestKit has <Count k="skills" /> skills and <Count k="agents" /> agents. You don't need to memorize them — this page helps you find exactly what you need.
 
 ## By Role
 

--- a/docs/site/content/docs/getting-started/release-channels.mdx
+++ b/docs/site/content/docs/getting-started/release-channels.mdx
@@ -5,6 +5,7 @@ description: Install OrchestKit from stable, beta, or alpha release channels usi
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { Step, Steps } from 'fumadocs-ui/components/steps';
+import { MinCC } from '@/components/count';
 
 OrchestKit offers three release channels. Each channel is a **separate git branch** that Claude Code resolves via the marketplace `@ref` syntax. The **stable** channel (default) is recommended for most users.
 
@@ -54,7 +55,7 @@ Look for: `Plugin: ork v7.2.0 (stable)`
 **What you get:**
 - Fully tested features across macOS, Ubuntu, Windows
 - Regular bug fixes and security patches
-- Compatible with Claude Code >= 2.1.148
+- Compatible with Claude Code >= <MinCC />
 
 **Update frequency:** Weekly or as needed for bug fixes.
 
@@ -166,7 +167,7 @@ Plugin:     ork v7.2.0-alpha.42 (alpha)
 ## Compatibility
 
 All three channels require:
-- Claude Code >= 2.1.148
+- Claude Code >= <MinCC />
 - Node.js >= 18 (for hooks)
 - Git (for commit/PR workflows)
 

--- a/docs/site/content/docs/memory/graph-memory.mdx
+++ b/docs/site/content/docs/memory/graph-memory.mdx
@@ -5,7 +5,7 @@ description: "The zero-config knowledge graph that stores entities and typed rel
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
-Graph memory is Tier 1 -- the **primary** storage layer in OrchestKit's memory architecture. It uses the `@anthropic/memory-mcp-server` to maintain a knowledge graph of entities and their relationships. It requires zero configuration and is always available.
+Graph memory is Tier 1 -- the **primary** storage layer in OrchestKit's memory architecture. It uses the `@modelcontextprotocol/server-memory` MCP server to maintain a knowledge graph of entities and their relationships. It requires zero configuration and is always available.
 
 ## How It Works
 
@@ -155,7 +155,6 @@ The memory writer infers entity types from the content of your text:
 |---|---|---|
 | `memory-context` | `prompt` | Searches graph for entities matching prompt keywords; injects search hints into Claude's context |
 | `memory-context-loader` | `prompt` (once) | Loads recent decisions from local JSONL on session start |
-| `memory-fabric-init` | `pretool` (once) | Lazy initialization of memory directories and session registration on first memory MCP call |
 
 ## Hooks That Write to the Graph
 
@@ -222,7 +221,7 @@ The knowledge graph MCP server is configured automatically by Claude Code. If yo
   "mcpServers": {
     "memory": {
       "command": "npx",
-      "args": ["-y", "@anthropic/memory-mcp-server"]
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
     }
   }
 }

--- a/docs/site/content/docs/memory/local-memory.mdx
+++ b/docs/site/content/docs/memory/local-memory.mdx
@@ -60,7 +60,7 @@ This is the primary local backup. Every decision captured by the memory writer i
 
 ### How It Gets Written
 
-The `storeDecision` function in `memory-writer.ts` always writes to `decisions.jsonl` as its first action (step 1 of 4). This ensures the decision is durably stored before any network or MCP operations attempt to process it.
+Memory hooks (such as `pre-compact-saver` and `context-exhaustion-warner`) append to `decisions.jsonl` as their first action. This ensures the decision is durably stored on disk before any graph or MCP operation attempts to process it.
 
 ### How It Gets Read
 
@@ -87,58 +87,6 @@ Example injected context:
 
 _For deeper graph traversal: use mcp__memory__search_nodes or mcp__memory__open_nodes_
 ```
-
-## `graph-queue.jsonl` -- Pending Graph Operations
-
-When the memory writer captures a decision, it builds graph operations (entity creation, relation creation, observation additions) and appends them to this queue. Each line represents a single operation to be processed.
-
-### Record Structure
-
-```json
-{
-  "type": "create_entities",
-  "payload": {
-    "entities": [
-      {
-        "name": "decision-m1abc-x7y2z3",
-        "entityType": "Decision",
-        "observations": [
-          "What: Use cursor-based pagination for all list endpoints",
-          "Rationale: Better performance for large datasets",
-          "Alternatives considered: offset-based pagination",
-          "Category: pagination",
-          "Confidence: 85%",
-          "Source: user_prompt",
-          "Project: orchestkit",
-          "Timestamp: 2026-02-06T10:30:00.000Z"
-        ]
-      },
-      {
-        "name": "cursor-pagination",
-        "entityType": "Pattern",
-        "observations": [
-          "Mentioned in decision: Use cursor-based pagination for all list endpoints"
-        ]
-      }
-    ]
-  },
-  "timestamp": "2026-02-06T10:30:00.001Z"
-}
-```
-
-A single decision typically generates two queued operations: one `create_entities` and one `create_relations`. The `buildGraphOperations` function in `memory-writer.ts` produces these operations, including:
-
-- A main entity for the decision itself
-- Entities for each mentioned technology/pattern
-- `CHOSE` or `PREFERS` relations from the decision to its entities
-- `CHOSE_OVER` relations for rejected alternatives
-- `CONSTRAINT` relations for limiting factors
-- `TRADEOFF` relations for accepted costs
-- `RELATES_TO` cross-links between co-occurring entities
-
-### Processing
-
-Graph queue operations are designed to be processed when the MCP memory server is available. The hook system reads pending operations and issues the corresponding `mcp__memory__create_entities` and `mcp__memory__create_relations` calls.
 
 ## `open-problems.jsonl` -- Problem Tracking
 

--- a/docs/site/content/docs/memory/native-cc-memory.mdx
+++ b/docs/site/content/docs/memory/native-cc-memory.mdx
@@ -20,30 +20,9 @@ This means anything written to MEMORY.md is visible to Claude in every conversat
 
 ## Auto-Promotion: Graph to MEMORY.md
 
-OrchestKit bridges its own memory system to CC Native through **auto-promotion**. The `storeDecision` function in `memory-writer.ts` evaluates every captured decision:
+OrchestKit bridges its own memory system to CC Native through **auto-promotion**: high-signal decisions captured during a session get persisted into `MEMORY.md`, where Claude Code injects them into every future session.
 
-```
-if (decision.metadata.confidence >= 0.7 && isCCNativeMemoryAvailable()) {
-    storeToCCNativeMemory(decision);
-}
-```
-
-The two conditions for auto-promotion:
-
-1. **Confidence >= 0.7** -- the decision must be high-confidence (see scoring below)
-2. **CC Native memory directory exists** -- Claude Code must have created the project directory (it does this automatically when you first open a project)
-
-### Confidence Scoring
-
-| Factor | Effect on Confidence |
-|---|---|
-| User explicitly states a decision ("we decided...", "always use...") | Higher (typically 0.8+) |
-| Decision includes rationale ("because...") | Higher |
-| User states a preference directly | Higher |
-| Pattern inferred from tool output | Lower (typically 0.4-0.6) |
-| Observation from agent completion | Lower |
-
-Only decisions with clear intent and strong signal cross the 0.7 threshold. This keeps MEMORY.md focused and concise.
+Promotion is performed by Claude itself, prompted by OrchestKit's session hooks (`session-summary`, `auto-remember-continuity`): at session end, Claude reviews what was decided and writes durable, high-confidence decisions to MEMORY.md. Low-signal material -- patterns inferred from tool output, transient observations -- stays in the session-local JSONL files instead. This keeps MEMORY.md focused and concise.
 
 ## What Gets Written
 
@@ -72,7 +51,7 @@ Each entry includes:
 
 ## Deduplication
 
-Before writing a new entry, the memory writer checks if the first 50 characters of the decision text already appear in the existing MEMORY.md content. If found, the write is skipped to avoid duplicate entries. This prevents the same decision from appearing multiple times if it is captured by multiple hooks in the same session.
+Before adding an entry, existing MEMORY.md content is checked for the same decision so it is not recorded twice, even when multiple hooks capture it in the same session.
 
 ## Ordering: Most Recent First
 

--- a/docs/site/content/docs/reference/skills/doctor.mdx
+++ b/docs/site/content/docs/reference/skills/doctor.mdx
@@ -715,15 +715,15 @@ Channel: alpha (v7.0.0-alpha.1)
 
 ```
 Installed Plugins: 1
-- ork: 111 skills, 37 agents, 211 hook entries
+- ork: 113 skills, 37 agents, 212 hook entries
 ```
 
 ## Skills Validation
 
 ```
-Skills: 79/79 valid
-- User-invocable: 18 commands
-- Reference skills: 61
+Skills: 113/113 valid
+- User-invocable: 32 commands
+- Reference skills: 81
 ```
 
 ## Agents Validation
@@ -1791,14 +1791,14 @@ jq '.properties | to_entries | map({key: .key, type: .value.type})' \
 
 ## Overview
 
-OrchestKit includes 111 skills validated against frontmatter requirements and content standards.
+OrchestKit includes 113 skills validated against frontmatter requirements and content standards.
 
 ## Skill Types
 
 | Type | Count | Frontmatter |
 |------|-------|-------------|
-| User-invocable | 18 | `user-invocable: true` |
-| Internal | 61 | `user-invocable: false` |
+| User-invocable | 32 | `user-invocable: true` |
+| Internal | 81 | `user-invocable: false` |
 
 ## Validation Checks
 

--- a/docs/site/content/docs/reference/skills/validate-counts.mdx
+++ b/docs/site/content/docs/reference/skills/validate-counts.mdx
@@ -218,8 +218,8 @@ Overview of every place counts appear and what they represent.
 
 | What | Path | How to Count |
 |------|------|-------------|
-| Skills | `src/skills/*/` | Subdirectory count |
-| Agents | `src/agents/*.md` | `.md` file count |
+| Skills | `src/skills/*/SKILL.md` | `SKILL.md` file count (`src/skills/shared/` has no SKILL.md and is not a skill) |
+| Agents | `src/agents/*.md` | `.md` file count excluding `README.md` |
 | Hooks | `src/hooks/hooks.json` → `.hooks[]` | Array length |
 
 ### Derived Counts (must stay in sync)

--- a/docs/site/content/docs/skills/overview.mdx
+++ b/docs/site/content/docs/skills/overview.mdx
@@ -153,7 +153,7 @@ When multiple skills are injected, they share this budget. The platform prioriti
 
 ## Skill Listing and Token Budget
 
-Of OrchestKit's 113 skills, **27 are user-invocable** command skills (you type `/ork:skill-name`). Of those, **22 are listed** in Claude's prompt context. **47 reference skills** are hidden from the listing entirely:
+Of OrchestKit's <Count k="skills" /> skills, **<Count k="commands" /> are user-invocable** command skills (you type `/ork:skill-name`). Of those, **23 are listed** in Claude's prompt context. **48 reference skills** are hidden from the listing entirely:
 
 - Users can invoke command skills via `/ork:skill-name` slash commands
 - Agents load reference skills via frontmatter `skills:` arrays

--- a/docs/site/content/docs/skills/writing-skills.mdx
+++ b/docs/site/content/docs/skills/writing-skills.mdx
@@ -157,7 +157,7 @@ argument-hint: "[file-or-topic]"      # /ork:assess [file-or-topic]
 argument-hint: "[search|load|history]" # /ork:memory [search|load|history]
 ```
 
-**`disable-model-invocation`** -- Set to `true` to hide the skill from Claude's prompt listing. The skill is still available via `/ork:skill-name` and agent `skills:` arrays, but Claude won't see it in its context window. Use for niche or rarely-needed skills to save tokens (~3,200 tokens/turn saved by hiding 51 of 111 skills -- exact count varies as skills are added).
+**`disable-model-invocation`** -- Set to `true` to hide the skill from Claude's prompt listing. The skill is still available via `/ork:skill-name` and agent `skills:` arrays, but Claude won't see it in its context window. Use for niche or rarely-needed skills to save tokens (~3,200 tokens/turn saved by hiding 57 of 113 skills -- exact count varies as skills are added).
 
 ```yaml
 disable-model-invocation: true  # Hidden from prompt listing, still invocable

--- a/docs/site/content/docs/troubleshooting/faq.mdx
+++ b/docs/site/content/docs/troubleshooting/faq.mdx
@@ -4,12 +4,13 @@ description: Frequently asked questions about OrchestKit.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { Count, MinCC } from '@/components/count';
 
 ## General
 
 ### What version of Claude Code do I need?
 
-OrchestKit requires Claude Code 2.1.148 or later. Check your version:
+OrchestKit requires Claude Code <MinCC /> or later. Check your version:
 
 ```bash
 claude --version
@@ -23,7 +24,7 @@ npm install -g @anthropic-ai/claude-code@latest
 
 ### How do I install OrchestKit?
 
-OrchestKit is a single plugin: **ork** — 113 skills, 37 agents, 212 hooks. Install with `claude install orchestkit/ork`.
+OrchestKit is a single plugin: **ork** — <Count k="skills" /> skills, <Count k="agents" /> agents, <Count k="hooks" /> hooks. Install with `claude install orchestkit/ork`.
 
 ### Can I use OrchestKit with other Claude Code plugins?
 
@@ -43,7 +44,7 @@ This is opt-in via an environment variable. Without it, OrchestKit operates enti
 
 ### How many skills are there?
 
-111 total: 32 command skills (user-invocable via `/ork:skillname`) and 80 reference skills (knowledge modules auto-injected by agents and hooks).
+<Count k="skills" /> total: <Count k="commands" /> command skills (user-invocable via `/ork:skillname`) and <Count k="references" /> reference skills (knowledge modules auto-injected by agents and hooks).
 
 ### What does `complexity: low|medium|high|max` mean?
 

--- a/docs/site/content/docs/troubleshooting/index.mdx
+++ b/docs/site/content/docs/troubleshooting/index.mdx
@@ -4,6 +4,7 @@ description: Solutions for the 10 most common OrchestKit issues.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+import { MinCC } from '@/components/count';
 
 This page covers the most frequent issues OrchestKit users encounter, ordered by how often they come up. For hook-specific debugging, see [Hook Debugging](/docs/troubleshooting/hook-debugging). For broader questions about how OrchestKit works, see the [FAQ](/docs/troubleshooting/faq).
 
@@ -129,7 +130,7 @@ The memory system has 3 tiers. If Tier 1 (Graph) is not configured, decisions fa
 **Fix:**
 
 ```bash
-# Check Claude Code version (requires >= 2.1.148)
+# Check Claude Code version (requires >= 2.1.183)
 claude --version
 
 # Verify agent definition exists
@@ -142,7 +143,7 @@ npm run test:agents
 npm run build
 ```
 
-If the Claude Code version is below 2.1.148, upgrade:
+If the Claude Code version is below <MinCC />, upgrade:
 
 ```bash
 npm install -g @anthropic-ai/claude-code@latest
@@ -205,7 +206,7 @@ Only use `--no-verify` for changes you are confident about. For substantial code
 
 ## 8. Count Drift After Adding Skills or Hooks
 
-**Symptom:** Tests fail with "expected 111 skills, found 73" or similar count mismatches.
+**Symptom:** Tests fail with "expected 113 skills, found 73" or similar count mismatches.
 
 **Cause:** Adding a skill or hook updates the source files but not the count references scattered across the codebase.
 

--- a/plugins/ork/skills/bare-eval/workflows/skill-fitness.mjs
+++ b/plugins/ork/skills/bare-eval/workflows/skill-fitness.mjs
@@ -54,7 +54,7 @@ phase('Score')
 const scored = await pipeline(
   SKILLS,
   (s) => agent(
-    `Read src/skills/${s}/SKILL.md (repo-relative to your cwd) and score this ONE skill's fitness for current Claude Code (mid-2026, floor 2.1.148, current model Opus 4.8).
+    `Read src/skills/${s}/SKILL.md (repo-relative to your cwd) and score this ONE skill's fitness for current Claude Code (mid-2026, floor 2.1.183, current model Opus 4.8).
 
 Score 0-10 each:
 - freshness: no stale model IDs (Opus 4.6/4.7 cited as current), no CC version requirement below the floor, no drifting hardcoded counts

--- a/plugins/ork/skills/doctor/references/health-check-outputs.md
+++ b/plugins/ork/skills/doctor/references/health-check-outputs.md
@@ -31,15 +31,15 @@ Channel: alpha (v7.0.0-alpha.1)
 
 ```
 Installed Plugins: 1
-- ork: 111 skills, 37 agents, 211 hook entries
+- ork: 113 skills, 37 agents, 212 hook entries
 ```
 
 ## Skills Validation
 
 ```
-Skills: 79/79 valid
-- User-invocable: 18 commands
-- Reference skills: 61
+Skills: 113/113 valid
+- User-invocable: 32 commands
+- Reference skills: 81
 ```
 
 ## Agents Validation

--- a/plugins/ork/skills/doctor/references/skills-validation.md
+++ b/plugins/ork/skills/doctor/references/skills-validation.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-OrchestKit includes 111 skills validated against frontmatter requirements and content standards.
+OrchestKit includes 113 skills validated against frontmatter requirements and content standards.
 
 ## Skill Types
 
 | Type | Count | Frontmatter |
 |------|-------|-------------|
-| User-invocable | 18 | `user-invocable: true` |
-| Internal | 61 | `user-invocable: false` |
+| User-invocable | 32 | `user-invocable: true` |
+| Internal | 81 | `user-invocable: false` |
 
 ## Validation Checks
 

--- a/plugins/ork/skills/validate-counts/references/count-locations.md
+++ b/plugins/ork/skills/validate-counts/references/count-locations.md
@@ -8,15 +8,15 @@ Overview of every place counts appear and what they represent.
 
 | What | Path | How to Count |
 |------|------|-------------|
-| Skills | `src/skills/*/` | Subdirectory count |
-| Agents | `src/agents/*.md` | `.md` file count |
+| Skills | `src/skills/*/SKILL.md` | `SKILL.md` file count (`src/skills/shared/` has no SKILL.md and is not a skill) |
+| Agents | `src/agents/*.md` | `.md` file count excluding `README.md` |
 | Hooks | `src/hooks/hooks.json` → `.hooks[]` | Array length |
 
 ### Derived Counts (must stay in sync)
 
 | File | Field | Example |
 |------|-------|---------|
-| `CLAUDE.md` | Project Overview line | "111 skills, 37 agents, 211 hooks" |
+| `CLAUDE.md` | Project Overview line | "113 skills, 37 agents, 212 hooks" |
 | `CLAUDE.md` | Version section | "55 entries (17 event types, 12 dispatchers, 9 native async)" |
 | `src/hooks/hooks.json` | top-level `description` | May embed hook count |
 | `manifests/ork.json` | `skills[]` length, `agents[]` length | Counted from arrays |

--- a/plugins/ork/skills/validate-counts/scripts/validate-counts.sh
+++ b/plugins/ork/skills/validate-counts/scripts/validate-counts.sh
@@ -31,8 +31,10 @@ fi
 # ACTUAL COUNTS (authoritative — from src/)
 # =============================================================================
 
-ACTUAL_SKILLS=$(find "$REPO_ROOT/src/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-ACTUAL_AGENTS=$(find "$REPO_ROOT/src/agents" -maxdepth 1 -name "*.md" | wc -l | tr -d ' ')
+# Skills = dirs containing a SKILL.md (src/skills/shared/ holds shared rules, not a skill)
+ACTUAL_SKILLS=$(find "$REPO_ROOT/src/skills" -mindepth 2 -maxdepth 2 -name "SKILL.md" | wc -l | tr -d ' ')
+# Agents = definition files only (README.md is not an agent)
+ACTUAL_AGENTS=$(find "$REPO_ROOT/src/agents" -maxdepth 1 -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')
 # hooks.json .hooks is an object keyed by event type → array of entries → each has .hooks array of commands
 # Count = total commands across all entries across all event types
 ACTUAL_HOOKS=$(jq '[.hooks | to_entries[] | .value[] | .hooks | length] | add' "$REPO_ROOT/src/hooks/hooks.json")
@@ -43,7 +45,7 @@ ACTUAL_HOOKS=$(jq '[.hooks | to_entries[] | .value[] | .hooks | length] | add' "
 
 CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 
-# Project Overview line: "111 skills, 37 agents, 211 hooks"
+# Project Overview line: "113 skills, 37 agents, 212 hooks"
 CLAUDE_OVERVIEW=$(grep -m1 'skills.*agents.*hooks' "$CLAUDE_MD" || true)
 CLAUDE_OV_SKILLS=$(echo "$CLAUDE_OVERVIEW" | grep -oE '[0-9]+ skills?' | grep -oE '[0-9]+' || echo "?")
 CLAUDE_OV_AGENTS=$(echo "$CLAUDE_OVERVIEW" | grep -oE '[0-9]+ agents?' | grep -oE '[0-9]+' || echo "?")

--- a/scripts/check-docs-facts.mjs
+++ b/scripts/check-docs-facts.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * check-docs-facts.mjs — fail CI when hand-written docs pages state a Claude Code
+ * floor or a component-count triple that contradicts the repo's ground truth.
+ *
+ * Why: the build-drift gate only covers GENERATED paths (content/docs/reference,
+ * content/docs/skills/by-category). Hand-written pages hard-coding facts rot
+ * silently across releases (observed: floor 2.1.148 advertised 10 days after the
+ * 2.1.183 bump). Pages should prefer <Count k="..."/> / <MinCC /> from
+ * @/components/count; this gate catches the literals that remain (frontmatter,
+ * code blocks, future additions).
+ *
+ * Scope: docs/site/content/docs/**\/*.mdx excluding generated paths.
+ * Escape hatch: lines containing "docs-facts-ignore" are skipped.
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DOCS = path.join(ROOT, 'docs/site/content/docs');
+const EXCLUDE = [
+  path.join(DOCS, 'reference'),
+  path.join(DOCS, 'skills/by-category'),
+];
+
+// ── Ground truth ────────────────────────────────────────────────────────────
+const floor = JSON.parse(
+  readFileSync(path.join(ROOT, 'shared/cc-support.json'), 'utf8'),
+).supported_floor;
+
+// Skills = dirs containing a SKILL.md (src/skills/shared/ is not a skill)
+const skills = readdirSync(path.join(ROOT, 'src/skills'), { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .filter((d) => existsSync(path.join(ROOT, 'src/skills', d.name, 'SKILL.md')))
+  .length;
+
+// Agents = definition files only (README.md is not an agent)
+const agents = readdirSync(path.join(ROOT, 'src/agents'))
+  .filter((f) => f.endsWith('.md') && f !== 'README.md').length;
+
+const hooksDesc = JSON.parse(
+  readFileSync(path.join(ROOT, 'src/hooks/hooks.json'), 'utf8'),
+).description;
+const hooksMatch = hooksDesc.match(/=\s*(\d+)\s+total hooks/);
+if (!hooksMatch) {
+  console.error('check-docs-facts: cannot parse hook total from hooks.json description');
+  process.exit(1);
+}
+const hooks = Number(hooksMatch[1]);
+
+// ── Checks ──────────────────────────────────────────────────────────────────
+// Floor-claim shapes; every captured 2.x.x version must equal the floor.
+const FLOOR_PATTERNS = [
+  /(?:>=|≥)\s*(2\.\d+\.\d+)/g,
+  /Claude Code (2\.\d+\.\d+) or later/g,
+  /below (2\.\d+\.\d+)/g,
+];
+// "N skills, M agents[, and K hooks]" is always a totals claim.
+const TRIPLE = /(\d+)\s+skills?,\s*(\d+)\s+agents?(?:,\s*(?:and\s+)?(\d+)\s+hooks?)?/g;
+
+function* mdxFiles(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (EXCLUDE.includes(p)) continue;
+    if (e.isDirectory()) yield* mdxFiles(p);
+    else if (e.name.endsWith('.mdx')) yield p;
+  }
+}
+
+let errors = 0;
+for (const file of mdxFiles(DOCS)) {
+  const rel = path.relative(ROOT, file);
+  readFileSync(file, 'utf8').split('\n').forEach((line, i) => {
+    if (line.includes('docs-facts-ignore')) return;
+    for (const pat of FLOOR_PATTERNS) {
+      pat.lastIndex = 0;
+      for (const m of line.matchAll(pat)) {
+        if (m[1] !== floor) {
+          console.error(`${rel}:${i + 1} states CC version ${m[1]} — supported floor is ${floor}`);
+          errors++;
+        }
+      }
+    }
+    TRIPLE.lastIndex = 0;
+    for (const m of line.matchAll(TRIPLE)) {
+      const [s, a] = [Number(m[1]), Number(m[2])];
+      const h = m[3] === undefined ? null : Number(m[3]);
+      if (s !== skills || a !== agents || (h !== null && h !== hooks)) {
+        console.error(`${rel}:${i + 1} states "${m[0]}" — actual: ${skills} skills, ${agents} agents, ${hooks} hooks`);
+        errors++;
+      }
+    }
+  });
+}
+
+if (errors) {
+  console.error(`check-docs-facts: ${errors} stale fact(s). Fix the value, use <Count k="..."/> / <MinCC />, or mark the line with docs-facts-ignore.`);
+  process.exit(1);
+}
+console.log(`check-docs-facts: OK (floor ${floor}, ${skills} skills, ${agents} agents, ${hooks} hooks)`);

--- a/scripts/stamp-cc-support.mjs
+++ b/scripts/stamp-cc-support.mjs
@@ -150,6 +150,17 @@ stamp('src/skills/doctor/references/version-compatibility.md', [
   },
 ]);
 
+stamp('docs/site/content/docs/troubleshooting/index.mdx', [
+  {
+    // Fenced code block — prose in docs uses <MinCC /> from @/components/count,
+    // but code blocks can't interpolate, so this literal is stamped instead.
+    label: 'code-block floor comment',
+    pattern: /(# Check Claude Code version \(requires >= )\d+\.\d+\.\d+(\))/,
+    replacement: `$1${supported_floor}$2`,
+    expectedMatches: 1,
+  },
+]);
+
 stamp('README.md', [
   {
     label: 'Claude Code shields.io badge floor',

--- a/src/skills/bare-eval/workflows/skill-fitness.mjs
+++ b/src/skills/bare-eval/workflows/skill-fitness.mjs
@@ -54,7 +54,7 @@ phase('Score')
 const scored = await pipeline(
   SKILLS,
   (s) => agent(
-    `Read src/skills/${s}/SKILL.md (repo-relative to your cwd) and score this ONE skill's fitness for current Claude Code (mid-2026, floor 2.1.148, current model Opus 4.8).
+    `Read src/skills/${s}/SKILL.md (repo-relative to your cwd) and score this ONE skill's fitness for current Claude Code (mid-2026, floor 2.1.183, current model Opus 4.8).
 
 Score 0-10 each:
 - freshness: no stale model IDs (Opus 4.6/4.7 cited as current), no CC version requirement below the floor, no drifting hardcoded counts

--- a/src/skills/doctor/references/health-check-outputs.md
+++ b/src/skills/doctor/references/health-check-outputs.md
@@ -31,15 +31,15 @@ Channel: alpha (v7.0.0-alpha.1)
 
 ```
 Installed Plugins: 1
-- ork: 111 skills, 37 agents, 211 hook entries
+- ork: 113 skills, 37 agents, 212 hook entries
 ```
 
 ## Skills Validation
 
 ```
-Skills: 79/79 valid
-- User-invocable: 18 commands
-- Reference skills: 61
+Skills: 113/113 valid
+- User-invocable: 32 commands
+- Reference skills: 81
 ```
 
 ## Agents Validation

--- a/src/skills/doctor/references/skills-validation.md
+++ b/src/skills/doctor/references/skills-validation.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-OrchestKit includes 111 skills validated against frontmatter requirements and content standards.
+OrchestKit includes 113 skills validated against frontmatter requirements and content standards.
 
 ## Skill Types
 
 | Type | Count | Frontmatter |
 |------|-------|-------------|
-| User-invocable | 18 | `user-invocable: true` |
-| Internal | 61 | `user-invocable: false` |
+| User-invocable | 32 | `user-invocable: true` |
+| Internal | 81 | `user-invocable: false` |
 
 ## Validation Checks
 

--- a/src/skills/validate-counts/references/count-locations.md
+++ b/src/skills/validate-counts/references/count-locations.md
@@ -8,15 +8,15 @@ Overview of every place counts appear and what they represent.
 
 | What | Path | How to Count |
 |------|------|-------------|
-| Skills | `src/skills/*/` | Subdirectory count |
-| Agents | `src/agents/*.md` | `.md` file count |
+| Skills | `src/skills/*/SKILL.md` | `SKILL.md` file count (`src/skills/shared/` has no SKILL.md and is not a skill) |
+| Agents | `src/agents/*.md` | `.md` file count excluding `README.md` |
 | Hooks | `src/hooks/hooks.json` → `.hooks[]` | Array length |
 
 ### Derived Counts (must stay in sync)
 
 | File | Field | Example |
 |------|-------|---------|
-| `CLAUDE.md` | Project Overview line | "111 skills, 37 agents, 211 hooks" |
+| `CLAUDE.md` | Project Overview line | "113 skills, 37 agents, 212 hooks" |
 | `CLAUDE.md` | Version section | "55 entries (17 event types, 12 dispatchers, 9 native async)" |
 | `src/hooks/hooks.json` | top-level `description` | May embed hook count |
 | `manifests/ork.json` | `skills[]` length, `agents[]` length | Counted from arrays |

--- a/src/skills/validate-counts/scripts/validate-counts.sh
+++ b/src/skills/validate-counts/scripts/validate-counts.sh
@@ -31,8 +31,10 @@ fi
 # ACTUAL COUNTS (authoritative — from src/)
 # =============================================================================
 
-ACTUAL_SKILLS=$(find "$REPO_ROOT/src/skills" -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-ACTUAL_AGENTS=$(find "$REPO_ROOT/src/agents" -maxdepth 1 -name "*.md" | wc -l | tr -d ' ')
+# Skills = dirs containing a SKILL.md (src/skills/shared/ holds shared rules, not a skill)
+ACTUAL_SKILLS=$(find "$REPO_ROOT/src/skills" -mindepth 2 -maxdepth 2 -name "SKILL.md" | wc -l | tr -d ' ')
+# Agents = definition files only (README.md is not an agent)
+ACTUAL_AGENTS=$(find "$REPO_ROOT/src/agents" -maxdepth 1 -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')
 # hooks.json .hooks is an object keyed by event type → array of entries → each has .hooks array of commands
 # Count = total commands across all entries across all event types
 ACTUAL_HOOKS=$(jq '[.hooks | to_entries[] | .value[] | .hooks | length] | add' "$REPO_ROOT/src/hooks/hooks.json")
@@ -43,7 +45,7 @@ ACTUAL_HOOKS=$(jq '[.hooks | to_entries[] | .value[] | .hooks | length] | add' "
 
 CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 
-# Project Overview line: "111 skills, 37 agents, 211 hooks"
+# Project Overview line: "113 skills, 37 agents, 212 hooks"
 CLAUDE_OVERVIEW=$(grep -m1 'skills.*agents.*hooks' "$CLAUDE_MD" || true)
 CLAUDE_OV_SKILLS=$(echo "$CLAUDE_OVERVIEW" | grep -oE '[0-9]+ skills?' | grep -oE '[0-9]+' || echo "?")
 CLAUDE_OV_AGENTS=$(echo "$CLAUDE_OVERVIEW" | grep -oE '[0-9]+ agents?' | grep -oE '[0-9]+' || echo "?")

--- a/tests/integration/test-cc-support-stamper.sh
+++ b/tests/integration/test-cc-support-stamper.sh
@@ -25,6 +25,11 @@ ORIG_SUPPORT=$(cat shared/cc-support.json)
 ORIG_CLAUDE_MD=$(cat CLAUDE.md)
 ORIG_MATRIX=$(cat src/hooks/src/lib/cc-version-matrix.ts)
 ORIG_DOC=$(cat src/skills/doctor/references/version-compatibility.md)
+# Every stamp target must be snapshotted, or a bumped-floor test run leaves
+# fixture values (2.1.999) in the working tree — README.md was missing here
+# long before the docs target existed.
+ORIG_README=$(cat README.md)
+ORIG_TROUBLESHOOTING=$(cat docs/site/content/docs/troubleshooting/index.mdx)
 
 # Extract the current MIN_CC_VERSION value so monotonic-guard assertions stay
 # resilient to floor bumps (was hardcoded "2.1.122" pre-M131).
@@ -39,6 +44,8 @@ restore() {
   echo "$ORIG_CLAUDE_MD" > CLAUDE.md
   echo "$ORIG_MATRIX" > src/hooks/src/lib/cc-version-matrix.ts
   echo "$ORIG_DOC" > src/skills/doctor/references/version-compatibility.md
+  echo "$ORIG_README" > README.md
+  echo "$ORIG_TROUBLESHOOTING" > docs/site/content/docs/troubleshooting/index.mdx
 }
 trap restore EXIT
 


### PR DESCRIPTION
## Summary

Docs freshness fix + prevention, from the `/ork:assess` run on "our fumadocs are not updated" (assessment rev2 verdict: 6.09/C — the docs pipeline itself is healthy; specific fact classes rotted).

**What was actually stale** (verified against ground truth: 113 skills / 37 agents / 212 hooks / CC floor 2.1.183):

- CC floor advertised as `2.1.148` on 5 hand-written pages (installation, FAQ, release-channels, troubleshooting, cookbook) and in the skill-fitness eval prompt. Security-relevant, not cosmetic: the skipped 2.1.148 to 2.1.183 range includes the 2.1.163 Bash HOME secrets-read fix.
- 111-era strings that predate two stamp sweeps (faq "111 total", skills-agents-hooks, writing-skills "51 of 111", doctor references that feed generated pages)
- `skills/overview` derived counts: 27 invocable / 22 listed / 47 hidden, actual 32 / 23 / 48
- Memory docs described internals that do not exist at HEAD (`memory-writer.ts`, `storeDecision`, `graph-queue.jsonl`, `memory-fabric-init` — verified by grep) and named a nonexistent MCP package (`@anthropic/memory-mcp-server`, actual `@modelcontextprotocol/server-memory`)

**What was NOT stale** (first-pass audit false positives, killed by verification): the "113 skills, 37 agents, 212 hooks" triples — `stamp-counts.sh` keeps those current on every build — and "81 reference skills".

**Root cause:** `stamp-counts.sh` heals only phrasings in its sed pattern list; phrasings outside the list rot silently, and nothing covered the docs floor at all.

## Prevention (three layers)

1. **Render, don't state**: `<Count k="skills|commands|references|agents|hooks" />` plus a new `<MinCC />` component (both from `@/components/count`) replace literals on 12 pages — prose now renders from `lib/generated/shared-data.ts`, so it cannot rot.
2. **Stamp what can't render**: `stamp-cc-support.mjs` gains a target for the one fenced-code-block floor literal.
3. **Gate what's left**: new `scripts/check-docs-facts.mjs` in the docs.yml validate job fails CI when any non-generated page states a floor claim or count triple that contradicts computed truth (`docs-facts-ignore` escape hatch per line).

Also fixes `validate-counts.sh` counting semantics (SKILL.md-based skills count; `README.md` is not an agent) — the counting tool itself had the naive-count bug.

## Test hygiene

`tests/integration/test-cc-support-stamper.sh` now snapshots and restores **every** stamp target. Previously README.md (and now the docs page) were mutated to the fixture floor `2.1.999` but never restored, so any interrupted run left fixture values in the working tree — observed live during this work.

## Verification

- ✅ `npm test --quick`: 60 passed, 0 failed (includes the zero-tolerance security suites)
- ✅ `tests/integration/test-cc-support-stamper.sh`: 10 passed, 0 failed
- ✅ docs site (Next) build compiles all MDX changes including the Count/MinCC conversions
- ✅ `node scripts/check-docs-facts.mjs`: OK (floor 2.1.183, 113 skills, 37 agents, 212 hooks)
- ✅ `npm run build`: zero drift in generated docs; regenerated `doctor.mdx` healed via the src reference fixes
- Full integration/e2e/performance suites left to CI (local full runs exceeded the foreground time cap)

## Playground

Interactive playground explaining the freshness pipeline — before/after coverage lanes, the counting trap, and the gate contract: `docs/feat--docs-freshness/index.html`

## Follow-up

- #2735 — memory tier-model reconciliation (docs 3-tier vs `memory-health.ts` 2-tier) + remaining removed-internals reference in `src/skills/memory/rules/deduplication-strategy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
