### PR TITLE
chore(1p): repoint op:// refs to post-move vaults

### DIFF
--- a/.claude/templates/mcp-disabled.json
+++ b/.claude/templates/mcp-disabled.json
@@ -21,7 +21,7 @@
     },
     "tavily": {
       "command": "sh",
-      "args": ["-c", "TAVILY_API_KEY=$(op read 'op://Private/Tavily API Key/API Key') exec npx -y tavily-mcp@latest"],
+      "args": ["-c", "TAVILY_API_KEY=$(op read 'op://Personal/Tavily API Key/API Key') exec npx -y tavily-mcp@latest"],
       "description": "Web search, extract, crawl, and deep research (requires API key)",
       "disabled": true
     },

--- a/.claude/templates/mcp-enabled.json
+++ b/.claude/templates/mcp-enabled.json
@@ -21,7 +21,7 @@
     },
     "tavily": {
       "command": "sh",
-      "args": ["-c", "TAVILY_API_KEY=$(op read 'op://Private/Tavily API Key/API Key') exec npx -y tavily-mcp@latest"],
+      "args": ["-c", "TAVILY_API_KEY=$(op read 'op://Personal/Tavily API Key/API Key') exec npx -y tavily-mcp@latest"],
       "description": "Web search, extract, crawl, and deep research",
       "auto": "70"
     },

--- a/packages/hook-contract-py/RELEASING.md
+++ b/packages/hook-contract-py/RELEASING.md
@@ -6,7 +6,7 @@ Tag-driven release flow. Tags matching `hook-contract-py/v<version>` trigger `.g
 
 | Registry | Username | Credential stored in |
 |---|---|---|
-| https://pypi.org | `yonyonai` | 1Password: `op://Personal/PyPI - yonyonai` (tag: `pypi,orchestkit,trusted-publisher`) |
+| https://pypi.org | `yonyonai` | 1Password: `op://HQ-Infra/PyPI - yonyonai` (tag: `pypi,orchestkit,trusted-publisher`) |
 | https://test.pypi.org | `yonyonai` (register if not yet) | Same 1Password entry |
 
 > No API token stored in GitHub Actions secrets — OIDC trusted publishing handles auth via short-lived tokens minted per-run.


### PR DESCRIPTION
These secrets were moved to new 1Password vaults during a hygiene audit; this repoints the local-dev config refs to match.

- `.claude/templates/mcp-disabled.json`: Tavily API Key `op://Private` -> `op://Personal`
- `.claude/templates/mcp-enabled.json`: Tavily API Key `op://Private` -> `op://Personal`
- `packages/hook-contract-py/RELEASING.md`: PyPI - yonyonai `op://Personal` -> `op://HQ-Infra`

No runtime behavior change.