### PR TITLE
ci(release-announce): growth channels, no LinkedIn

### DIFF
--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -4,8 +4,13 @@
 #
 # On a published release (or manual dispatch), POST the release facts to the
 # Yonatan-HQ platform marketing intake (POST /api/marketing/release-announce),
-# which drafts per-channel posts (Twitter/X, LinkedIn, Dev.to, Hashnode, ...).
-# Drafts are HUMAN-GATED on the platform — nothing publishes from here.
+# which drafts per-channel posts for the GROWTH channels (Twitter/X, Dev.to,
+# Hashnode, Substack, Threads). Drafts are HUMAN-GATED on the platform —
+# nothing publishes from here.
+#
+# LinkedIn is deliberately NOT auto-drafted — it is a curated, hand-written
+# channel. Instagram joins ANNOUNCE_CHANNELS once Meta Business Verification
+# clears (needs instagram_content_publish).
 #
 # Cadence: minor/major (X.Y.0) releases only; patch bumps are skipped to keep
 # the review queue clean. workflow_dispatch overrides for any version.
@@ -97,6 +102,9 @@ jobs:
           RELEASE_URL: ${{ github.event.release.html_url || format('https://github.com/{0}/releases/tag/v{1}', github.repository, steps.meta.outputs.version) }}
           RELEASE_NOTES: ${{ github.event.release.body }}
           REPO: ${{ github.repository }}
+          # Growth channels only — LinkedIn is curated/hand-written (never auto).
+          # Instagram joins once Meta Business Verification clears.
+          ANNOUNCE_CHANNELS: twitter,devto,hashnode,substack,threads
           HQ_API_URL: ${{ secrets.HQ_API_URL }}
           HQ_API_TOKEN: ${{ secrets.HQ_API_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}

--- a/scripts/announce-release.mjs
+++ b/scripts/announce-release.mjs
@@ -12,7 +12,10 @@
  *   RELEASE_URL       canonical link for the announcement     [required]
  *   RELEASE_NOTES     release body markdown                   [optional]
  *   REPO              owner/name (default yonatangross/orchestkit)
- *   ANNOUNCE_CHANNELS comma list (default twitter,linkedin,devto,hashnode)
+ *   ANNOUNCE_CHANNELS comma list (default twitter,devto,hashnode,substack,threads)
+ *                     — LinkedIn is intentionally excluded: it is a curated,
+ *                     hand-written channel, never auto-drafted. Instagram joins
+ *                     once Meta Business Verification clears.
  *   HQ_API_URL        platform API base                       [enables live POST]
  *   HQ_API_TOKEN      platform API_STATIC_TOKEN               [enables live POST]
  *   DRY_RUN           "true" to compose without posting
@@ -34,7 +37,7 @@ const {
   RELEASE_URL,
   RELEASE_NOTES = "",
   REPO = "yonatangross/orchestkit",
-  ANNOUNCE_CHANNELS = "twitter,linkedin,devto,hashnode",
+  ANNOUNCE_CHANNELS = "twitter,devto,hashnode,substack,threads",
   HQ_API_URL,
   HQ_API_TOKEN,
   DRY_RUN = "false",


### PR DESCRIPTION
## What
Release announcements were auto-drafting to **LinkedIn** (`twitter,linkedin,devto,hashnode`). LinkedIn is a curated, hand-written channel — it should **never** be auto-drafted.

Set `ANNOUNCE_CHANNELS` (mjs default **and** explicitly in the workflow) to the growth set:
```
twitter, devto, hashnode, substack, threads
```
Instagram will join once Meta Business Verification clears (needs `instagram_content_publish`).

## Why now
The rail is **live** — v8.65.0 posted successfully on 2026-07-05, so LinkedIn drafts are actively created on each minor/major release.

## Notes
- Drafts remain human-gated on the platform (#1739) — behavior unchanged there.
- Follow-up (separate): v8.64.0 + v8.63.0 minor releases *failed* to announce — reliability, not addressed here.
- Follow-up (platform): the HQ route `_DEFAULT_CHANNELS` fallback still lists linkedin; aligning in a separate platform PR.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
