### PR TITLE
fix(agent-readiness): orank gap triage - block scrape bots, fix PyPI homepage

### DIFF
--- a/docs/chore--orank-2026-07-08-fixes/playground.html
+++ b/docs/chore--orank-2026-07-08-fixes/playground.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>orank 81/B Gap Triage — OrchestKit</title>
+<style>
+  :root {
+    --pg-bg: hsl(232 26% 7%); --pg-ink: hsl(220 18% 93%);
+    --pg-muted: hsl(220 14% 64%); --pg-faint: hsl(220 12% 46%);
+    --pg-glass: hsl(0 0% 100% / .05); --pg-glass-edge: hsl(0 0% 100% / .18);
+    --pg-accent: hsl(248 84% 68%); --pg-accent-deep: hsl(248 70% 54%);
+    --pg-ok: hsl(160 60% 55%); --pg-warm: hsl(38 95% 60%); --pg-risk: hsl(8 75% 62%);
+    --pg-radius-md: 16px; --pg-ease: cubic-bezier(.2,.8,.25,1);
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: var(--pg-bg);
+    background-image: radial-gradient(1100px 620px at 12% -8%, hsl(248 60% 22% / .55), transparent 60%),
+      radial-gradient(900px 560px at 105% 12%, hsl(262 55% 20% / .45), transparent 55%);
+    background-attachment: fixed; color: var(--pg-ink);
+    font-family: -apple-system, "SF Pro Display", "Segoe UI", Inter, sans-serif;
+    min-height: 100vh; padding: 48px 24px 96px; line-height: 1.55;
+  }
+  .wrap { max-width: 980px; margin-inline: auto; }
+  .mono { font-family: "SF Mono", ui-monospace, "JetBrains Mono", Menlo, monospace; }
+  .eyebrow { color: var(--pg-accent); font-size: 13px; font-weight: 600; letter-spacing: 1.6px; text-transform: uppercase; }
+  h1 { font-size: 30px; font-weight: 700; letter-spacing: -.3px; margin-block: 8px 12px; }
+  .sub { color: var(--pg-muted); max-width: 68ch; }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 16px; margin-block: 32px; }
+  .tile { background: var(--pg-glass); border: 1px solid var(--pg-glass-edge); border-radius: var(--pg-radius-md);
+    backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+    box-shadow: inset 0 1px 0 hsl(0 0% 100% / .12), 0 20px 60px -22px hsl(232 40% 3% / .7); padding: 16px; }
+  .tile .v { font-size: 26px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .tile .l { color: var(--pg-faint); font-size: 12.5px; margin-block-start: 4px; }
+  .row { display: grid; grid-template-columns: 140px 1fr; gap: 16px; align-items: start;
+    padding: 16px 0; border-block-end: 1px solid hsl(0 0% 100% / .08); }
+  .tag { font-size: 11px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase;
+    padding: 4px 10px; border-radius: 999px; display: inline-block; }
+  .tag.shipped { color: var(--pg-ok); background: hsl(160 60% 55% / .12); }
+  .tag.fneg { color: var(--pg-accent); background: hsl(248 84% 68% / .12); }
+  .tag.bydesign { color: var(--pg-muted); background: hsl(0 0% 100% / .08); }
+  .tag.deferred { color: var(--pg-warm); background: hsl(38 95% 60% / .12); }
+  .row h3 { font-size: 14.5px; font-weight: 600; margin-block-end: 4px; }
+  .row p { color: var(--pg-muted); font-size: 13px; }
+  .code { font-family: "SF Mono", monospace; font-size: 12px; color: var(--pg-faint);
+    background: hsl(0 0% 100% / .04); padding: 2px 6px; border-radius: 4px; }
+  section.block { margin-block-start: 40px; }
+  section.block > h2 { font-size: 17px; font-weight: 700; letter-spacing: -.2px; margin-block-end: 4px; }
+  section.block > p.hint { color: var(--pg-faint); font-size: 12.5px; margin-block-end: 8px; }
+  .promptbar { position: sticky; inset-block-end: 16px; margin-block-start: 48px; display: flex;
+    align-items: center; gap: 12px; background: hsl(232 26% 10% / .92); border: 1px solid var(--pg-glass-edge);
+    border-radius: var(--pg-radius-md); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px);
+    box-shadow: 0 20px 60px -22px hsl(232 40% 3% / .7); padding: 12px 16px; opacity: .92; }
+  .promptbar .txt { font-size: 12.5px; color: var(--pg-muted); flex: 1; min-inline-size: 0; overflow: hidden;
+    text-overflow: ellipsis; white-space: nowrap; }
+  .promptbar button { font: inherit; font-size: 13px; font-weight: 600; color: hsl(0 0% 100%);
+    background: var(--pg-accent-deep); border: none; border-radius: 9px; padding: 8px 16px; cursor: pointer;
+    transition: background 100ms var(--pg-ease); }
+  .promptbar button:hover { background: var(--pg-accent); }
+  @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="eyebrow">OrchestKit · orank Agent-Readiness Follow-up</div>
+  <h1>81/B Gap Triage — What Shipped, What's a False Alarm</h1>
+  <p class="sub">Every "Access"-layer fail on this scan traces to one deliberate choice: the API is
+  anonymous, read-only, and free, and refuses to fabricate OAuth metadata for an authorization
+  server that doesn't exist. This page shows what was live-verified before touching any code.</p>
+
+  <div class="tiles">
+    <div class="tile"><div class="v">81 → ?</div><div class="l">score (77/B on 07-07)</div></div>
+    <div class="tile"><div class="v">2</div><div class="l">real fixes shipped</div></div>
+    <div class="tile"><div class="v">2</div><div class="l">confirmed scanner false-negatives</div></div>
+    <div class="tile"><div class="v">5</div><div class="l">by-design, correctly left alone</div></div>
+    <div class="tile"><div class="v">1</div><div class="l">deferred (architecture-level)</div></div>
+  </div>
+
+  <section class="block">
+    <h2>Shipped this PR</h2>
+    <p class="hint">Live-verified, real, honest fixes</p>
+    <div class="row"><span class="tag shipped">shipped</span>
+      <div><h3>robots.txt: block CCBot + Bytespider</h3>
+        <p>Third-party bulk-scrape aggregators, distinct from named search/assistant crawlers
+        (GPTBot, ClaudeBot, Perplexity...) which stay welcomed — including ones whose purpose
+        <em>is</em> opt-in training (Google-Extended, Applebot-Extended). Scoped
+        <span class="code">Content-Signal: ai-train=no</span> on the two blocked bots only.</p></div>
+    </div>
+    <div class="row"><span class="tag shipped">shipped</span>
+      <div><h3>PyPI hook-contract Homepage field</h3>
+        <p><span class="code">packages/hook-contract-py/pyproject.toml</span> pointed at GitHub
+        instead of the product domain. Fixed — but PyPI metadata is immutable per-release, so this
+        needs a version bump to actually appear. Tracked as
+        <span class="code">#2796</span> rather than auto-publishing.</p></div>
+    </div>
+  </section>
+
+  <section class="block">
+    <h2>Confirmed scanner false-negatives</h2>
+    <p class="hint">Already shipped and live — orank's scanner just probed the wrong signal</p>
+    <div class="row"><span class="tag fneg">no code</span>
+      <div><h3>Deprecation / versioning policy</h3>
+        <p><span class="code">/api-policy.md</span> returns 200 and states the policy in prose.
+        Scanner likely checks for Sunset/Deprecation HTTP headers, not page content.</p></div>
+    </div>
+    <div class="row"><span class="tag fneg">no code</span>
+      <div><h3>Multi-surface MCP coverage</h3>
+        <p>Real path is <span class="code">/.well-known/mcp/server-card.json</span> (not
+        <span class="code">/mcp/server-card.json</span> — I guessed wrong once mid-session). Lists
+        both the hosted streamable-HTTP surface and the GHCR stdio Docker image.</p></div>
+    </div>
+  </section>
+
+  <section class="block">
+    <h2>By-design, verified correct — do not fix</h2>
+    <p class="hint">One recurring pattern across five separate orank findings</p>
+    <div class="row"><span class="tag bydesign">by-design</span>
+      <div><h3>AS metadata 404 · agent_auth endpoints · WWW-Authenticate hint · empty PRM scopes · no sandbox env</h3>
+        <p><span class="code">auth.md</span> states it in its own prose: "publishing RFC 8414
+        metadata for [an authorization server] that does not exist would be misleading." Faking
+        any of these to score points is the exact fabrication this site refuses to do.</p></div>
+    </div>
+  </section>
+
+  <section class="block">
+    <h2>Investigated, deliberately deferred</h2>
+    <p class="hint">Real gap, but not a same-session fix</p>
+    <div class="row"><span class="tag deferred">deferred</span>
+      <div><h3>Content-density (Identity 4.78%)</h3>
+        <p>Measured live: 59.5% of homepage HTML is Next.js RSC hydration payload, 17.5% is
+        Tailwind classes (expected), ~4.9% is readable text. Root cause is architectural — needs
+        client/server component restructuring with iterative browser verification, not a rushed
+        same-session edit.</p></div>
+    </div>
+  </section>
+</div>
+<script>
+  // static — no interactive state needed for a diff-summary dashboard
+</script>
+</body>
+</html>

--- a/docs/site/app/robots.txt/route.ts
+++ b/docs/site/app/robots.txt/route.ts
@@ -1,16 +1,21 @@
 import { SITE } from "@/lib/constants";
 
 // Custom robots.txt route (replaces the app/robots.ts metadata convention, which
-// cannot emit arbitrary directives). Permissive stance: OrchestKit is an
-// open-source project that WANTS agents to discover, search, train on, and learn
-// from its docs — so named AI crawlers are explicitly allowed (and ai-train=yes
-// is kept) rather than blocked. The schemamap directive points at the NLWeb
-// Schema Feeds map.
+// cannot emit arbitrary directives). Tiered stance (2026-07-08, orank fix
+// applied): OrchestKit WANTS named, accountable AI companies with a real
+// product (search, assistant, or opt-in model training) to crawl and train on
+// its docs — those stay explicitly allowed with ai-train=yes, including
+// crawlers whose sole purpose IS training (GPTBot, Google-Extended,
+// Applebot-Extended). What's blocked is different in kind, not degree:
+// third-party bulk-scrape aggregators with no accountable product behind them
+// (CCBot = Common Crawl, resold to unknown downstream buyers; Bytespider =
+// ByteDance's crawler, widely blocked for ignoring crawl-rate limits). The
+// schemamap directive points at the NLWeb Schema Feeds map.
 export const revalidate = false;
 
-// AI crawlers we explicitly welcome. Listing them by name (each with Allow: /)
-// is the discoverability signal orank rewards, and it documents intent: nothing
-// here is blocked.
+// Named AI crawlers we explicitly welcome — search, assistant, or opt-in
+// training, all from an accountable company with a real product. Listing them
+// by name (each with Allow: /) is the discoverability signal orank rewards.
 const AI_BOTS = [
 	"GPTBot",
 	"ChatGPT-User",
@@ -21,22 +26,37 @@ const AI_BOTS = [
 	"Google-Extended",
 	"PerplexityBot",
 	"Perplexity-User",
-	"CCBot",
 	"Applebot-Extended",
-	"Bytespider",
 	"meta-externalagent",
 ];
+
+// Third-party bulk-scrape aggregators — blocked, not welcomed. Distinct from
+// AI_BOTS above; do not merge the two lists.
+const BLOCKED_BOTS = ["CCBot", "Bytespider"];
 
 export function GET() {
 	const lines: string[] = [
 		"User-agent: *",
 		"Allow: /",
 		"",
-		"# OrchestKit is open source (MIT) and welcomes AI crawlers explicitly.",
+		"# OrchestKit is open source (MIT) and welcomes named AI crawlers explicitly.",
 	];
 
 	for (const bot of AI_BOTS) {
 		lines.push("", `User-agent: ${bot}`, "Allow: /");
+	}
+
+	lines.push(
+		"",
+		"# Third-party bulk-scrape aggregators are blocked, not welcomed.",
+	);
+	for (const bot of BLOCKED_BOTS) {
+		lines.push(
+			"",
+			`User-agent: ${bot}`,
+			"Disallow: /",
+			"Content-Signal: ai-train=no, search=no, ai-input=no",
+		);
 	}
 
 	lines.push(

--- a/packages/hook-contract-py/pyproject.toml
+++ b/packages/hook-contract-py/pyproject.toml
@@ -38,7 +38,7 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yonatangross/orchestkit"
+Homepage = "https://orchestkit.yonyon.ai"
 Repository = "https://github.com/yonatangross/orchestkit"
 Issues = "https://github.com/yonatangross/orchestkit/issues"
 "Source spec" = "https://github.com/yonatangross/orchestkit/blob/main/spec/hook-events.spec.yml"


### PR DESCRIPTION
## Summary

Follow-up to a live orank scan (orchestkit.yonyon.ai, 2026-07-08, score 81/B). Every "Access" gap
was live-verified against the site/code before touching anything — most turned out to be one
recurring by-design pattern or a scanner false-negative, not real gaps.

### Shipped
- **robots.txt**: block CCBot (Common Crawl) and Bytespider (ByteDance) — third-party bulk-scrape
  aggregators with no accountable product behind them, distinct from the named search/assistant
  crawlers (GPTBot, ClaudeBot, Perplexity, etc.) that stay explicitly welcomed with `ai-train=yes`,
  including ones whose purpose *is* opt-in training (Google-Extended, Applebot-Extended). Scoped
  `Content-Signal: ai-train=no` on just the two blocked bots — no blanket global flip, which would
  have contradicted the still-true global `ai-train=yes`.
- **PyPI hook-contract Homepage**: `packages/hook-contract-py/pyproject.toml` pointed at the GitHub
  repo instead of the product domain. Fixed (not release-please governed, safe to hand-edit). PyPI
  metadata is immutable per-release though, so this only takes effect on the next publish —
  tracked as #2796 rather than auto-publishing a package.

### Confirmed scanner false-negatives (no code needed)
- Deprecation/versioning policy — live at `/api-policy.md`, 200, states the policy in prose.
- Multi-surface MCP coverage — live at `/.well-known/mcp/server-card.json`, lists both the hosted
  streamable-HTTP surface and the GHCR stdio Docker image.

### Investigated, deliberately deferred
Content-density gap (Identity 48/51, lost on 4.78% text ratio) — measured live: 59.5% of homepage
HTML is Next.js RSC hydration payload, 17.5% is Tailwind classes (expected), ~4.9% is readable
text. Architecture-level fix (client/server component restructuring), not a same-session change.

### Left unfixed by design
`auth.md`'s own prose states it: AS metadata 404, agent_auth endpoints, WWW-Authenticate hint,
empty PRM `authorization_servers`/`scopes`, no sandbox env — all one pattern. The API is
anonymous/read-only/free; publishing fake OAuth metadata for an authorization server that doesn't
exist would be the exact fabrication this site's stated principle refuses to do.

## Playground

`docs/chore--orank-2026-07-08-fixes/playground.html` — visual gap triage (shipped / false-negative
/ by-design / deferred), matching the categorization above.

## Test plan

- `npx biome check app/robots.txt/route.ts` — clean
- `npx next build` (docs/site) — succeeds, `/robots.txt` prerenders statically
- Live-curl verification of every claim above (api-policy.md 200, mcp/server-card.json 200 at the
  correct path, robots.txt content) before writing any code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
