### PR TITLE
feat(implement): add Step 0b blast-radius clarification interview

### DIFF
--- a/docs/site/content/docs/reference/skills/implement.mdx
+++ b/docs/site/content/docs/reference/skills/implement.mdx
@@ -191,6 +191,12 @@ Load worktree details: `Read("$\{CLAUDE_SKILL_DIR\}/references/worktree-isolatio
 
 ---
 
+## Step 0b: Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, resolve the unknowns whose answers would **change the architecture**, in blast-radius order — schema/migration → auth → API contract → perf/scale → cosmetics (last). Grep first, then `AskUserQuestion` one at a time (highest first, cap ~5, skip the obvious). Each answer becomes a row in a Decisions table written to `.claude/chain/decisions.json` and the PR body, feeding Phase 4 (Architecture) as constraints. Do NOT start Phase 1 with an unresolved schema/auth question; skip in `low` effort. Full protocol: `Read("$\{CLAUDE_SKILL_DIR\}/references/blast-radius-clarification.md")`.
+
+---
+
 ## Task Management (MANDATORY)
 
 **BEFORE doing ANYTHING else, create tasks to track progress:**
@@ -298,24 +304,7 @@ Agent(subagent_type="ork:test-generator", run_in_background=true, ...)
 
 Full pattern reference (when to use vs. `TaskOutput`, until-condition gates, partial-result salvage, anti-patterns): `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/chain-patterns/references/monitor-patterns.md")`.
 
-**Partial results (CC 2.1.98):** Background agents that fail now report partial progress to the parent. If a worktree-isolated agent crashes mid-implementation, synthesize its partial output instead of re-spawning:
-
-```python
-# After collecting agent results:
-for agent_result in agent_results:
-    if "[PARTIAL RESULT]" in agent_result.output:
-        # Agent crashed mid-work — salvage what it produced
-        partial_files = Bash(command="git diff --name-only", cwd=agent_result.worktree)
-        if partial_files:
-            # Merge partial work — commit what's usable, flag incomplete items
-            TaskUpdate(taskId=agent_task_id, status="completed",
-                       description=f"Partial: {len(partial_files)} files from crashed agent")
-        # Do NOT re-spawn — partial progress > wasted tokens re-doing work
-    elif agent_result.status == "BLOCKED":
-        # Agent hit a genuine blocker — escalate to user
-        TaskUpdate(taskId=agent_task_id, status="in_progress",
-                   description=f"BLOCKED: {agent_result.concerns[0]}")
-```
+**Partial results (CC 2.1.98):** if a worktree-isolated agent crashes mid-implementation, salvage its partial output — `git diff --name-only` in its worktree, commit what's usable, flag incomplete items — instead of re-spawning; escalate a `BLOCKED` agent to the user. Full salvage logic: the monitor-patterns reference above.
 
 ### Worktree-Isolated Implementation (CC 2.1.50)
 
@@ -477,6 +466,7 @@ Load on demand with `Read("$\{CLAUDE_SKILL_DIR\}/references/&lt;file&gt;")`:
 | `agent-phases.md` | Agent prompts and spawn templates |
 | `agent-teams-phases.md` | Agent Teams mode phases |
 | `interview-mode.md` | Interview/take-home constraints |
+| `blast-radius-clarification.md` | Step 0b: ask-what-before-how blast-radius interview + decisions table |
 | `orchestration-modes.md` | Task tool vs Agent Teams selection |
 | `feedback-loop.md` | Checkpoint triggers and actions |
 | `cc-enhancements.md` | CC version-specific features |
@@ -951,7 +941,7 @@ git worktree list
 
 ---
 
-## References (17)
+## References (18)
 
 ### Agent Phases
 
@@ -2090,6 +2080,71 @@ Track actual values to validate.
 - **Use Agent Teams** when auditors need to cross-reference findings in real-time
 - **Use Task Tool** for quick, independent audits (single agent sufficient)
 - **Complexity threshold:** Average score >= 3.0 across 7 dimensions
+
+
+### Blast Radius Clarification
+
+# Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, find the unknowns whose answers would **change the architecture** and
+resolve them in blast-radius order — biggest consequence first. The cheapest place to
+settle an ambiguity is before code exists; the same ambiguity found mid-build is a
+rework, and found post-merge is an incident. This is "ask what before you ask how" made
+into a step.
+
+## When to run
+
+- Runs as **Step 0b**, after context discovery / worktree (Step 0a) and BEFORE Task
+  Management + Phase 1.
+- **Skip** in `low` effort, or when the feature is small and unambiguous (&lt; ~3 files, no
+  schema / auth / contract surface).
+- **Grep the codebase first** — never ask a question the code already answers.
+
+## Blast-radius order (ask highest first; skip any tier already unambiguous)
+
+| # | Tier | Why it's high blast-radius | Example question |
+|---|------|----------------------------|------------------|
+| 1 | Data model / schema / migration | An answer reshapes every downstream layer | "New table, or a column on `&lt;Y&gt;`? Nullable? Backfill?" |
+| 2 | Auth / security / trust boundary | Sets who can act + the threat model | "Who calls this — portal user, admin, service token?" |
+| 3 | API contract / breaking change | Ripples to every consumer | "Change an existing response shape, or add a new endpoint?" |
+| 4 | Data volume / performance / scale | Sets the algorithm + index strategy | "Expected cardinality / hot path / concurrency?" |
+| 5 | UX / copy / cosmetics | Cheap to change later — ask LAST | "Inline panel or modal?" |
+
+## Protocol
+
+1. One question at a time via `AskUserQuestion`, **highest blast-radius first**.
+2. Ask ONLY the genuinely ambiguous, high-blast-radius items — not the obvious ones. Stop
+   as soon as the remaining unknowns are low-blast-radius / cosmetic. **Cap ~5.**
+3. Each answer becomes a row in the Decisions table.
+4. Write the table to `.claude/chain/decisions.json` and surface it in the **PR body**
+   (Phase 9 documentation) so the "why" lands where reviewers see it.
+5. Feed the schema / auth / contract answers into **Phase 4 (Architecture)** as
+   constraints — they are inputs to the architecture agents, not afterthoughts.
+
+## Decisions table (written to state + PR body)
+
+```markdown
+## Decisions (blast-radius clarification)
+| # | Question | Decision | Blast radius | Rationale |
+|---|----------|----------|--------------|-----------|
+| 1 | New table or column on projects? | new `project_metric` table | schema | needs its own lifecycle + FK |
+| 2 | Who can write it? | admin + service token only | auth | portal users are read-only here |
+```
+
+## Why (the failure classes this closes)
+
+- **"Start solo → 3 interrupts"** — the operator gets pulled in three separate times
+  mid-build for questions a two-minute up-front interview would have batched.
+- **Premature architecture / root-cause commitment** — building on an unstated schema or
+  auth assumption, then discovering it was wrong after the architecture is set.
+
+## Anti-patterns
+
+- Asking cosmetic questions first — spends the user's attention on the cheapest unknowns.
+- Interrogating the obvious, or asking what the codebase already answers (grep first).
+- Asking everything → analysis paralysis. Cap and stop at low blast-radius.
+- Proceeding on an ambiguous **schema or auth** question — the exact rework this step
+  exists to prevent. If a tier-1/2 unknown is unresolved, do NOT start Phase 1.
 
 
 ### Cc Enhancements

--- a/plugins/ork/commands/implement.md
+++ b/plugins/ork/commands/implement.md
@@ -179,6 +179,11 @@ If worktree selected:
 Load worktree details: `Read("${CLAUDE_SKILL_DIR}/references/worktree-isolation-mode.md")`
 
 
+## Step 0b: Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, resolve the unknowns whose answers would **change the architecture**, in blast-radius order — schema/migration → auth → API contract → perf/scale → cosmetics (last). Grep first, then `AskUserQuestion` one at a time (highest first, cap ~5, skip the obvious). Each answer becomes a row in a Decisions table written to `.claude/chain/decisions.json` and the PR body, feeding Phase 4 (Architecture) as constraints. Do NOT start Phase 1 with an unresolved schema/auth question; skip in `low` effort. Full protocol: `Read("${CLAUDE_SKILL_DIR}/references/blast-radius-clarification.md")`.
+
+
 ## Task Management (MANDATORY)
 
 **BEFORE doing ANYTHING else, create tasks to track progress:**
@@ -285,24 +290,7 @@ Agent(subagent_type="ork:test-generator", run_in_background=true, ...)
 
 Full pattern reference (when to use vs. `TaskOutput`, until-condition gates, partial-result salvage, anti-patterns): `Read("${CLAUDE_PLUGIN_ROOT}/skills/chain-patterns/references/monitor-patterns.md")`.
 
-**Partial results (CC 2.1.98):** Background agents that fail now report partial progress to the parent. If a worktree-isolated agent crashes mid-implementation, synthesize its partial output instead of re-spawning:
-
-```python
-# After collecting agent results:
-for agent_result in agent_results:
-    if "[PARTIAL RESULT]" in agent_result.output:
-        # Agent crashed mid-work — salvage what it produced
-        partial_files = Bash(command="git diff --name-only", cwd=agent_result.worktree)
-        if partial_files:
-            # Merge partial work — commit what's usable, flag incomplete items
-            TaskUpdate(taskId=agent_task_id, status="completed",
-                       description=f"Partial: {len(partial_files)} files from crashed agent")
-        # Do NOT re-spawn — partial progress > wasted tokens re-doing work
-    elif agent_result.status == "BLOCKED":
-        # Agent hit a genuine blocker — escalate to user
-        TaskUpdate(taskId=agent_task_id, status="in_progress",
-                   description=f"BLOCKED: {agent_result.concerns[0]}")
-```
+**Partial results (CC 2.1.98):** if a worktree-isolated agent crashes mid-implementation, salvage its partial output — `git diff --name-only` in its worktree, commit what's usable, flag incomplete items — instead of re-spawning; escalate a `BLOCKED` agent to the user. Full salvage logic: the monitor-patterns reference above.
 
 ### Worktree-Isolated Implementation (CC 2.1.50)
 
@@ -461,6 +449,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `agent-phases.md` | Agent prompts and spawn templates |
 | `agent-teams-phases.md` | Agent Teams mode phases |
 | `interview-mode.md` | Interview/take-home constraints |
+| `blast-radius-clarification.md` | Step 0b: ask-what-before-how blast-radius interview + decisions table |
 | `orchestration-modes.md` | Task tool vs Agent Teams selection |
 | `feedback-loop.md` | Checkpoint triggers and actions |
 | `cc-enhancements.md` | CC version-specific features |

--- a/plugins/ork/skills/implement/SKILL.md
+++ b/plugins/ork/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ compatibility: "Claude Code 2.1.183+. Requires memory MCP server, context7 MCP s
 description: "Full-power feature implementation using parallel subagents for backend, frontend, testing, and security. Coordinates architecture design, code generation, test coverage, and quality verification in a single workflow with worktree isolation. Chains with /ork:cover for test generation and /ork:verify for validation. Use when implementing features, building new capabilities, or creating full-stack functionality."
 argument-hint: "[feature-description]"
 context: fork
-version: 2.7.0
+version: 2.8.0
 disable-model-invocation: true  # M127 A/S5: slash-only — explicit /ork:implement only
 author: OrchestKit
 tags: [implementation, feature, full-stack, parallel-agents, reflection, worktree]
@@ -220,6 +220,12 @@ Load worktree details: `Read("${CLAUDE_SKILL_DIR}/references/worktree-isolation-
 
 ---
 
+## Step 0b: Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, resolve the unknowns whose answers would **change the architecture**, in blast-radius order — schema/migration → auth → API contract → perf/scale → cosmetics (last). Grep first, then `AskUserQuestion` one at a time (highest first, cap ~5, skip the obvious). Each answer becomes a row in a Decisions table written to `.claude/chain/decisions.json` and the PR body, feeding Phase 4 (Architecture) as constraints. Do NOT start Phase 1 with an unresolved schema/auth question; skip in `low` effort. Full protocol: `Read("${CLAUDE_SKILL_DIR}/references/blast-radius-clarification.md")`.
+
+---
+
 ## Task Management (MANDATORY)
 
 **BEFORE doing ANYTHING else, create tasks to track progress:**
@@ -327,24 +333,7 @@ Agent(subagent_type="ork:test-generator", run_in_background=true, ...)
 
 Full pattern reference (when to use vs. `TaskOutput`, until-condition gates, partial-result salvage, anti-patterns): `Read("${CLAUDE_PLUGIN_ROOT}/skills/chain-patterns/references/monitor-patterns.md")`.
 
-**Partial results (CC 2.1.98):** Background agents that fail now report partial progress to the parent. If a worktree-isolated agent crashes mid-implementation, synthesize its partial output instead of re-spawning:
-
-```python
-# After collecting agent results:
-for agent_result in agent_results:
-    if "[PARTIAL RESULT]" in agent_result.output:
-        # Agent crashed mid-work — salvage what it produced
-        partial_files = Bash(command="git diff --name-only", cwd=agent_result.worktree)
-        if partial_files:
-            # Merge partial work — commit what's usable, flag incomplete items
-            TaskUpdate(taskId=agent_task_id, status="completed",
-                       description=f"Partial: {len(partial_files)} files from crashed agent")
-        # Do NOT re-spawn — partial progress > wasted tokens re-doing work
-    elif agent_result.status == "BLOCKED":
-        # Agent hit a genuine blocker — escalate to user
-        TaskUpdate(taskId=agent_task_id, status="in_progress",
-                   description=f"BLOCKED: {agent_result.concerns[0]}")
-```
+**Partial results (CC 2.1.98):** if a worktree-isolated agent crashes mid-implementation, salvage its partial output — `git diff --name-only` in its worktree, commit what's usable, flag incomplete items — instead of re-spawning; escalate a `BLOCKED` agent to the user. Full salvage logic: the monitor-patterns reference above.
 
 ### Worktree-Isolated Implementation (CC 2.1.50)
 
@@ -506,6 +495,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `agent-phases.md` | Agent prompts and spawn templates |
 | `agent-teams-phases.md` | Agent Teams mode phases |
 | `interview-mode.md` | Interview/take-home constraints |
+| `blast-radius-clarification.md` | Step 0b: ask-what-before-how blast-radius interview + decisions table |
 | `orchestration-modes.md` | Task tool vs Agent Teams selection |
 | `feedback-loop.md` | Checkpoint triggers and actions |
 | `cc-enhancements.md` | CC version-specific features |

--- a/plugins/ork/skills/implement/references/blast-radius-clarification.md
+++ b/plugins/ork/skills/implement/references/blast-radius-clarification.md
@@ -1,0 +1,61 @@
+# Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, find the unknowns whose answers would **change the architecture** and
+resolve them in blast-radius order — biggest consequence first. The cheapest place to
+settle an ambiguity is before code exists; the same ambiguity found mid-build is a
+rework, and found post-merge is an incident. This is "ask what before you ask how" made
+into a step.
+
+## When to run
+
+- Runs as **Step 0b**, after context discovery / worktree (Step 0a) and BEFORE Task
+  Management + Phase 1.
+- **Skip** in `low` effort, or when the feature is small and unambiguous (< ~3 files, no
+  schema / auth / contract surface).
+- **Grep the codebase first** — never ask a question the code already answers.
+
+## Blast-radius order (ask highest first; skip any tier already unambiguous)
+
+| # | Tier | Why it's high blast-radius | Example question |
+|---|------|----------------------------|------------------|
+| 1 | Data model / schema / migration | An answer reshapes every downstream layer | "New table, or a column on `<Y>`? Nullable? Backfill?" |
+| 2 | Auth / security / trust boundary | Sets who can act + the threat model | "Who calls this — portal user, admin, service token?" |
+| 3 | API contract / breaking change | Ripples to every consumer | "Change an existing response shape, or add a new endpoint?" |
+| 4 | Data volume / performance / scale | Sets the algorithm + index strategy | "Expected cardinality / hot path / concurrency?" |
+| 5 | UX / copy / cosmetics | Cheap to change later — ask LAST | "Inline panel or modal?" |
+
+## Protocol
+
+1. One question at a time via `AskUserQuestion`, **highest blast-radius first**.
+2. Ask ONLY the genuinely ambiguous, high-blast-radius items — not the obvious ones. Stop
+   as soon as the remaining unknowns are low-blast-radius / cosmetic. **Cap ~5.**
+3. Each answer becomes a row in the Decisions table.
+4. Write the table to `.claude/chain/decisions.json` and surface it in the **PR body**
+   (Phase 9 documentation) so the "why" lands where reviewers see it.
+5. Feed the schema / auth / contract answers into **Phase 4 (Architecture)** as
+   constraints — they are inputs to the architecture agents, not afterthoughts.
+
+## Decisions table (written to state + PR body)
+
+```markdown
+## Decisions (blast-radius clarification)
+| # | Question | Decision | Blast radius | Rationale |
+|---|----------|----------|--------------|-----------|
+| 1 | New table or column on projects? | new `project_metric` table | schema | needs its own lifecycle + FK |
+| 2 | Who can write it? | admin + service token only | auth | portal users are read-only here |
+```
+
+## Why (the failure classes this closes)
+
+- **"Start solo → 3 interrupts"** — the operator gets pulled in three separate times
+  mid-build for questions a two-minute up-front interview would have batched.
+- **Premature architecture / root-cause commitment** — building on an unstated schema or
+  auth assumption, then discovering it was wrong after the architecture is set.
+
+## Anti-patterns
+
+- Asking cosmetic questions first — spends the user's attention on the cheapest unknowns.
+- Interrogating the obvious, or asking what the codebase already answers (grep first).
+- Asking everything → analysis paralysis. Cap and stop at low blast-radius.
+- Proceeding on an ambiguous **schema or auth** question — the exact rework this step
+  exists to prevent. If a tier-1/2 unknown is unresolved, do NOT start Phase 1.

--- a/src/skills/implement/SKILL.md
+++ b/src/skills/implement/SKILL.md
@@ -5,7 +5,7 @@ compatibility: "Claude Code 2.1.183+. Requires memory MCP server, context7 MCP s
 description: "Full-power feature implementation using parallel subagents for backend, frontend, testing, and security. Coordinates architecture design, code generation, test coverage, and quality verification in a single workflow with worktree isolation. Chains with /ork:cover for test generation and /ork:verify for validation. Use when implementing features, building new capabilities, or creating full-stack functionality."
 argument-hint: "[feature-description]"
 context: fork
-version: 2.7.0
+version: 2.8.0
 disable-model-invocation: true  # M127 A/S5: slash-only — explicit /ork:implement only
 author: OrchestKit
 tags: [implementation, feature, full-stack, parallel-agents, reflection, worktree]
@@ -220,6 +220,12 @@ Load worktree details: `Read("${CLAUDE_SKILL_DIR}/references/worktree-isolation-
 
 ---
 
+## Step 0b: Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, resolve the unknowns whose answers would **change the architecture**, in blast-radius order — schema/migration → auth → API contract → perf/scale → cosmetics (last). Grep first, then `AskUserQuestion` one at a time (highest first, cap ~5, skip the obvious). Each answer becomes a row in a Decisions table written to `.claude/chain/decisions.json` and the PR body, feeding Phase 4 (Architecture) as constraints. Do NOT start Phase 1 with an unresolved schema/auth question; skip in `low` effort. Full protocol: `Read("${CLAUDE_SKILL_DIR}/references/blast-radius-clarification.md")`.
+
+---
+
 ## Task Management (MANDATORY)
 
 **BEFORE doing ANYTHING else, create tasks to track progress:**
@@ -327,24 +333,7 @@ Agent(subagent_type="ork:test-generator", run_in_background=true, ...)
 
 Full pattern reference (when to use vs. `TaskOutput`, until-condition gates, partial-result salvage, anti-patterns): `Read("${CLAUDE_PLUGIN_ROOT}/skills/chain-patterns/references/monitor-patterns.md")`.
 
-**Partial results (CC 2.1.98):** Background agents that fail now report partial progress to the parent. If a worktree-isolated agent crashes mid-implementation, synthesize its partial output instead of re-spawning:
-
-```python
-# After collecting agent results:
-for agent_result in agent_results:
-    if "[PARTIAL RESULT]" in agent_result.output:
-        # Agent crashed mid-work — salvage what it produced
-        partial_files = Bash(command="git diff --name-only", cwd=agent_result.worktree)
-        if partial_files:
-            # Merge partial work — commit what's usable, flag incomplete items
-            TaskUpdate(taskId=agent_task_id, status="completed",
-                       description=f"Partial: {len(partial_files)} files from crashed agent")
-        # Do NOT re-spawn — partial progress > wasted tokens re-doing work
-    elif agent_result.status == "BLOCKED":
-        # Agent hit a genuine blocker — escalate to user
-        TaskUpdate(taskId=agent_task_id, status="in_progress",
-                   description=f"BLOCKED: {agent_result.concerns[0]}")
-```
+**Partial results (CC 2.1.98):** if a worktree-isolated agent crashes mid-implementation, salvage its partial output — `git diff --name-only` in its worktree, commit what's usable, flag incomplete items — instead of re-spawning; escalate a `BLOCKED` agent to the user. Full salvage logic: the monitor-patterns reference above.
 
 ### Worktree-Isolated Implementation (CC 2.1.50)
 
@@ -506,6 +495,7 @@ Load on demand with `Read("${CLAUDE_SKILL_DIR}/references/<file>")`:
 | `agent-phases.md` | Agent prompts and spawn templates |
 | `agent-teams-phases.md` | Agent Teams mode phases |
 | `interview-mode.md` | Interview/take-home constraints |
+| `blast-radius-clarification.md` | Step 0b: ask-what-before-how blast-radius interview + decisions table |
 | `orchestration-modes.md` | Task tool vs Agent Teams selection |
 | `feedback-loop.md` | Checkpoint triggers and actions |
 | `cc-enhancements.md` | CC version-specific features |

--- a/src/skills/implement/references/blast-radius-clarification.md
+++ b/src/skills/implement/references/blast-radius-clarification.md
@@ -1,0 +1,61 @@
+# Blast-Radius Clarification (ask "what" before "how")
+
+Before Phase 1, find the unknowns whose answers would **change the architecture** and
+resolve them in blast-radius order — biggest consequence first. The cheapest place to
+settle an ambiguity is before code exists; the same ambiguity found mid-build is a
+rework, and found post-merge is an incident. This is "ask what before you ask how" made
+into a step.
+
+## When to run
+
+- Runs as **Step 0b**, after context discovery / worktree (Step 0a) and BEFORE Task
+  Management + Phase 1.
+- **Skip** in `low` effort, or when the feature is small and unambiguous (< ~3 files, no
+  schema / auth / contract surface).
+- **Grep the codebase first** — never ask a question the code already answers.
+
+## Blast-radius order (ask highest first; skip any tier already unambiguous)
+
+| # | Tier | Why it's high blast-radius | Example question |
+|---|------|----------------------------|------------------|
+| 1 | Data model / schema / migration | An answer reshapes every downstream layer | "New table, or a column on `<Y>`? Nullable? Backfill?" |
+| 2 | Auth / security / trust boundary | Sets who can act + the threat model | "Who calls this — portal user, admin, service token?" |
+| 3 | API contract / breaking change | Ripples to every consumer | "Change an existing response shape, or add a new endpoint?" |
+| 4 | Data volume / performance / scale | Sets the algorithm + index strategy | "Expected cardinality / hot path / concurrency?" |
+| 5 | UX / copy / cosmetics | Cheap to change later — ask LAST | "Inline panel or modal?" |
+
+## Protocol
+
+1. One question at a time via `AskUserQuestion`, **highest blast-radius first**.
+2. Ask ONLY the genuinely ambiguous, high-blast-radius items — not the obvious ones. Stop
+   as soon as the remaining unknowns are low-blast-radius / cosmetic. **Cap ~5.**
+3. Each answer becomes a row in the Decisions table.
+4. Write the table to `.claude/chain/decisions.json` and surface it in the **PR body**
+   (Phase 9 documentation) so the "why" lands where reviewers see it.
+5. Feed the schema / auth / contract answers into **Phase 4 (Architecture)** as
+   constraints — they are inputs to the architecture agents, not afterthoughts.
+
+## Decisions table (written to state + PR body)
+
+```markdown
+## Decisions (blast-radius clarification)
+| # | Question | Decision | Blast radius | Rationale |
+|---|----------|----------|--------------|-----------|
+| 1 | New table or column on projects? | new `project_metric` table | schema | needs its own lifecycle + FK |
+| 2 | Who can write it? | admin + service token only | auth | portal users are read-only here |
+```
+
+## Why (the failure classes this closes)
+
+- **"Start solo → 3 interrupts"** — the operator gets pulled in three separate times
+  mid-build for questions a two-minute up-front interview would have batched.
+- **Premature architecture / root-cause commitment** — building on an unstated schema or
+  auth assumption, then discovering it was wrong after the architecture is set.
+
+## Anti-patterns
+
+- Asking cosmetic questions first — spends the user's attention on the cheapest unknowns.
+- Interrogating the obvious, or asking what the codebase already answers (grep first).
+- Asking everything → analysis paralysis. Cap and stop at low blast-radius.
+- Proceeding on an ambiguous **schema or auth** question — the exact rework this step
+  exists to prevent. If a tier-1/2 unknown is unresolved, do NOT start Phase 1.


### PR DESCRIPTION
## What

Adds **Step 0b: Blast-Radius Clarification** to `/ork:implement` — an "ask what before how" pre-phase that runs before Phase 1. An ordered `AskUserQuestion` pass surfaces the unknowns whose answers would **change the architecture**, in blast-radius order:

> schema / migration → auth → API contract → perf / scale → cosmetics (last)

Ask one at a time, highest blast-radius first, cap ~5, skip the obvious (grep first). Each answer becomes a row in a **Decisions table** written to `.claude/chain/decisions.json` and the PR body, feeding **Phase 4 (Architecture)** as constraints. Do NOT start Phase 1 with an unresolved schema/auth question.

## Why

Closes two documented failure classes:
- **"start solo → eat 3 interrupts"** — batch the high-consequence questions up front instead of being pulled in three times mid-build.
- **premature architecture commitment** — building on an unstated schema/auth assumption, then discovering it was wrong after the architecture is set.

Inspired by Thariq's "Finding Your Unknowns" field guide ("The Interview"). Companion to **#2753** (the verify-manifest merge gate) — these are the two adoptions from that guide worth net-new effort; the other 9 techniques were already covered by existing skills.

## Changed

- **new** `references/blast-radius-clarification.md` — blast-radius order, protocol, decisions-table format, anti-patterns
- `SKILL.md` — Step 0b + refs entry; `implement 2.7.0 → 2.8.0`
- **net −10 lines** (stays under the 520-line gate) by condensing a Monitor partial-results pseudo-code block already covered by the linked monitor-patterns reference
- `plugins/` rebuilt (skills mirror + regenerated command wrapper)

## Verification Manifest (dogfooding #2753's new gate)

| # | Load-bearing claim | Asserted by | Provenance | Evidence |
|---|--------------------|-------------|------------|----------|
| 1 | Under the 520-line gate | length gate | ✅ VERIFIED | `test-skill-length.sh` · implement 510 ≤ 520, Failed: 0 |
| 2 | SKILL.md structure valid | structure gate | ✅ VERIFIED | `test-skill-md.sh` · "SUCCESS: all critical tests passed", 0 failures |
| 3 | Token hard-ceiling not tripped | tokens gate | ✅ VERIFIED | 6449 < 8000 hard ceiling; the 5000 WARN is pre-existing (was 6439) |
| 4 | `src` == `plugins` | — | ✅ VERIFIED | `diff -r src/skills/implement plugins/ork/skills/implement` · identical |
| 5 | `commands/implement.md` = build output | build logic | ✅ VERIFIED | regenerated via `generate_command_from_skill`; diff = only the Step 0b delta |
| 6 | directive-density passes | density gate | ✅ VERIFIED | exit 0 |
| 7 | cross-language parity clean | parity gate | 🟡 CLAIMED | not runnable locally (`npm package not built` in depless worktree); change touches no parity surface — confirm in CI |

**Manifest impact:** row 7 CLAIMED (local env, not the change) → confirm green in CI; all others VERIFIED.

**Follow-up:** apply the same pre-phase to `/ork:fix-issue`.
