### PR TITLE
feat(docs-site): D1 design foundation - powered-trace token grammar

### DIFF
--- a/docs/feat--docs-design-foundation/index.html
+++ b/docs/feat--docs-design-foundation/index.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Docs Design Overhaul — Current vs D1 vs D2 vs D3, live</title>
+<style>
+  /* ---------- playground chrome (cool-glass, per standard) ---------- */
+  :root {
+    --pg-bg: hsl(232 26% 7%); --pg-ink: hsl(220 18% 93%); --pg-muted: hsl(220 12% 64%);
+    --pg-faint: hsl(220 10% 46%); --pg-glass: hsl(0 0% 100% / .05); --pg-glass-2: hsl(0 0% 100% / .08);
+    --pg-glass-edge: hsl(0 0% 100% / .18); --pg-accent: hsl(248 84% 68%);
+    --r-sm: 9px; --r-md: 16px; --ease: cubic-bezier(.2,.8,.25,1);
+  }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    background: var(--pg-bg);
+    background-image: radial-gradient(900px 600px at 10% -10%, hsl(248 70% 22% / .5), transparent 60%),
+                      radial-gradient(700px 500px at 95% 10%, hsl(262 65% 20% / .4), transparent 55%);
+    background-attachment: fixed; color: var(--pg-ink);
+    font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif; min-height: 100vh;
+  }
+  code, .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  .layout { display: grid; grid-template-columns: 330px 1fr; gap: 16px; max-width: 1460px; margin: 0 auto; padding: 24px 16px 130px; }
+  @media (max-width: 980px) { .layout { grid-template-columns: 1fr; } }
+  header.hero-pg { grid-column: 1 / -1; padding: 4px 4px 0; }
+  header.hero-pg h1 { font-size: 21px; font-weight: 700; letter-spacing: -.3px; }
+  header.hero-pg p { color: var(--pg-muted); margin-top: 4px; max-width: 82ch; }
+  .glass { background: var(--pg-glass); border: 1px solid var(--pg-glass-edge); border-radius: var(--r-md);
+    backdrop-filter: blur(16px); box-shadow: 0 20px 60px -22px hsl(232 40% 3% / .7), inset 0 1px 0 hsl(0 0% 100% / .1); }
+  aside { display: flex; flex-direction: column; gap: 12px; align-self: start; position: sticky; top: 16px; }
+  .panel { padding: 16px; }
+  .panel h3 { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: var(--pg-faint); font-weight: 600; margin-bottom: 8px; }
+  .stage-btn { display: block; width: 100%; text-align: left; border: 1px solid var(--pg-glass-edge); background: var(--pg-glass);
+    border-radius: var(--r-sm); color: var(--pg-ink); padding: 10px 12px; margin-bottom: 8px; font: inherit; cursor: pointer;
+    transition: border-color 200ms var(--ease), background 200ms var(--ease); }
+  .stage-btn:hover { background: var(--pg-glass-2); }
+  .stage-btn[aria-pressed="true"] { border-color: var(--pg-accent); background: hsl(248 84% 68% / .09); }
+  .stage-btn .nm { font-weight: 600; font-size: 13.5px; display: flex; justify-content: space-between; }
+  .stage-btn .d { color: var(--pg-muted); font-size: 12px; margin-top: 2px; }
+  .score { font-size: 11px; color: var(--pg-faint); }
+  label.knob { display: flex; justify-content: space-between; align-items: center; gap: 8px; color: var(--pg-muted); font-size: 12.5px; margin-top: 9px; }
+  input[type=range] { width: 130px; accent-color: var(--pg-accent); }
+  input[type=checkbox] { accent-color: var(--pg-accent); width: 15px; height: 15px; }
+  .knob .v { font-family: ui-monospace, Menlo, monospace; color: var(--pg-ink); font-size: 11.5px; min-width: 34px; text-align: right; }
+  main { min-width: 0; display: flex; flex-direction: column; gap: 14px; }
+  .verdict { padding: 12px 16px; font-size: 12.5px; color: var(--pg-muted); }
+  .verdict b { color: var(--pg-ink); }
+  .browser { border-radius: var(--r-md); border: 1px solid var(--pg-glass-edge); overflow: hidden; }
+  .browser-bar { display: flex; align-items: center; gap: 8px; padding: 8px 12px; background: hsl(232 20% 13%); border-bottom: 1px solid hsl(0 0% 100% / .08); }
+  .browser-bar .dots i { display: inline-block; width: 9px; height: 9px; border-radius: 50%; background: hsl(0 0% 100% / .15); margin-right: 4px; }
+  .browser-bar .url { flex: 1; text-align: center; font-size: 11px; color: var(--pg-faint); font-family: ui-monospace, Menlo, monospace; }
+  .promptbar { position: fixed; left: 50%; transform: translateX(-50%); bottom: 14px; width: min(1428px, calc(100vw - 32px));
+    display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: center; padding: 12px 14px; border-radius: var(--r-md);
+    z-index: 40; background: hsl(232 26% 10% / .93); border: 1px solid var(--pg-glass-edge); backdrop-filter: blur(18px); }
+  #prompt { color: var(--pg-muted); font-size: 12.5px; max-height: 80px; overflow-y: auto; white-space: pre-wrap; }
+  #copy { background: var(--pg-accent); border: none; color: hsl(232 30% 10%); font: inherit; font-weight: 700;
+    border-radius: var(--r-sm); padding: 10px 18px; cursor: pointer; }
+
+  /* ================= DOCS MOCK — Circuit Forge base ================= */
+  .mock {
+    /* stage-driven custom props (JS writes these) */
+    --m-primary: oklch(0.696 0.170 163);
+    --m-terminus: oklch(0.696 0.170 163);
+    --m-bg: oklch(0.165 0.022 265);
+    --m-fg: oklch(0.929 0.013 255);
+    --m-muted: oklch(0.62 0.02 260);
+    --m-card: oklch(0.205 0.025 262);
+    --m-border: oklch(0.30 0.02 260);
+    --m-radius-card: 8px;
+    --m-shadow-card: none;
+    --m-section-pad: 34px;
+    background: var(--m-bg); color: var(--m-fg);
+    font-family: "Geist", system-ui, sans-serif; overflow: hidden; position: relative;
+  }
+  .m-section { padding: var(--m-section-pad) clamp(20px, 5%, 64px); position: relative; }
+  /* hero */
+  .m-hero { display: grid; grid-template-columns: 1.15fr 1fr; gap: 32px; align-items: center; position: relative; }
+  .m-hero-art { position: relative; min-height: 220px; border-radius: var(--m-radius-card); overflow: hidden; }
+  .m-blob { position: absolute; inset: 0; background: radial-gradient(60% 70% at 60% 40%, color-mix(in oklch, var(--m-primary) 22%, transparent), transparent 70%); }
+  .m-grid-bg { position: absolute; inset: 0; opacity: 0;
+    background-image: radial-gradient(color-mix(in oklch, var(--m-primary) 45%, transparent) 1.2px, transparent 1.2px);
+    background-size: 22px 22px; }
+  .mock.anim .m-grid-bg.on { opacity: .5; animation: flicker 3.2s linear infinite; }
+  .m-grid-bg.on { opacity: .35; }
+  @keyframes flicker { 0%,100% { opacity: .28 } 40% { opacity: .55 } 55% { opacity: .38 } 70% { opacity: .6 } }
+  .m-eyebrow { display: none; font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: .12em;
+    color: var(--m-primary); margin-bottom: 8px; font-family: ui-monospace, Menlo, monospace; }
+  .mock.eyebrows .m-eyebrow { display: block; }
+  .m-h1 { font-size: 30px; font-weight: 700; letter-spacing: -.5px; line-height: 1.15; }
+  .mock.gradtext .m-h1 span { background: linear-gradient(135deg, var(--m-primary), var(--m-terminus));
+    -webkit-background-clip: text; background-clip: text; color: transparent; }
+  .m-sub { color: var(--m-muted); margin-top: 10px; max-width: 46ch; font-size: 13.5px; }
+  .m-ctas { display: flex; gap: 10px; margin-top: 18px; }
+  .m-btn { border-radius: calc(var(--m-radius-card) - 2px); padding: 9px 16px; font-size: 13px; font-weight: 600; border: 1px solid transparent; cursor: pointer; transition: transform 150ms, box-shadow 150ms; }
+  .m-btn.primary { background: var(--m-primary); color: oklch(0.13 0.02 260); }
+  .mock.glow .m-btn.primary:hover { transform: scale(1.04); box-shadow: 0 0 20px color-mix(in oklch, var(--m-primary) 30%, transparent); }
+  .m-btn.ghost { background: transparent; border-color: var(--m-border); color: var(--m-fg); }
+  .m-stats { display: flex; gap: 26px; margin-top: 20px; }
+  .m-stat .v { font-size: 22px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .m-stat .k { font-size: 11px; color: var(--m-muted); }
+  /* terminal (D3) */
+  .m-term { display: none; position: relative; background: oklch(0.14 0.015 260); border: 1px solid var(--m-border);
+    border-radius: var(--m-radius-card); box-shadow: var(--m-shadow-card); font-family: ui-monospace, Menlo, monospace;
+    font-size: 11px; line-height: 1.75; padding: 14px 16px; color: var(--m-muted); }
+  .mock.term .m-term { display: block; }
+  .mock.term .m-hero-art .m-blob, .mock.term .m-hero-art .m-grid-bg { border-radius: var(--m-radius-card); }
+  .m-term .g { color: var(--m-primary); }
+  .m-term .c { color: var(--m-fg); }
+  .m-term .line { white-space: nowrap; overflow: hidden; }
+  .mock.anim.term .m-term .line { width: 0; animation: type 0.6s steps(40, end) forwards; }
+  .mock.anim.term .m-term .line:nth-child(2) { animation-delay: .5s } .mock.anim.term .m-term .line:nth-child(3) { animation-delay: 1s }
+  .mock.anim.term .m-term .line:nth-child(4) { animation-delay: 1.5s } .mock.anim.term .m-term .line:nth-child(5) { animation-delay: 2s }
+  .mock.anim.term .m-term .line:nth-child(6) { animation-delay: 2.5s } .mock.anim.term .m-term .line:nth-child(7) { animation-delay: 3s }
+  .mock.anim.term .m-term .line:nth-child(8) { animation-delay: 3.5s }
+  @keyframes type { to { width: 100% } }
+  /* cards */
+  .m-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+  .m-card { position: relative; background: var(--m-card); border: 1px solid var(--m-border);
+    border-radius: var(--m-radius-card); padding: 16px; box-shadow: var(--m-shadow-card);
+    transition: transform 200ms var(--ease), box-shadow 200ms var(--ease), border-color 200ms; overflow: hidden; }
+  .mock.lift .m-card:hover { transform: translateY(-4px);
+    box-shadow: 0 12px 24px -8px color-mix(in oklch, var(--m-primary) 15%, transparent), 0 4px 24px color-mix(in oklch, var(--m-primary) 12%, transparent);
+    border-color: color-mix(in oklch, var(--m-primary) 30%, var(--m-border)); }
+  .m-card.featured::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 2px;
+    background: linear-gradient(135deg, var(--m-primary), var(--m-terminus)); opacity: 0; transition: opacity 200ms; }
+  .mock.gradtop .m-card.featured::before { opacity: .65; }
+  .mock.gradtop .m-card.featured:hover::before { opacity: 1; }
+  .m-card .spot { position: absolute; inset: 0; opacity: 0; pointer-events: none; transition: opacity 250ms;
+    background: radial-gradient(180px circle at var(--mx, 50%) var(--my, 50%), color-mix(in oklch, var(--m-primary) 14%, transparent), transparent 70%); }
+  .mock.spotlight .m-card:hover .spot { opacity: 1; }
+  .m-card h4 { font-size: 14.5px; font-weight: 650; }
+  .m-card p { color: var(--m-muted); font-size: 12px; margin-top: 5px; line-height: 1.55; }
+  .m-card .cnt { font-size: 20px; font-weight: 700; color: var(--m-primary); font-variant-numeric: tabular-nums; margin-bottom: 6px; }
+  /* article sample */
+  .m-article { border-top: 1px solid var(--m-border); }
+  .m-article .m-prose { max-width: 68ch; }
+  .m-article h2 { font-size: 20px; font-weight: 700; letter-spacing: -.3px; margin-bottom: 8px; }
+  .m-article p { color: var(--m-muted); font-size: 13px; line-height: 1.7; margin-bottom: 10px; }
+  .m-callout { background: var(--m-card); border: 1px solid var(--m-border); border-left: 3px solid var(--m-primary);
+    border-radius: calc(var(--m-radius-card) - 2px); padding: 12px 14px; font-size: 12.5px; color: var(--m-muted); box-shadow: var(--m-shadow-card); }
+  @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }
+</style>
+</head>
+<body>
+<div class="layout">
+  <header class="hero-pg">
+    <h1>Docs Design Overhaul — the bundles, rendered live</h1>
+    <p>One mock of the orchestkit.yonyon.ai landing + article chrome, restyled in place per bundle. Real token values from both design systems (Circuit Forge emerald · portfolio grammar). <b>Hover the cards</b> to feel each stage; the terminus slider taste-tests the emerald→teal→indigo debate on the hero gradient.</p>
+  </header>
+
+  <aside>
+    <div class="glass panel">
+      <h3>Stage</h3>
+      <div id="stages"></div>
+    </div>
+    <div class="glass panel">
+      <h3>Knobs</h3>
+      <label class="knob">Gradient terminus hue <input type="range" id="hue" min="162" max="290" step="1" value="188"><span class="v" id="hueV">188</span></label>
+      <label class="knob">Eyebrows <input type="checkbox" id="kEyebrow" checked></label>
+      <label class="knob">Hover-lift cards <input type="checkbox" id="kLift" checked></label>
+      <label class="knob">Motion (grid flicker, tickers, typing) <input type="checkbox" id="kAnim" checked></label>
+    </div>
+  </aside>
+
+  <main>
+    <div class="glass verdict" id="verdict"></div>
+    <div class="browser">
+      <div class="browser-bar"><span class="dots"><i></i><i></i><i></i></span><span class="url">orchestkit.yonyon.ai — live-styled mock</span></div>
+
+      <div class="mock" id="mock">
+        <!-- HERO -->
+        <div class="m-section m-hero">
+          <div>
+            <div class="m-eyebrow">Claude Code Plugin</div>
+            <div class="m-h1">Ship with <span>battle-tested</span> AI workflows</div>
+            <p class="m-sub">114 skills, 37 agents, and 218 hooks with built-in best practices, security gates, and quality loops for Claude Code.</p>
+            <div class="m-ctas">
+              <button class="m-btn primary">Install OrchestKit</button>
+              <button class="m-btn ghost">Browse The Lab</button>
+            </div>
+            <div class="m-stats">
+              <div class="m-stat"><div class="v" data-count="114">114</div><div class="k">skills</div></div>
+              <div class="m-stat"><div class="v" data-count="37">37</div><div class="k">agents</div></div>
+              <div class="m-stat"><div class="v" data-count="218">218</div><div class="k">hooks</div></div>
+            </div>
+          </div>
+          <div class="m-hero-art">
+            <div class="m-blob"></div>
+            <div class="m-grid-bg" id="gridbg"></div>
+            <div class="m-term">
+              <div class="line"><span class="g">$</span> <span class="c">/ork:brainstorm docs-site UI/UX overhaul</span></div>
+              <div class="line">→ grounding: 273 pages, 70% generated reference</div>
+              <div class="line">→ agents: ia-thinker · search-thinker · benchmarks</div>
+              <div class="line">✓ 18 ideas → 7 kept → 2 bundles</div>
+              <div class="line"><span class="g">$</span> <span class="c">ship B1+B2</span></div>
+              <div class="line">→ PR #2963 reference root tab <span class="g">✓ merged</span></div>
+              <div class="line">→ PR #2964 search: 24/24 golden <span class="g">✓ merged</span></div>
+              <div class="line"><span class="g">✓ live on orchestkit.yonyon.ai in 3h11m</span></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- PRIMITIVES -->
+        <div class="m-section">
+          <div class="m-eyebrow">Primitives</div>
+          <div class="m-cards">
+            <div class="m-card featured"><div class="spot"></div><div class="cnt" data-count="114">114</div><h4>Skills</h4><p>Reusable knowledge modules: patterns, frameworks, and workflows injected on demand.</p></div>
+            <div class="m-card featured"><div class="spot"></div><div class="cnt" data-count="37">37</div><h4>Agents</h4><p>Specialized personas with curated tools, from backend architects to security auditors.</p></div>
+            <div class="m-card featured"><div class="spot"></div><div class="cnt" data-count="218">218</div><h4>Hooks</h4><p>TypeScript lifecycle automation: security gates, memory sync, audit logging.</p></div>
+          </div>
+        </div>
+
+        <!-- ARTICLE SAMPLE -->
+        <div class="m-section m-article">
+          <div class="m-prose">
+            <div class="m-eyebrow">Guides</div>
+            <h2>How we adopt every Claude Code release</h2>
+            <p>Claude Code ships several releases a week. OrchestKit silently breaks if it falls behind, so the repo runs an automated adoption loop: detect, extract, verify, file, adopt, subtract.</p>
+            <div class="m-callout">In one July 2026 week, the loop turned three releases into 37 auto-filed, scored adoption issues. Zero were written by hand.</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="promptbar">
+  <div id="prompt"></div>
+  <button id="copy">Copy prompt</button>
+</div>
+
+<script>
+const STAGES = [
+  { id: "current", nm: "Current — Circuit Forge", score: null,
+    d: "Shipped state: flat cards, static blob, no eyebrows, uniform radii.",
+    verdict: `<b>Baseline.</b> Solid tokens (emerald oklch, WCAG-tuned) but no elevation language, no typographic kickers, generic spacing — reads as templated Fumadocs. This is the "sucks" the brainstorm diagnosed.`,
+    flags: [] },
+  { id: "d1", nm: "D1 — Foundation", score: 9.0,
+    d: "Token grammar port: eyebrows, radius ramp, shadow trio, hover-lift, gradient-top, fluid spacing, teal terminus.",
+    verdict: `<b>Pure CSS, zero LCP risk.</b> The portfolio's token GRAMMAR on the emerald anchor: 14px card radius, 2-layer shadows, hover-lift with primary-tinted glow, gradient top borders, eyebrow kickers, fluid section padding, gradient headline to the +26° terminus. Hover the cards.`,
+    flags: ["eyebrows", "lift", "gradtop", "gradtext", "glow", "d1tokens"] },
+  { id: "d2", nm: "D1+D2 — Component lift", score: 8.5,
+    d: "+ 21st.dev via minimal shadcn: number tickers, flickering grid hero, spotlight cards.",
+    verdict: `<b>+ the registry unlock.</b> shadcn minimal-mode (fd-alias bridge, fd-* stays canonical) brings NumberTicker (watch the stats count up), a flickering circuit grid behind the hero, and mouse-spotlight on the primitive cards. Budget: &lt;30KB, all reduced-motion gated.`,
+    flags: ["eyebrows", "lift", "gradtop", "gradtext", "glow", "d1tokens", "gridbg", "tickers", "spotlight"] },
+  { id: "d3", nm: "D1+D2+D3 — Signature hero", score: 8.2,
+    d: "+ terminal card replaying a REAL session (today's docs-UX ship).",
+    verdict: `<b>The one bold move.</b> The hero art becomes a terminal replaying a genuine session — this morning's actual brainstorm → two PRs → live in 3h11m. Survives screenshots, explains the product. The honesty rule: if the transcript ever reads fake, cut it.`,
+    flags: ["eyebrows", "lift", "gradtop", "gradtext", "glow", "d1tokens", "gridbg", "tickers", "spotlight", "term"] },
+];
+
+const state = { stage: "d1", hue: 188, eyebrow: true, lift: true, anim: true };
+
+const mock = document.getElementById("mock");
+
+function applyStage() {
+  const s = STAGES.find(x => x.id === state.stage);
+  const f = new Set(s.flags);
+  if (!state.eyebrow) f.delete("eyebrows");
+  if (!state.lift) f.delete("lift");
+  mock.className = "mock " + [...f].filter(x => x !== "d1tokens").join(" ") + (state.anim ? " anim" : "");
+  // tokens
+  const d1 = f.has("d1tokens");
+  mock.style.setProperty("--m-radius-card", d1 ? "14px" : "8px");
+  mock.style.setProperty("--m-shadow-card", d1 ? "0 1px 2px 0 oklch(0 0 0 / .2), 0 2px 6px -1px oklch(0 0 0 / .28)" : "none");
+  mock.style.setProperty("--m-section-pad", d1 ? "clamp(2.5rem, 1.5rem + 3vw, 4.2rem)" : "34px");
+  mock.style.setProperty("--m-terminus", `oklch(0.66 0.15 ${state.hue})`);
+  document.getElementById("gridbg").classList.toggle("on", f.has("gridbg"));
+  document.getElementById("verdict").innerHTML = s.verdict +
+    (state.hue > 250 ? ` <span style="color:hsl(45 90% 65%)">⚠ terminus ${state.hue} = indigo territory — the rejected full-unification look; taste it, then come back to 188.</span>` : "");
+  runTickers(f.has("tickers") && state.anim);
+  renderControls();
+  updatePrompt();
+}
+
+let tickerTimers = [];
+function runTickers(on) {
+  tickerTimers.forEach(clearInterval); tickerTimers = [];
+  document.querySelectorAll("[data-count]").forEach(el => {
+    const target = +el.dataset.count;
+    if (!on) { el.textContent = target; return; }
+    let cur = 0; const step = Math.max(1, Math.round(target / 40));
+    el.textContent = "0";
+    const t = setInterval(() => {
+      cur = Math.min(target, cur + step);
+      el.textContent = cur;
+      if (cur >= target) clearInterval(t);
+    }, 28);
+    tickerTimers.push(t);
+  });
+}
+
+function renderControls() {
+  document.getElementById("stages").innerHTML = STAGES.map(s => `
+    <button class="stage-btn" data-id="${s.id}" aria-pressed="${state.stage === s.id}">
+      <span class="nm">${s.nm}${s.score ? `<span class="score">${s.score.toFixed(1)}</span>` : ""}</span>
+      <span class="d">${s.d}</span>
+    </button>`).join("");
+}
+
+function updatePrompt() {
+  const parts = [];
+  if (state.stage === "current") {
+    parts.push("Keep the current Circuit Forge styling on orchestkit.yonyon.ai (no design changes).");
+  } else {
+    parts.push(`Implement the docs-site design overhaul (docs/site, orchestkit repo) through stage ${state.stage.toUpperCase()}:`);
+    parts.push(`1. D1 Foundation (app/global.css only): port the portfolio token GRAMMAR onto the emerald anchor — radius ramp off 0.625rem (card = r+4), 2-layer card shadows, hover-lift (-4px + primary-tinted color-mix shadow), gradient-top-border on featured cards, eyebrow utility (12px/600/uppercase/.12em, emerald, mono), fluid section spacing clamps, prose measure 68ch, and a gradient terminus token at hue ${state.hue} (oklch(0.66 0.15 ${state.hue})) used ONLY decoratively (hero headline gradient, gradient borders). All glows color-mix'd from var(--color-fd-primary), never hardcoded. Keep ease-out-expo; adopt 150/200/400ms durations.${state.eyebrow ? "" : " SKIP eyebrows."}${state.lift ? "" : " SKIP hover-lift."}`);
+    if (state.stage === "d2" || state.stage === "d3") {
+      parts.push("2. D2 Component lift: add shadcn minimal-mode (components.json + cn() + ~20-line fd-alias bridge in global.css; fd-* stays canonical, no migration of existing components). Install from 21st.dev registry: NumberTicker (hero stats + primitives counts + cc-adoption-board tiles, min-width reserved per digit, reduced-motion shows final value), a flickering-grid hero background (color = var(--color-fd-primary), pointer-events-none, lazy-mounted, reduced-motion static), and spotlight-hover treatment on the three primitives cards only. Bundle delta budget < 30KB; add a lint note that new components use bg-fd-* utilities.");
+    }
+    if (state.stage === "d3") {
+      parts.push("3. D3 Signature hero: replace the hero art with a terminal card (HTML text, Geist Mono, CSS steps() line reveal, full transcript readable when static / reduced-motion) replaying the REAL 2026-07-17 session: /ork:brainstorm docs UX → 3 agents → 18 ideas → PRs #2963 + #2964 merged → live in 3h11m. Keep the transcript honest — regenerate it from a real session whenever it drifts.");
+    }
+    parts.push("Verify: golden before/after screenshots of landing + a guide page + a reference page at 2 widths; LCP unchanged on landing (webpagetest or lighthouse CI); contrast checks only where new color pairs appear (terminus is decorative-only). Ship as PR(s) with the playground-gate artifact; D1 first, D2 separate.");
+  }
+  document.getElementById("prompt").textContent = parts.join("\n");
+}
+
+document.addEventListener("click", e => {
+  const b = e.target.closest(".stage-btn");
+  if (b) { state.stage = b.dataset.id; applyStage(); }
+});
+document.getElementById("hue").addEventListener("input", e => {
+  state.hue = +e.target.value; document.getElementById("hueV").textContent = state.hue; applyStage();
+});
+document.getElementById("kEyebrow").addEventListener("change", e => { state.eyebrow = e.target.checked; applyStage(); });
+document.getElementById("kLift").addEventListener("change", e => { state.lift = e.target.checked; applyStage(); });
+document.getElementById("kAnim").addEventListener("change", e => { state.anim = e.target.checked; applyStage(); });
+
+// spotlight mouse tracking
+document.addEventListener("mousemove", e => {
+  const card = e.target.closest(".m-card");
+  if (!card || !mock.classList.contains("spotlight")) return;
+  const r = card.getBoundingClientRect();
+  card.style.setProperty("--mx", `${e.clientX - r.left}px`);
+  card.style.setProperty("--my", `${e.clientY - r.top}px`);
+});
+
+document.getElementById("copy").addEventListener("click", () => {
+  navigator.clipboard.writeText(document.getElementById("prompt").textContent).then(() => {
+    const b = document.getElementById("copy"); const t = b.textContent;
+    b.textContent = "Copied!"; setTimeout(() => (b.textContent = t), 1200);
+  });
+});
+
+applyStage();
+</script>
+</body>
+</html>

--- a/docs/site/__tests__/nav-structure.test.ts
+++ b/docs/site/__tests__/nav-structure.test.ts
@@ -3,10 +3,13 @@
 
 import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 
+// vitest runs with root = docs/site; cwd-relative resolution is stable across
+// direct invocation and the full suite (import.meta.url gets mangled by the
+// happy-dom transform in the latter).
 const content = (p: string) =>
-  JSON.parse(readFileSync(fileURLToPath(new URL(`../content/docs/${p}`, import.meta.url)), "utf8"));
+  JSON.parse(readFileSync(resolve(process.cwd(), "content", "docs", p), "utf8"));
 
 /**
  * Guards the sidebar information architecture:

--- a/docs/site/app/(home)/page.tsx
+++ b/docs/site/app/(home)/page.tsx
@@ -158,7 +158,7 @@ export default async function HomePage() {
                 Stop explaining your stack.
               </span>
               <br />
-              Start shipping.
+              <span className="headline-trace">Start shipping.</span>
             </h1>
           </AnimateOnView>
 
@@ -329,17 +329,8 @@ export default async function HomePage() {
               <Link
                 key={p.letter}
                 href={p.href}
-                className="group relative overflow-hidden rounded-[10px] border border-fd-border bg-[var(--color-fd-surface-raised)] p-5 transition-all duration-150 hover:-translate-y-px hover:border-[color-mix(in_oklch,var(--color-fd-primary)_40%,var(--color-fd-border))] hover:shadow-[0_0_0_4px_var(--color-fd-glow)]"
+                className="group card-elevated card-trace card-lift relative overflow-hidden rounded-[var(--radius-card)] border border-fd-border bg-[var(--color-fd-surface-raised)] p-5"
               >
-                {/* Top-accent shimmer on hover */}
-                <span
-                  aria-hidden="true"
-                  className="absolute inset-x-0 top-0 h-px opacity-0 transition-opacity duration-150 group-hover:opacity-100"
-                  style={{
-                    background:
-                      "linear-gradient(90deg, transparent 0%, color-mix(in oklch, var(--color-fd-primary) 40%, transparent) 50%, transparent 100%)",
-                  }}
-                />
                 <div className="mb-5 flex items-start justify-between">
                   <div
                     aria-hidden="true"

--- a/docs/site/app/global.css
+++ b/docs/site/app/global.css
@@ -53,6 +53,10 @@
   /* Glow token — transparent emerald for hover effects, focus rings */
   --color-fd-glow: oklch(0.696 0.170 163 / 0.25);
 
+  /* Gradient terminus — the "powered trace" endpoint. Decorative ONLY
+     (gradients, borders); never text, never interactive. +26° from primary,
+     mirroring the portfolio's primary→terminus hue relationship. */
+  --color-fd-terminus: oklch(0.62 0.14 188);
 }
 
 /* ============================================================
@@ -92,6 +96,9 @@
 
   /* Glow — brighter in dark mode */
   --color-fd-glow: oklch(0.696 0.170 163 / 0.30);
+
+  /* Terminus — lifted for dark surfaces, still decorative-only */
+  --color-fd-terminus: oklch(0.78 0.12 188);
 }
 
 /* Semantic colors required by Fumadocs preset */
@@ -110,14 +117,36 @@
 :root {
   --color-success: oklch(0.696 0.170 163); /* #10b981 */
   --duration-fast: 150ms;
+  --duration-base: 200ms;
   --duration-normal: 300ms;
-  --duration-slow: 500ms;
+  --duration-slow: 400ms;
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
   color-scheme: light;
+
+  /* Radius ramp — semantic slots off one base (portfolio grammar) */
+  --radius-base: 0.625rem;
+  --radius-card: calc(var(--radius-base) + 4px);    /* 14px */
+  --radius-control: calc(var(--radius-base) - 2px); /* 8px  */
+  --radius-pill: 9999px;
+
+  /* Elevation — 2-layer subtle card shadow + overlay; glow derives from
+     primary via color-mix so it stays hue-portable */
+  --shadow-card: 0 1px 2px 0 oklch(0 0 0 / 0.04), 0 2px 6px -1px oklch(0 0 0 / 0.08);
+  --shadow-overlay: 0 16px 48px -8px oklch(0 0 0 / 0.24);
+  --shadow-glow: 0 0 20px color-mix(in oklch, var(--color-fd-primary) 25%, transparent);
+
+  /* Fluid spacing — section rhythm scales with viewport */
+  --section-y: clamp(2.5rem, 1.5rem + 3vw, 4.5rem);
+  --section-x: clamp(1rem, 0.5rem + 2vw, 2rem);
+
+  /* The signature: a powered circuit trace, primary → terminus */
+  --gradient-trace: linear-gradient(135deg, var(--color-fd-primary), var(--color-fd-terminus));
 }
 
 .dark {
   color-scheme: dark;
+  --shadow-card: 0 1px 2px 0 oklch(0 0 0 / 0.20), 0 2px 6px -1px oklch(0 0 0 / 0.28);
+  --shadow-overlay: 0 16px 48px -8px oklch(0 0 0 / 0.55);
 }
 
 /* ============================================================
@@ -172,6 +201,83 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-fd-muted-foreground);
+}
+
+/* ============================================================
+   SURFACE SYSTEM — cards, traces, lifts (the D1 grammar)
+   Featured surfaces only; dense index lists stay quiet.
+   ============================================================ */
+
+/* Elevated card: soft 2-layer shadow + card radius */
+.card-elevated {
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-card);
+}
+
+/* Powered trace — the signature. A 2px primary→terminus gradient along the
+   top edge; brightens on hover like a live circuit. */
+.card-trace {
+  position: relative;
+  overflow: hidden;
+}
+.card-trace::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--gradient-trace);
+  opacity: 0.65;
+  transition: opacity var(--duration-base) var(--ease-out-expo);
+}
+.card-trace:hover::before {
+  opacity: 1;
+}
+
+/* Headline trace — gradient text span for hero/section headlines.
+   Decorative emphasis only; surrounding text carries the accessible color. */
+.headline-trace {
+  background: var(--gradient-trace);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .card-lift {
+    transition:
+      transform var(--duration-base) var(--ease-out-expo),
+      box-shadow var(--duration-base) var(--ease-out-expo),
+      border-color var(--duration-base) var(--ease-out-expo);
+  }
+  .card-lift:hover {
+    transform: translateY(-4px);
+    box-shadow:
+      0 12px 24px -8px color-mix(in oklch, var(--color-fd-primary) 15%, transparent),
+      0 4px 24px color-mix(in oklch, var(--color-fd-primary) 12%, transparent);
+    border-color: color-mix(in oklch, var(--color-fd-primary) 30%, var(--color-fd-border));
+  }
+  .btn-glow {
+    transition:
+      transform var(--duration-fast) var(--ease-out-expo),
+      box-shadow var(--duration-fast) var(--ease-out-expo);
+  }
+  .btn-glow:hover {
+    transform: scale(1.03);
+    box-shadow: var(--shadow-glow);
+  }
+}
+
+/* Fluid section rhythm */
+.section-flow {
+  padding-block: var(--section-y);
+}
+
+/* Reading measure for docs prose — long-form pages cap at a comfortable line
+   length even on wide viewports (the layout is full-width). */
+#nd-docs-layout article .prose {
+  max-width: 68ch;
 }
 
 /* ============================================================

--- a/docs/site/components/cc-adoption-board.tsx
+++ b/docs/site/components/cc-adoption-board.tsx
@@ -45,7 +45,7 @@ export function CcAdoptionBoard() {
         ].map((t) => (
           <div
             key={t.k}
-            className="rounded-lg border p-4"
+            className="card-elevated rounded-[var(--radius-card)] border p-4"
             style={{ borderColor: "var(--color-fd-border)", background: "var(--color-fd-card)" }}
           >
             <div className="font-mono text-xl font-bold" style={{ color: "var(--color-fd-foreground)" }}>

--- a/docs/site/components/lab-gallery.tsx
+++ b/docs/site/components/lab-gallery.tsx
@@ -6,7 +6,7 @@ import { LAB_ENTRIES, type LabEntry } from "@/lib/generated/lab-data";
 function LabCard({ entry }: { entry: LabEntry }) {
   return (
     <div
-      className="flex flex-col rounded-lg border p-5 transition-all duration-200 hover:shadow-md"
+      className={`card-elevated card-lift flex flex-col rounded-[var(--radius-card)] border p-5 ${entry.featured ? "card-trace" : ""}`}
       style={{ borderColor: "var(--color-fd-border)", background: "var(--color-fd-card)" }}
     >
       <div className="flex items-start justify-between gap-2">


### PR DESCRIPTION
## Summary

D1 "Foundation" bundle from the design brainstorm (owner-picked): the yonyon.ai portfolio's token GRAMMAR ported onto the Circuit Forge emerald anchor. No hue change, no new dependencies, pure CSS + surgical class application.

- **Tokens** (`global.css`): terminus color at +26 degrees (teal 188, decorative-only), `--gradient-trace`, radius ramp (card/control/pill off 0.625rem), 2-layer card shadow + overlay + primary-derived glow (all `color-mix`, hue-portable), fluid section clamps, 200ms base duration.
- **Surface system**: `.card-trace` — the signature "powered trace": a 2px primary→terminus gradient top edge that brightens on hover; `.card-elevated`, `.card-lift` (featured surfaces only), `.btn-glow`, `.headline-trace`, `.section-flow`, 68ch prose measure.
- **Applied**: hero action line ("Start shipping." wears the trace), primitives cards (replaces the hover-only shimmer; radius 10→14px, real elevation), Lab gallery cards (trace on featured), adoption-board tiles. Dense index lists deliberately untouched.
- **Also fixes**: `nav-structure.test.ts` path resolution failing under the full vitest suite (import.meta.url mangled by the happy-dom transform; invisible to CI because the docs-site vitest suite is not wired into repo CI — filed separately).

## Playground

Decision playground for the overhaul (stages, knobs, terminus-hue slider): `docs/feat--docs-design-foundation/index.html`.

## Verification

- Full site suite unmasked exit code: 318/318, 25 files
- 273 MDX compile, `next build` green in an isolated worktree
- Before/after screenshots on the built site: hero gradient, card traces, elevation all render (early blank-hero was cold-start compile timing, verified fine at steady state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

