### PR TITLE
ci: skip autoheal on dependabot PRs instead of failing

### DIFF
--- a/.github/workflows/skill-autobuild.yml
+++ b/.github/workflows/skill-autobuild.yml
@@ -55,7 +55,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # SAME-REPO ONLY — never run (or grant write) for fork PRs.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    #
+    # DEPENDABOT IS EXCLUDED ON PURPOSE. Dependabot-triggered runs read from
+    # GitHub's separate *Dependabot* secret store, so `secrets.RELEASE_BOT_*`
+    # resolve to empty strings and the token mint below dies in ~4s with
+    # "'app-id' input must be set to a non-empty string". That surfaced as a
+    # red `autoheal` check claiming the heal failed when it had never run,
+    # which is actively misleading during triage.
+    #
+    # Skipping keeps the signal honest. When Dependabot bumps a dep under
+    # src/** (e.g. src/hooks/package.json), the generated mirror in plugins/
+    # goes stale and ci.yml's "Build drift detected" gate fails correctly.
+    # Fix it by hand: check out the PR branch, `npm run build`, commit the
+    # regenerated artifacts. See the PR that added this comment for the full
+    # write-up of why the alternatives were rejected.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
     # GITHUB_TOKEN stays read-only; the heal commit is pushed with the App token
     # (#2528-A) so required checks re-trigger on the healed SHA.
     permissions:


### PR DESCRIPTION
## Problem

Dependabot PRs that touch `src/**` produced a red `autoheal` check that had
never actually run. Root-caused while clearing #3006 (biome 2.5.4).

```
autoheal on #3006 -> failed in 4s at step 1
Error: 'app-id' input must be set to a non-empty string
```

GitHub keeps Dependabot secrets in a store separate from Actions secrets, so
`secrets.RELEASE_BOT_*` resolve to empty in a dependabot-triggered run and the
token mint fails before the build ever starts.

Verified:

| store | RELEASE_BOT_APP_ID | RELEASE_BOT_PRIVATE_KEY |
|---|---|---|
| Actions | present | present |
| Dependabot | missing | missing |

## Fix

Guard the job on the PR author so dependabot PRs skip cleanly rather than
reporting a failure that never happened.

The `Build drift detected` gate in `ci.yml` still fails correctly on these PRs.
That failure is real and wanted: dependabot cannot run `npm run build`, so the
generated mirror under `plugins/` goes stale. The manual fix is now documented
inline in the workflow.

## Alternatives rejected

- **Rotate the App key into the Dependabot store.** Real fix, but the existing
  private key is unreadable (write-only in GitHub, absent from 1Password), so it
  would require rotating a key every other workflow depends on to solve a roughly
  monthly five-minute chore.
- **`pull_request_target`.** Grants secrets, but pairs a write-capable token with
  `npm run build` over PR-controlled content, which is an arbitrary code execution
  path via lockfile install scripts. The workflow's own header warns against it.

## Verification

- `actionlint` exit 0, no findings in this file
- YAML parses; guard resolves to a single expression
- pre-commit workflow lint passed

playground: not applicable, CI-only change with no user-visible surface.