### PR TITLE
ci(release-announce): handle 202 queued response

### DIFF
--- a/scripts/announce-release.mjs
+++ b/scripts/announce-release.mjs
@@ -135,9 +135,18 @@ console.log(JSON.stringify({ status: res.status, ...data }, null, 2));
 output(`review_url=${data.review_url || ""}`);
 output(`draft_count=${draftCount}`);
 output(`skipped=${data.skipped === true}`);
+output(`queued=${data.queued === true}`);
 
 if (data.skipped) {
   summary(`### 📣 Release announce\nAlready drafted for ${REPO} ${RELEASE_VERSION} — skipped (idempotent).`);
+} else if (data.queued) {
+  // The platform now generates drafts in a background task and returns 202
+  // (async since it 524'd inline behind Cloudflare). Drafts land in the review
+  // queue shortly; draft_ids aren't known synchronously.
+  summary(
+    `### 📣 Release announce\nQueued drafting for ${REPO} ${RELEASE_VERSION} — posts will appear in the review queue shortly.\n` +
+      (data.review_url ? `\n👉 Review + approve: ${data.review_url}` : ""),
+  );
 } else {
   summary(
     `### 📣 Release announce\nDrafted **${draftCount}** post(s) for ${REPO} ${RELEASE_VERSION}.\n` +


### PR DESCRIPTION
## What
The platform `release-announce` route went **async** (platform#6753) — it now returns **`202 {queued:true, draft_ids:[]}`** (generation runs in a Celery task) instead of `201 + draft_ids`. `202` is `res.ok`, so this never *failed* the release, but the CI summary misreported **"Drafted 0 posts"**.

Add a `queued` branch: report **"Queued drafting … posts will appear in the review queue shortly"** + emit a `queued` step output.

## Notes
- Pairs with platform#6753 (async fix). Harmless until that deploys to prod — until then the route still returns 201 and the existing `drafted N` branch runs.
- `node --check` clean. Drafts remain human-gated on the platform.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
