### PR TITLE
feat(verify): add Verification Manifest (VERIFIED vs CLAIMED) gate

### DIFF
--- a/docs/site/content/docs/reference/skills/verify.mdx
+++ b/docs/site/content/docs/reference/skills/verify.mdx
@@ -328,6 +328,16 @@ Define verification rules in `.claude/policies/verification-policy.json`:
 
 ---
 
+## Verification Manifest (VERIFIED vs CLAIMED)
+
+Agent scores, tool summaries, and every "X is clean / passing / fixed" sentence are **claims** until the lead re-runs the proof. Before the verdict, build a **Verification Manifest** marking every *load-bearing* claim ✅ VERIFIED (lead ran it fresh — cites `command · exit · key line`), 🟡 CLAIMED (an agent/tool/doc asserted it, not re-run), ⬜ UNCHECKED, or ⚪ WAIVED (accepted non-blocking, with a reason). An agent's "PASS" copied into the report is still CLAIMED — VERIFIED means *the lead* ran it; a sub-agent's number (price, model-id, count) is CLAIMED until checked against source.
+
+> **Verdict rule:** any load-bearing claim still 🟡 CLAIMED or ⬜ UNCHECKED **caps the verdict at IMPROVEMENTS RECOMMENDED** (never READY FOR MERGE) until it is ✅ VERIFIED or ⚪ WAIVED — this stacks with the dimension-level blockers (both must clear), and under `--streak=N` it resets the streak.
+
+Protocol — claim sources, build step, template, and anti-patterns (laundering, optimism-marking, omission): `Read("$\{CLAUDE_SKILL_DIR\}/references/verification-manifest.md")`.
+
+---
+
 ## Report Format
 
 Load details: `Read("$\{CLAUDE_SKILL_DIR\}/references/report-template.md")` for full format. Summary:
@@ -341,6 +351,10 @@ Load details: `Read("$\{CLAUDE_SKILL_DIR\}/references/report-template.md")` for 
 **[READY FOR MERGE | IMPROVEMENTS RECOMMENDED | BLOCKED]**
 
 [--streak=N mode only: **STREAK [current]/[target]** — READY FOR MERGE requires the full target; any non-ready run resets to 0.]
+
+## Verification Manifest
+[✅ VERIFIED · 🟡 CLAIMED · ⬜ UNCHECKED · ⚪ WAIVED — any load-bearing 🟡/⬜ caps the verdict below READY FOR MERGE]
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
 ```
 
 > **Push notifications (CC 2.1.110+):** Verify runs for >5 min are common on complex changes. When the final verdict is ready, call `PushNotification` to alert the user — they likely walked away from the terminal. Requires Remote Control with "Push when Claude decides" config; fails silently for users without it.
@@ -365,6 +379,7 @@ Load on demand with `Read("$\{CLAUDE_SKILL_DIR\}/references/&lt;file&gt;")`:
 | `quality-model.md` | Scoring dimensions and weights (8 unified) |
 | `grading-rubric.md` | Per-agent scoring criteria |
 | `report-template.md` | Full report format with visual evidence section |
+| `verification-manifest.md` | VERIFIED‑vs‑CLAIMED provenance ledger: states, verdict rule, claim sources, template, anti‑patterns |
 | `alternative-comparison.md` | Approach comparison template |
 | `orchestration-mode.md` | Agent Teams vs Task Tool |
 | `policy-as-code.md` | Verification policy configuration |
@@ -427,6 +442,7 @@ TaskUpdate(taskId=commit_id, addBlockedBy=[verify_task_id])
 
 ---
 
+**Version:** 4.5.0 (July 2026) — Added the Verification Manifest (VERIFIED vs CLAIMED) — a load-bearing-claim provenance ledger that caps the verdict below READY FOR MERGE until unverified claims are re-run or waived
 **Version:** 4.4.0 (June 2026) — Added `--streak=N` consecutive-pass gate (#2540)
 
 
@@ -581,7 +597,7 @@ Verification can be blocked by policy-as-code rules. See [Policy-as-Code](../ref
 
 ---
 
-## References (10)
+## References (11)
 
 ### Alternative Comparison
 
@@ -1017,6 +1033,20 @@ Copy this template and fill in results from parallel agent verification.
 **Status**: [READY FOR MERGE | NEEDS ATTENTION | BLOCKED]
 
 [1-2 sentence summary of verification results]
+
+---
+
+## Verification Manifest
+
+> Provenance of every load-bearing claim. Any 🟡 CLAIMED or ⬜ UNCHECKED row caps the
+> status below READY FOR MERGE until it is ✅ VERIFIED or ⚪ WAIVED. See
+> `references/verification-manifest.md`.
+
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
+|---|--------------------|-------------|------------|----------------------------------|
+| 1 | [e.g. Types check clean] | [agent/tool/doc] | ✅ VERIFIED / 🟡 CLAIMED / ⬜ UNCHECKED / ⚪ WAIVED | [`cmd` · exit 0 · key line, or reason] |
+
+**Manifest impact**: [none — all load-bearing claims VERIFIED] / [verdict capped at IMPROVEMENTS RECOMMENDED — rows [N] unverified]
 
 ---
 
@@ -1521,6 +1551,109 @@ Focus: React 19, Zod, exhaustive types, skeletons, prefetch, a11y
 1. Identify uncovered files
 2. Check for excluded patterns
 3. Focus on critical paths first
+
+
+### Verification Manifest
+
+# Verification Manifest (VERIFIED vs CLAIMED)
+
+The report's agent scores, tool summaries, and every "X is fixed / clean / passing"
+sentence are **claims** until the lead independently re-runs the proof. The single
+most common verification failure is relaying an agent's assertion as a fact — a
+sub-agent reports "tsc clean", the lead copies that into the report, it ships, and it
+does **not** work.
+
+The **Verification Manifest** is a provenance ledger that closes that seam. For every
+*load-bearing* claim in the run, the lead records whether it was independently
+**VERIFIED** (with the exact command + output), merely **CLAIMED** (asserted by an
+agent / tool / doc, never re-run), or **UNCHECKED** (assumed). It is the operational
+form of the [Verification Gate](../../shared/rules/verification-gate.md) and
+[Anti-Sycophancy](../../shared/rules/anti-sycophancy.md) rules — turning "no completion
+claims without fresh evidence" from a principle into a filled-in table.
+
+## Definitions
+
+**Load-bearing claim** — one where flipping it false would change the verdict, ship a
+bug, or invalidate the merge. You do **not** manifest every trivial statement; you
+manifest the claims the merge *rests on*. If in doubt, it's load-bearing.
+
+**Provenance states**
+
+| State | Meaning | Row must include |
+|-------|---------|------------------|
+| ✅ **VERIFIED** | The **lead** ran the proof **fresh this session** and read the output. | The command · exit code · the key output line |
+| 🟡 **CLAIMED** | A sub-agent, tool summary, doc, or memory asserted it — **not** independently re-run by the lead. | Who asserted it |
+| ⬜ **UNCHECKED** | Assumed true; nobody ran a proof (e.g. "no other caller depends on this" with no grep). | Why it was assumed |
+| ⚪ **WAIVED** | A CLAIMED/UNCHECKED item deliberately accepted as non-blocking. | A one-line reason + issue ref if deferred |
+
+> An agent reporting "PASS" and the lead **copying** that into the manifest is still
+> 🟡 CLAIMED — not ✅ VERIFIED. VERIFIED means *the lead* ran it. The distinction is the
+> whole point.
+
+## The rule (wired to the verdict)
+
+> **Any load-bearing claim that is 🟡 CLAIMED or ⬜ UNCHECKED caps the verdict at
+> IMPROVEMENTS RECOMMENDED — it cannot grade READY FOR MERGE — until it is ✅ VERIFIED
+> or explicitly ⚪ WAIVED with a reason.**
+
+This sits *alongside* the dimension-level blockers (see `grading-rubric.md`): a strong
+composite score never launders an unverified load-bearing claim into "done." Both gates
+must clear. Under `--streak=N`, a run carrying any load-bearing CLAIMED/UNCHECKED item is
+not READY and therefore **resets the streak to 0** (consistent with the existing reset
+rule).
+
+## How to build it (a synthesis step, after agents return, before the verdict)
+
+1. **Enumerate claims** from three sources:
+   - **a. Agent output** — every sub-agent `approval` / score / "PASS" / "clean" /
+     "no X found" is a CLAIM by default.
+   - **b. The working narrative** — every "X is fixed / passing / done" sentence.
+   - **c. Premises the change rests on** — facts pulled from a doc, memory, or prior
+     session ("the migration already ran", "the endpoint returns Y"). Docs and memory are
+     Tier 2–4 (see the context-precedence rule): **CLAIMED until re-checked at HEAD.**
+2. **For each, decide: can I cheaply run the proof now?**
+   - Yes → run it **fresh**, capture `command · exit · key line` → ✅ VERIFIED.
+   - No → 🟡 CLAIMED / ⬜ UNCHECKED; if load-bearing, it caps the verdict (or ⚪ WAIVE it
+     with a reason).
+3. **Spend verification on the load-bearing few.** You need not re-run *everything* — you
+   need to never *present* a CLAIMED item *as* VERIFIED.
+
+## Template
+
+```markdown
+## Verification Manifest
+
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
+|---|--------------------|-------------|------------|----------------------------------|
+| 1 | Types check clean (web) | frontend-ui-developer | ✅ VERIFIED | `pnpm --filter web type-check` · exit 0 · 0 errors |
+| 2 | Unit suite green | test-generator | ✅ VERIFIED | `uv run pytest tests/unit -q` · exit 0 · 214 passed |
+| 3 | No N+1 in order_service | backend-system-architect | 🟡 CLAIMED | agent asserted; not re-run → **caps verdict** |
+| 4 | Migration a2f1b already applied | memory (2026-07-01) | ⬜ UNCHECKED | Tier-2 premise; re-check at HEAD before relying |
+| 5 | Bundle within budget | — | ⚪ WAIVED | deferred, tracked #NNNN (non-blocking) |
+
+**Manifest verdict impact:** rows 3 & 4 are load-bearing and unverified →
+verdict capped at IMPROVEMENTS RECOMMENDED until VERIFIED or WAIVED.
+```
+
+## Anti-patterns
+
+- **Laundering** — copying an agent's "PASS" into the table as ✅ VERIFIED without
+  re-running. That's CLAIMED. VERIFIED is the *lead's* fresh run.
+- **Optimism-marking** — flipping everything to ✅ to clear the gate. The manifest
+  measures honesty, not confidence. "Should be fine" is ⬜, not ✅.
+- **Convenient omission** — leaving a load-bearing claim off the table to dodge the
+  verdict cap. The omission *is* the bug the manifest exists to catch.
+- **Trusting agent numbers** — a price, model-id, cost, or count emitted by a sub-agent
+  is CLAIMED until checked against source. (Sub-agents have fabricated off-by-1000×
+  figures and retired model ids.) Central-verify before the row goes ✅.
+
+## Effort scaling
+
+| `/effort` | Manifest |
+|-----------|----------|
+| **low** (quick check) | Optional — skip unless a claim would block. |
+| **medium** | Required for any claim that would block or pass the verdict. |
+| **high** / **xhigh** | Full manifest, including doc/memory premises (source c). |
 
 
 ### Verification Phases

--- a/plugins/ork/commands/verify.md
+++ b/plugins/ork/commands/verify.md
@@ -311,6 +311,15 @@ Define verification rules in `.claude/policies/verification-policy.json`:
 ```
 
 
+## Verification Manifest (VERIFIED vs CLAIMED)
+
+Agent scores, tool summaries, and every "X is clean / passing / fixed" sentence are **claims** until the lead re-runs the proof. Before the verdict, build a **Verification Manifest** marking every *load-bearing* claim ✅ VERIFIED (lead ran it fresh — cites `command · exit · key line`), 🟡 CLAIMED (an agent/tool/doc asserted it, not re-run), ⬜ UNCHECKED, or ⚪ WAIVED (accepted non-blocking, with a reason). An agent's "PASS" copied into the report is still CLAIMED — VERIFIED means *the lead* ran it; a sub-agent's number (price, model-id, count) is CLAIMED until checked against source.
+
+> **Verdict rule:** any load-bearing claim still 🟡 CLAIMED or ⬜ UNCHECKED **caps the verdict at IMPROVEMENTS RECOMMENDED** (never READY FOR MERGE) until it is ✅ VERIFIED or ⚪ WAIVED — this stacks with the dimension-level blockers (both must clear), and under `--streak=N` it resets the streak.
+
+Protocol — claim sources, build step, template, and anti-patterns (laundering, optimism-marking, omission): `Read("${CLAUDE_SKILL_DIR}/references/verification-manifest.md")`.
+
+
 ## Report Format
 
 Load details: `Read("${CLAUDE_SKILL_DIR}/references/report-template.md")` for full format. Summary:
@@ -324,6 +333,10 @@ Load details: `Read("${CLAUDE_SKILL_DIR}/references/report-template.md")` for fu
 **[READY FOR MERGE | IMPROVEMENTS RECOMMENDED | BLOCKED]**
 
 [--streak=N mode only: **STREAK [current]/[target]** — READY FOR MERGE requires the full target; any non-ready run resets to 0.]
+
+## Verification Manifest
+[✅ VERIFIED · 🟡 CLAIMED · ⬜ UNCHECKED · ⚪ WAIVED — any load-bearing 🟡/⬜ caps the verdict below READY FOR MERGE]
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
 ```
 
 > **Push notifications (CC 2.1.110+):** Verify runs for >5 min are common on complex changes. When the final verdict is ready, call `PushNotification` to alert the user — they likely walked away from the terminal. Requires Remote Control with "Push when Claude decides" config; fails silently for users without it.
@@ -347,6 +360,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `quality-model.md` | Scoring dimensions and weights (8 unified) |
 | `grading-rubric.md` | Per-agent scoring criteria |
 | `report-template.md` | Full report format with visual evidence section |
+| `verification-manifest.md` | VERIFIED‑vs‑CLAIMED provenance ledger: states, verdict rule, claim sources, template, anti‑patterns |
 | `alternative-comparison.md` | Approach comparison template |
 | `orchestration-mode.md` | Agent Teams vs Task Tool |
 | `policy-as-code.md` | Verification policy configuration |
@@ -407,4 +421,5 @@ TaskUpdate(taskId=commit_id, addBlockedBy=[verify_task_id])
 - `browser-tools` - Browser automation for visual capture
 
 
+**Version:** 4.5.0 (July 2026) — Added the Verification Manifest (VERIFIED vs CLAIMED) — a load-bearing-claim provenance ledger that caps the verdict below READY FOR MERGE until unverified claims are re-run or waived
 **Version:** 4.4.0 (June 2026) — Added `--streak=N` consecutive-pass gate (#2540)

--- a/plugins/ork/skills/verify/SKILL.md
+++ b/plugins/ork/skills/verify/SKILL.md
@@ -5,7 +5,7 @@ compatibility: "Claude Code 2.1.183+. Requires memory MCP server."
 description: "Comprehensive verification using parallel test agents for unit tests, integration tests, E2E validation, security scanning, and type checking. Runs coverage analysis, detects regressions, and validates against project conventions. Reports pass/fail with detailed findings and coverage deltas. Use when verifying implementations, validating changes after /ork:implement, or running pre-merge quality gates."
 argument-hint: "[feature-or-scope]"
 context: fork
-version: 4.4.0
+version: 4.5.0
 author: OrchestKit
 tags: [verification, testing, quality, validation, parallel-agents, grading]
 user-invocable: true
@@ -27,7 +27,7 @@ metadata:
   category: workflow-automation
   mcp-server: memory
 triggers:
-  keywords: [verify, verifiy, validate, verification, "ready for merge", "check everything", "security scan", "give me a score", "full verification", "grade my"]
+  keywords: [verify, verifiy, validate, verification, "ready for merge", "check everything", "security scan", "give me a score", "full verification", "grade my", "verified vs claimed", "what did you actually verify", "prove it"]
   examples:
     - "verify the authentication implementation"
     - "is this feature ready for merge? check everything"
@@ -349,6 +349,16 @@ Define verification rules in `.claude/policies/verification-policy.json`:
 
 ---
 
+## Verification Manifest (VERIFIED vs CLAIMED)
+
+Agent scores, tool summaries, and every "X is clean / passing / fixed" sentence are **claims** until the lead re-runs the proof. Before the verdict, build a **Verification Manifest** marking every *load-bearing* claim ✅ VERIFIED (lead ran it fresh — cites `command · exit · key line`), 🟡 CLAIMED (an agent/tool/doc asserted it, not re-run), ⬜ UNCHECKED, or ⚪ WAIVED (accepted non-blocking, with a reason). An agent's "PASS" copied into the report is still CLAIMED — VERIFIED means *the lead* ran it; a sub-agent's number (price, model-id, count) is CLAIMED until checked against source.
+
+> **Verdict rule:** any load-bearing claim still 🟡 CLAIMED or ⬜ UNCHECKED **caps the verdict at IMPROVEMENTS RECOMMENDED** (never READY FOR MERGE) until it is ✅ VERIFIED or ⚪ WAIVED — this stacks with the dimension-level blockers (both must clear), and under `--streak=N` it resets the streak.
+
+Protocol — claim sources, build step, template, and anti-patterns (laundering, optimism-marking, omission): `Read("${CLAUDE_SKILL_DIR}/references/verification-manifest.md")`.
+
+---
+
 ## Report Format
 
 Load details: `Read("${CLAUDE_SKILL_DIR}/references/report-template.md")` for full format. Summary:
@@ -362,6 +372,10 @@ Load details: `Read("${CLAUDE_SKILL_DIR}/references/report-template.md")` for fu
 **[READY FOR MERGE | IMPROVEMENTS RECOMMENDED | BLOCKED]**
 
 [--streak=N mode only: **STREAK [current]/[target]** — READY FOR MERGE requires the full target; any non-ready run resets to 0.]
+
+## Verification Manifest
+[✅ VERIFIED · 🟡 CLAIMED · ⬜ UNCHECKED · ⚪ WAIVED — any load-bearing 🟡/⬜ caps the verdict below READY FOR MERGE]
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
 ```
 
 > **Push notifications (CC 2.1.110+):** Verify runs for >5 min are common on complex changes. When the final verdict is ready, call `PushNotification` to alert the user — they likely walked away from the terminal. Requires Remote Control with "Push when Claude decides" config; fails silently for users without it.
@@ -386,6 +400,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `quality-model.md` | Scoring dimensions and weights (8 unified) |
 | `grading-rubric.md` | Per-agent scoring criteria |
 | `report-template.md` | Full report format with visual evidence section |
+| `verification-manifest.md` | VERIFIED‑vs‑CLAIMED provenance ledger: states, verdict rule, claim sources, template, anti‑patterns |
 | `alternative-comparison.md` | Approach comparison template |
 | `orchestration-mode.md` | Agent Teams vs Task Tool |
 | `policy-as-code.md` | Verification policy configuration |
@@ -448,4 +463,5 @@ TaskUpdate(taskId=commit_id, addBlockedBy=[verify_task_id])
 
 ---
 
+**Version:** 4.5.0 (July 2026) — Added the Verification Manifest (VERIFIED vs CLAIMED) — a load-bearing-claim provenance ledger that caps the verdict below READY FOR MERGE until unverified claims are re-run or waived
 **Version:** 4.4.0 (June 2026) — Added `--streak=N` consecutive-pass gate (#2540)

--- a/plugins/ork/skills/verify/references/report-template.md
+++ b/plugins/ork/skills/verify/references/report-template.md
@@ -23,6 +23,20 @@ Copy this template and fill in results from parallel agent verification.
 
 ---
 
+## Verification Manifest
+
+> Provenance of every load-bearing claim. Any 🟡 CLAIMED or ⬜ UNCHECKED row caps the
+> status below READY FOR MERGE until it is ✅ VERIFIED or ⚪ WAIVED. See
+> `references/verification-manifest.md`.
+
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
+|---|--------------------|-------------|------------|----------------------------------|
+| 1 | [e.g. Types check clean] | [agent/tool/doc] | ✅ VERIFIED / 🟡 CLAIMED / ⬜ UNCHECKED / ⚪ WAIVED | [`cmd` · exit 0 · key line, or reason] |
+
+**Manifest impact**: [none — all load-bearing claims VERIFIED] / [verdict capped at IMPROVEMENTS RECOMMENDED — rows [N] unverified]
+
+---
+
 ## Agent Results
 
 ### 1. Code Quality (code-quality-reviewer)

--- a/plugins/ork/skills/verify/references/verification-manifest.md
+++ b/plugins/ork/skills/verify/references/verification-manifest.md
@@ -1,0 +1,99 @@
+# Verification Manifest (VERIFIED vs CLAIMED)
+
+The report's agent scores, tool summaries, and every "X is fixed / clean / passing"
+sentence are **claims** until the lead independently re-runs the proof. The single
+most common verification failure is relaying an agent's assertion as a fact — a
+sub-agent reports "tsc clean", the lead copies that into the report, it ships, and it
+does **not** work.
+
+The **Verification Manifest** is a provenance ledger that closes that seam. For every
+*load-bearing* claim in the run, the lead records whether it was independently
+**VERIFIED** (with the exact command + output), merely **CLAIMED** (asserted by an
+agent / tool / doc, never re-run), or **UNCHECKED** (assumed). It is the operational
+form of the [Verification Gate](../../shared/rules/verification-gate.md) and
+[Anti-Sycophancy](../../shared/rules/anti-sycophancy.md) rules — turning "no completion
+claims without fresh evidence" from a principle into a filled-in table.
+
+## Definitions
+
+**Load-bearing claim** — one where flipping it false would change the verdict, ship a
+bug, or invalidate the merge. You do **not** manifest every trivial statement; you
+manifest the claims the merge *rests on*. If in doubt, it's load-bearing.
+
+**Provenance states**
+
+| State | Meaning | Row must include |
+|-------|---------|------------------|
+| ✅ **VERIFIED** | The **lead** ran the proof **fresh this session** and read the output. | The command · exit code · the key output line |
+| 🟡 **CLAIMED** | A sub-agent, tool summary, doc, or memory asserted it — **not** independently re-run by the lead. | Who asserted it |
+| ⬜ **UNCHECKED** | Assumed true; nobody ran a proof (e.g. "no other caller depends on this" with no grep). | Why it was assumed |
+| ⚪ **WAIVED** | A CLAIMED/UNCHECKED item deliberately accepted as non-blocking. | A one-line reason + issue ref if deferred |
+
+> An agent reporting "PASS" and the lead **copying** that into the manifest is still
+> 🟡 CLAIMED — not ✅ VERIFIED. VERIFIED means *the lead* ran it. The distinction is the
+> whole point.
+
+## The rule (wired to the verdict)
+
+> **Any load-bearing claim that is 🟡 CLAIMED or ⬜ UNCHECKED caps the verdict at
+> IMPROVEMENTS RECOMMENDED — it cannot grade READY FOR MERGE — until it is ✅ VERIFIED
+> or explicitly ⚪ WAIVED with a reason.**
+
+This sits *alongside* the dimension-level blockers (see `grading-rubric.md`): a strong
+composite score never launders an unverified load-bearing claim into "done." Both gates
+must clear. Under `--streak=N`, a run carrying any load-bearing CLAIMED/UNCHECKED item is
+not READY and therefore **resets the streak to 0** (consistent with the existing reset
+rule).
+
+## How to build it (a synthesis step, after agents return, before the verdict)
+
+1. **Enumerate claims** from three sources:
+   - **a. Agent output** — every sub-agent `approval` / score / "PASS" / "clean" /
+     "no X found" is a CLAIM by default.
+   - **b. The working narrative** — every "X is fixed / passing / done" sentence.
+   - **c. Premises the change rests on** — facts pulled from a doc, memory, or prior
+     session ("the migration already ran", "the endpoint returns Y"). Docs and memory are
+     Tier 2–4 (see the context-precedence rule): **CLAIMED until re-checked at HEAD.**
+2. **For each, decide: can I cheaply run the proof now?**
+   - Yes → run it **fresh**, capture `command · exit · key line` → ✅ VERIFIED.
+   - No → 🟡 CLAIMED / ⬜ UNCHECKED; if load-bearing, it caps the verdict (or ⚪ WAIVE it
+     with a reason).
+3. **Spend verification on the load-bearing few.** You need not re-run *everything* — you
+   need to never *present* a CLAIMED item *as* VERIFIED.
+
+## Template
+
+```markdown
+## Verification Manifest
+
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
+|---|--------------------|-------------|------------|----------------------------------|
+| 1 | Types check clean (web) | frontend-ui-developer | ✅ VERIFIED | `pnpm --filter web type-check` · exit 0 · 0 errors |
+| 2 | Unit suite green | test-generator | ✅ VERIFIED | `uv run pytest tests/unit -q` · exit 0 · 214 passed |
+| 3 | No N+1 in order_service | backend-system-architect | 🟡 CLAIMED | agent asserted; not re-run → **caps verdict** |
+| 4 | Migration a2f1b already applied | memory (2026-07-01) | ⬜ UNCHECKED | Tier-2 premise; re-check at HEAD before relying |
+| 5 | Bundle within budget | — | ⚪ WAIVED | deferred, tracked #NNNN (non-blocking) |
+
+**Manifest verdict impact:** rows 3 & 4 are load-bearing and unverified →
+verdict capped at IMPROVEMENTS RECOMMENDED until VERIFIED or WAIVED.
+```
+
+## Anti-patterns
+
+- **Laundering** — copying an agent's "PASS" into the table as ✅ VERIFIED without
+  re-running. That's CLAIMED. VERIFIED is the *lead's* fresh run.
+- **Optimism-marking** — flipping everything to ✅ to clear the gate. The manifest
+  measures honesty, not confidence. "Should be fine" is ⬜, not ✅.
+- **Convenient omission** — leaving a load-bearing claim off the table to dodge the
+  verdict cap. The omission *is* the bug the manifest exists to catch.
+- **Trusting agent numbers** — a price, model-id, cost, or count emitted by a sub-agent
+  is CLAIMED until checked against source. (Sub-agents have fabricated off-by-1000×
+  figures and retired model ids.) Central-verify before the row goes ✅.
+
+## Effort scaling
+
+| `/effort` | Manifest |
+|-----------|----------|
+| **low** (quick check) | Optional — skip unless a claim would block. |
+| **medium** | Required for any claim that would block or pass the verdict. |
+| **high** / **xhigh** | Full manifest, including doc/memory premises (source c). |

--- a/src/skills/verify/SKILL.md
+++ b/src/skills/verify/SKILL.md
@@ -5,7 +5,7 @@ compatibility: "Claude Code 2.1.183+. Requires memory MCP server."
 description: "Comprehensive verification using parallel test agents for unit tests, integration tests, E2E validation, security scanning, and type checking. Runs coverage analysis, detects regressions, and validates against project conventions. Reports pass/fail with detailed findings and coverage deltas. Use when verifying implementations, validating changes after /ork:implement, or running pre-merge quality gates."
 argument-hint: "[feature-or-scope]"
 context: fork
-version: 4.4.0
+version: 4.5.0
 author: OrchestKit
 tags: [verification, testing, quality, validation, parallel-agents, grading]
 user-invocable: true
@@ -27,7 +27,7 @@ metadata:
   category: workflow-automation
   mcp-server: memory
 triggers:
-  keywords: [verify, verifiy, validate, verification, "ready for merge", "check everything", "security scan", "give me a score", "full verification", "grade my"]
+  keywords: [verify, verifiy, validate, verification, "ready for merge", "check everything", "security scan", "give me a score", "full verification", "grade my", "verified vs claimed", "what did you actually verify", "prove it"]
   examples:
     - "verify the authentication implementation"
     - "is this feature ready for merge? check everything"
@@ -349,6 +349,16 @@ Define verification rules in `.claude/policies/verification-policy.json`:
 
 ---
 
+## Verification Manifest (VERIFIED vs CLAIMED)
+
+Agent scores, tool summaries, and every "X is clean / passing / fixed" sentence are **claims** until the lead re-runs the proof. Before the verdict, build a **Verification Manifest** marking every *load-bearing* claim ✅ VERIFIED (lead ran it fresh — cites `command · exit · key line`), 🟡 CLAIMED (an agent/tool/doc asserted it, not re-run), ⬜ UNCHECKED, or ⚪ WAIVED (accepted non-blocking, with a reason). An agent's "PASS" copied into the report is still CLAIMED — VERIFIED means *the lead* ran it; a sub-agent's number (price, model-id, count) is CLAIMED until checked against source.
+
+> **Verdict rule:** any load-bearing claim still 🟡 CLAIMED or ⬜ UNCHECKED **caps the verdict at IMPROVEMENTS RECOMMENDED** (never READY FOR MERGE) until it is ✅ VERIFIED or ⚪ WAIVED — this stacks with the dimension-level blockers (both must clear), and under `--streak=N` it resets the streak.
+
+Protocol — claim sources, build step, template, and anti-patterns (laundering, optimism-marking, omission): `Read("${CLAUDE_SKILL_DIR}/references/verification-manifest.md")`.
+
+---
+
 ## Report Format
 
 Load details: `Read("${CLAUDE_SKILL_DIR}/references/report-template.md")` for full format. Summary:
@@ -362,6 +372,10 @@ Load details: `Read("${CLAUDE_SKILL_DIR}/references/report-template.md")` for fu
 **[READY FOR MERGE | IMPROVEMENTS RECOMMENDED | BLOCKED]**
 
 [--streak=N mode only: **STREAK [current]/[target]** — READY FOR MERGE requires the full target; any non-ready run resets to 0.]
+
+## Verification Manifest
+[✅ VERIFIED · 🟡 CLAIMED · ⬜ UNCHECKED · ⚪ WAIVED — any load-bearing 🟡/⬜ caps the verdict below READY FOR MERGE]
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
 ```
 
 > **Push notifications (CC 2.1.110+):** Verify runs for >5 min are common on complex changes. When the final verdict is ready, call `PushNotification` to alert the user — they likely walked away from the terminal. Requires Remote Control with "Push when Claude decides" config; fails silently for users without it.
@@ -386,6 +400,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `quality-model.md` | Scoring dimensions and weights (8 unified) |
 | `grading-rubric.md` | Per-agent scoring criteria |
 | `report-template.md` | Full report format with visual evidence section |
+| `verification-manifest.md` | VERIFIED‑vs‑CLAIMED provenance ledger: states, verdict rule, claim sources, template, anti‑patterns |
 | `alternative-comparison.md` | Approach comparison template |
 | `orchestration-mode.md` | Agent Teams vs Task Tool |
 | `policy-as-code.md` | Verification policy configuration |
@@ -448,4 +463,5 @@ TaskUpdate(taskId=commit_id, addBlockedBy=[verify_task_id])
 
 ---
 
+**Version:** 4.5.0 (July 2026) — Added the Verification Manifest (VERIFIED vs CLAIMED) — a load-bearing-claim provenance ledger that caps the verdict below READY FOR MERGE until unverified claims are re-run or waived
 **Version:** 4.4.0 (June 2026) — Added `--streak=N` consecutive-pass gate (#2540)

--- a/src/skills/verify/references/report-template.md
+++ b/src/skills/verify/references/report-template.md
@@ -23,6 +23,20 @@ Copy this template and fill in results from parallel agent verification.
 
 ---
 
+## Verification Manifest
+
+> Provenance of every load-bearing claim. Any 🟡 CLAIMED or ⬜ UNCHECKED row caps the
+> status below READY FOR MERGE until it is ✅ VERIFIED or ⚪ WAIVED. See
+> `references/verification-manifest.md`.
+
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
+|---|--------------------|-------------|------------|----------------------------------|
+| 1 | [e.g. Types check clean] | [agent/tool/doc] | ✅ VERIFIED / 🟡 CLAIMED / ⬜ UNCHECKED / ⚪ WAIVED | [`cmd` · exit 0 · key line, or reason] |
+
+**Manifest impact**: [none — all load-bearing claims VERIFIED] / [verdict capped at IMPROVEMENTS RECOMMENDED — rows [N] unverified]
+
+---
+
 ## Agent Results
 
 ### 1. Code Quality (code-quality-reviewer)

--- a/src/skills/verify/references/verification-manifest.md
+++ b/src/skills/verify/references/verification-manifest.md
@@ -1,0 +1,99 @@
+# Verification Manifest (VERIFIED vs CLAIMED)
+
+The report's agent scores, tool summaries, and every "X is fixed / clean / passing"
+sentence are **claims** until the lead independently re-runs the proof. The single
+most common verification failure is relaying an agent's assertion as a fact — a
+sub-agent reports "tsc clean", the lead copies that into the report, it ships, and it
+does **not** work.
+
+The **Verification Manifest** is a provenance ledger that closes that seam. For every
+*load-bearing* claim in the run, the lead records whether it was independently
+**VERIFIED** (with the exact command + output), merely **CLAIMED** (asserted by an
+agent / tool / doc, never re-run), or **UNCHECKED** (assumed). It is the operational
+form of the [Verification Gate](../../shared/rules/verification-gate.md) and
+[Anti-Sycophancy](../../shared/rules/anti-sycophancy.md) rules — turning "no completion
+claims without fresh evidence" from a principle into a filled-in table.
+
+## Definitions
+
+**Load-bearing claim** — one where flipping it false would change the verdict, ship a
+bug, or invalidate the merge. You do **not** manifest every trivial statement; you
+manifest the claims the merge *rests on*. If in doubt, it's load-bearing.
+
+**Provenance states**
+
+| State | Meaning | Row must include |
+|-------|---------|------------------|
+| ✅ **VERIFIED** | The **lead** ran the proof **fresh this session** and read the output. | The command · exit code · the key output line |
+| 🟡 **CLAIMED** | A sub-agent, tool summary, doc, or memory asserted it — **not** independently re-run by the lead. | Who asserted it |
+| ⬜ **UNCHECKED** | Assumed true; nobody ran a proof (e.g. "no other caller depends on this" with no grep). | Why it was assumed |
+| ⚪ **WAIVED** | A CLAIMED/UNCHECKED item deliberately accepted as non-blocking. | A one-line reason + issue ref if deferred |
+
+> An agent reporting "PASS" and the lead **copying** that into the manifest is still
+> 🟡 CLAIMED — not ✅ VERIFIED. VERIFIED means *the lead* ran it. The distinction is the
+> whole point.
+
+## The rule (wired to the verdict)
+
+> **Any load-bearing claim that is 🟡 CLAIMED or ⬜ UNCHECKED caps the verdict at
+> IMPROVEMENTS RECOMMENDED — it cannot grade READY FOR MERGE — until it is ✅ VERIFIED
+> or explicitly ⚪ WAIVED with a reason.**
+
+This sits *alongside* the dimension-level blockers (see `grading-rubric.md`): a strong
+composite score never launders an unverified load-bearing claim into "done." Both gates
+must clear. Under `--streak=N`, a run carrying any load-bearing CLAIMED/UNCHECKED item is
+not READY and therefore **resets the streak to 0** (consistent with the existing reset
+rule).
+
+## How to build it (a synthesis step, after agents return, before the verdict)
+
+1. **Enumerate claims** from three sources:
+   - **a. Agent output** — every sub-agent `approval` / score / "PASS" / "clean" /
+     "no X found" is a CLAIM by default.
+   - **b. The working narrative** — every "X is fixed / passing / done" sentence.
+   - **c. Premises the change rests on** — facts pulled from a doc, memory, or prior
+     session ("the migration already ran", "the endpoint returns Y"). Docs and memory are
+     Tier 2–4 (see the context-precedence rule): **CLAIMED until re-checked at HEAD.**
+2. **For each, decide: can I cheaply run the proof now?**
+   - Yes → run it **fresh**, capture `command · exit · key line` → ✅ VERIFIED.
+   - No → 🟡 CLAIMED / ⬜ UNCHECKED; if load-bearing, it caps the verdict (or ⚪ WAIVE it
+     with a reason).
+3. **Spend verification on the load-bearing few.** You need not re-run *everything* — you
+   need to never *present* a CLAIMED item *as* VERIFIED.
+
+## Template
+
+```markdown
+## Verification Manifest
+
+| # | Load-bearing claim | Asserted by | Provenance | Evidence (cmd · exit · key line) |
+|---|--------------------|-------------|------------|----------------------------------|
+| 1 | Types check clean (web) | frontend-ui-developer | ✅ VERIFIED | `pnpm --filter web type-check` · exit 0 · 0 errors |
+| 2 | Unit suite green | test-generator | ✅ VERIFIED | `uv run pytest tests/unit -q` · exit 0 · 214 passed |
+| 3 | No N+1 in order_service | backend-system-architect | 🟡 CLAIMED | agent asserted; not re-run → **caps verdict** |
+| 4 | Migration a2f1b already applied | memory (2026-07-01) | ⬜ UNCHECKED | Tier-2 premise; re-check at HEAD before relying |
+| 5 | Bundle within budget | — | ⚪ WAIVED | deferred, tracked #NNNN (non-blocking) |
+
+**Manifest verdict impact:** rows 3 & 4 are load-bearing and unverified →
+verdict capped at IMPROVEMENTS RECOMMENDED until VERIFIED or WAIVED.
+```
+
+## Anti-patterns
+
+- **Laundering** — copying an agent's "PASS" into the table as ✅ VERIFIED without
+  re-running. That's CLAIMED. VERIFIED is the *lead's* fresh run.
+- **Optimism-marking** — flipping everything to ✅ to clear the gate. The manifest
+  measures honesty, not confidence. "Should be fine" is ⬜, not ✅.
+- **Convenient omission** — leaving a load-bearing claim off the table to dodge the
+  verdict cap. The omission *is* the bug the manifest exists to catch.
+- **Trusting agent numbers** — a price, model-id, cost, or count emitted by a sub-agent
+  is CLAIMED until checked against source. (Sub-agents have fabricated off-by-1000×
+  figures and retired model ids.) Central-verify before the row goes ✅.
+
+## Effort scaling
+
+| `/effort` | Manifest |
+|-----------|----------|
+| **low** (quick check) | Optional — skip unless a claim would block. |
+| **medium** | Required for any claim that would block or pass the verdict. |
+| **high** / **xhigh** | Full manifest, including doc/memory premises (source c). |


### PR DESCRIPTION
## What

Adds a **Verification Manifest (VERIFIED vs CLAIMED)** to `/ork:verify` — a per-claim provenance ledger that gates the verdict. It operationalizes the existing [Verification Gate](../blob/main/src/skills/shared/rules/verification-gate.md) (a principle) into a filled-in artifact (a table).

For every **load-bearing** claim in a verification run, the lead marks it:

| State | Meaning |
|---|---|
| ✅ VERIFIED | the **lead** re-ran the proof fresh, cites `command · exit · key line` |
| 🟡 CLAIMED | an agent/tool/doc asserted it — not independently re-run |
| ⬜ UNCHECKED | assumed true, no proof run |
| ⚪ WAIVED | accepted non-blocking, with a reason |

> **Verdict rule:** any load-bearing 🟡/⬜ claim caps the verdict at IMPROVEMENTS RECOMMENDED (never READY FOR MERGE) until VERIFIED or WAIVED — stacks with the dimension-level blockers, and resets `--streak`.

## Why

The single most common verification failure is **relaying an agent's assertion as a fact** — a sub-agent reports "tsc clean", it's copied into the report, it ships, it doesn't work. Same class: fabricated agent numbers (off-by-1000× costs, retired model-ids), stale-doc premises. The manifest forces the distinction *the lead ran it* vs *something asserted it*, and won't let a green composite launder an unverified claim into "done."

Inspired by Thariq's "Finding Your Unknowns" field guide (the "Quiz Me Before I Merge" artifact) — repurposed from testing the *human's* comprehension to auditing the *agents'* claims.

## Changed

- **new** `references/verification-manifest.md` — states, verdict rule, claim sources (agent output · narrative · doc/memory premises), template, anti-patterns
- `SKILL.md` — manifest section + verdict wiring + report-summary row + refs entry; `verify 4.4.0 → 4.5.0`
- `references/report-template.md` — manifest table after Summary
- `plugins/` rebuilt from `src/` (skills mirror + regenerated `commands/verify.md`)

## Verification Manifest (dogfooded — this PR verifying itself)

| # | Load-bearing claim | Asserted by | Provenance | Evidence |
|---|--------------------|-------------|------------|----------|
| 1 | Skill length within limit | length gate | ✅ VERIFIED | `bash tests/skills/test-skill-length.sh` · exit 0 · verify 467 ≤ 520, Failed: 0 |
| 2 | SKILL.md structure valid | structure gate | ✅ VERIFIED | `bash tests/skills/structure/test-skill-md.sh` · "SUCCESS: All critical tests passed", Failed: 0 |
| 3 | Token hard-ceiling not tripped | tokens gate | ✅ VERIFIED | ceiling 8000, `offender_count: 0`; verify 5670 < 8000. (5000 is a soft WARN only) |
| 4 | Token WARN is pre-existing, not introduced | — | ✅ VERIFIED | origin/main verify ≈ 5216 tok (> 5000 before this change); delta +453 after trim |
| 5 | Directive-density gate passes | density gate | ✅ VERIFIED | `test-directive-density.sh` · exit 0 |
| 6 | `src/` and `plugins/` skill copies identical | — | ✅ VERIFIED | `diff -r src/skills/verify plugins/ork/skills/verify` · identical |
| 7 | `commands/verify.md` matches build output | build logic | ✅ VERIFIED | regenerated via `build-plugins.sh`'s exact `generate_command_from_skill` logic; diff = only the added manifest lines |
| 8 | Cross-language parity clean | parity gate | 🟡 CLAIMED | `parity-check.py` exit 1 **locally = "npm package not built"** (depless worktree), not a content failure; change touches no parity surface. Re-verify in CI. |

**Manifest impact:** row 8 is CLAIMED (blocked by local env, not the change) → confirm green in CI before merge; all other load-bearing claims VERIFIED.
