### PR TITLE
fix(docs-site): lab generator falls back to committed copies

### DIFF
--- a/docs/fix--lab-generator-fallback/index.html
+++ b/docs/fix--lab-generator-fallback/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"><title>Lab generator fallback — fix note</title>
+<style>body{background:hsl(232 26% 7%);color:hsl(220 18% 93%);font:15px/1.6 system-ui;max-width:720px;margin:40px auto;padding:0 20px}
+code{font-family:ui-monospace,Menlo,monospace;background:hsl(0 0% 100%/.08);padding:1px 5px;border-radius:4px}
+.card{background:hsl(0 0% 100%/.05);border:1px solid hsl(0 0% 100%/.18);border-radius:16px;padding:20px;margin-top:16px}</style></head>
+<body><h1>Lab generator: clean-checkout fallback</h1>
+<div class="card"><p><b>Found by adversarial verification of #2952:</b> <code>generate-lab-data.mjs</code> hard-failed on clean checkouts because 3 manifest sources under <code>docs/*.html</code> are gitignored working artifacts.</p>
+<p><b>Fix:</b> prefer the repo source; fall back to the committed <code>public/lab/</code> copy with a warning; fail only when both are missing.</p>
+<p><b>Verified:</b> fresh worktree run → 3 graceful fallbacks, 10 entries, <code>lab-data.ts</code> byte-identical.</p></div></body></html>

--- a/docs/site/lib/generated/cc-adoption-data.ts
+++ b/docs/site/lib/generated/cc-adoption-data.ts
@@ -144,4 +144,4 @@ export const CC_SUPPORT = {
   policy: "latest + 3 previous minors",
 } as const;
 
-export const GENERATED_AT = { commit: "0210a37f6", date: "2026-07-17" } as const;
+export const GENERATED_AT = { commit: "95e8b6d2a", date: "2026-07-17" } as const;

--- a/docs/site/scripts/generate-lab-data.mjs
+++ b/docs/site/scripts/generate-lab-data.mjs
@@ -12,7 +12,10 @@
  * outputs. Sources under docs/*.html may be gitignored working artifacts —
  * the committed public/lab copies are the published canon.
  *
- * Fails loudly when a manifest source is missing (e.g. pruned playground):
+ * Source resolution: prefer the repo source file; when it is absent (several
+ * sources under docs/*.html are gitignored working artifacts, so clean
+ * checkouts don't have them) fall back to the committed public/lab copy with
+ * a warning. Fails loudly only when BOTH are missing (truly pruned entry):
  * remove the entry or restore the file.
  */
 import { execSync } from "node:child_process";
@@ -35,11 +38,19 @@ const entries = [];
 const missing = [];
 for (const e of manifest.entries) {
   const src = path.join(REPO, e.source);
-  if (!fs.existsSync(src)) {
+  const committed = path.join(OUT_LAB, `${e.slug}.html`);
+  let html;
+  if (fs.existsSync(src)) {
+    html = fs.readFileSync(src, "utf8");
+  } else if (fs.existsSync(committed)) {
+    console.warn(
+      `[generate-lab-data] source absent (gitignored or pruned): ${e.source} — keeping committed public/lab/${e.slug}.html`,
+    );
+    html = fs.readFileSync(committed, "utf8");
+  } else {
     missing.push(e.source);
     continue;
   }
-  const html = fs.readFileSync(src, "utf8");
   const title = e.title ?? html.match(/<title>([^<]*)<\/title>/)?.[1]?.trim() ?? e.slug;
   const description =
     e.description ??


### PR DESCRIPTION
## Summary

Follow-up to #2952 — the adversarial verification finding landed on the branch two minutes after the squash-merge, so it missed the train.

`generate-lab-data.mjs` hard-failed on clean checkouts: three lab-manifest sources under `docs/*.html` are gitignored working artifacts that only exist on the authoring machine. The generator now prefers the repo source, falls back to the committed `public/lab/` copy with a warning, and fails only when both are missing (a truly pruned entry).

Verified in a fresh worktree: 3 graceful fallbacks, 10 entries, `lab-data.ts` reproduces byte-identical (only the generated-at stamp moves).

## Playground

Fix note: `docs/fix--lab-generator-fallback/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
