### PR TITLE
fix(emulate-seed): mention emulate 0.9.0 (Nuxt adapter) in skill body

### DIFF
--- a/docs/site/content/docs/reference/skills/emulate-seed.mdx
+++ b/docs/site/content/docs/reference/skills/emulate-seed.mdx
@@ -90,7 +90,7 @@ npx emulate --service github,stripe --seed ./emulate.config.yaml
 npx emulate init --service github
 ```
 
-## Services (0.8.0 — 14 emulators)
+## Services (0.9.0 — 14 emulators)
 
 > **New across releases:**
 > - **0.5.0** — added Clerk, MongoDB Atlas, Stripe, Resend, and Okta emulators; portless integration (embedded emulators without dedicated ports); Google OAuth `hd` claim support; Stripe Checkout + Resend magic link examples; AWS S3 emulator now matches the official SDK wire format.
@@ -98,6 +98,7 @@ npx emulate init --service github
 > - **0.6.1** — Vercel Blob store.
 > - **0.7.0** — added Linear (13th provider): stateful orgs/teams/issues/cycles + webhooks.
 > - **0.8.0** — added Twilio (14th provider): accounts, phone numbers, messages, calls, conversations, messaging services, Verify flows, and simulator endpoints, with a Next.js SMS-verification example.
+> - **0.9.0** — added a Nuxt emulator adapter (alongside the Next.js adapter); provider count unchanged.
 >
 > All backwards-compatible.
 

--- a/plugins/ork/skills/emulate-seed/SKILL.md
+++ b/plugins/ork/skills/emulate-seed/SKILL.md
@@ -95,7 +95,7 @@ npx emulate --service github,stripe --seed ./emulate.config.yaml
 npx emulate init --service github
 ```
 
-## Services (0.8.0 — 14 emulators)
+## Services (0.9.0 — 14 emulators)
 
 > **New across releases:**
 > - **0.5.0** — added Clerk, MongoDB Atlas, Stripe, Resend, and Okta emulators; portless integration (embedded emulators without dedicated ports); Google OAuth `hd` claim support; Stripe Checkout + Resend magic link examples; AWS S3 emulator now matches the official SDK wire format.
@@ -103,6 +103,7 @@ npx emulate init --service github
 > - **0.6.1** — Vercel Blob store.
 > - **0.7.0** — added Linear (13th provider): stateful orgs/teams/issues/cycles + webhooks.
 > - **0.8.0** — added Twilio (14th provider): accounts, phone numbers, messages, calls, conversations, messaging services, Verify flows, and simulator endpoints, with a Next.js SMS-verification example.
+> - **0.9.0** — added a Nuxt emulator adapter (alongside the Next.js adapter); provider count unchanged.
 >
 > All backwards-compatible.
 

--- a/src/skills/emulate-seed/SKILL.md
+++ b/src/skills/emulate-seed/SKILL.md
@@ -95,7 +95,7 @@ npx emulate --service github,stripe --seed ./emulate.config.yaml
 npx emulate init --service github
 ```
 
-## Services (0.8.0 — 14 emulators)
+## Services (0.9.0 — 14 emulators)
 
 > **New across releases:**
 > - **0.5.0** — added Clerk, MongoDB Atlas, Stripe, Resend, and Okta emulators; portless integration (embedded emulators without dedicated ports); Google OAuth `hd` claim support; Stripe Checkout + Resend magic link examples; AWS S3 emulator now matches the official SDK wire format.
@@ -103,6 +103,7 @@ npx emulate init --service github
 > - **0.6.1** — Vercel Blob store.
 > - **0.7.0** — added Linear (13th provider): stateful orgs/teams/issues/cycles + webhooks.
 > - **0.8.0** — added Twilio (14th provider): accounts, phone numbers, messages, calls, conversations, messaging services, Verify flows, and simulator endpoints, with a Next.js SMS-verification example.
+> - **0.9.0** — added a Nuxt emulator adapter (alongside the Next.js adapter); provider count unchanged.
 >
 > All backwards-compatible.
 


### PR DESCRIPTION
The weekly pin-sync (#2772) bumped `upstream-version-tested` to 0.9.0 but left the body at 0.8.0, so `test-upstream-version-drift.mjs` fails **every PR against main** (first victim: #2768).

- `## Services (0.9.0 — 14 emulators)` heading + release-note line: 0.9.0 = Nuxt emulator adapter (vercel-labs/emulate#188), provider count unchanged — verified against upstream commits (no GH release/tag exists for 0.9.0; npm is the source).
- Mirrored in both `src/skills` and `plugins/ork/skills` copies (same pair #2772 touched).
- Linter local run: 7/7 pass.