### PR TITLE
ci: pin actions in skill-claims-audit to SHA

### DIFF
--- a/.github/workflows/skill-claims-audit.yml
+++ b/.github/workflows/skill-claims-audit.yml
@@ -20,9 +20,9 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
           node-version: 22
 


### PR DESCRIPTION
## Problem

`skill-claims-audit.yml` was the **only** workflow in the repo using tag refs instead of SHA pins. Two tools flagged it, four open alerts:

| alert | tool | severity | line |
|---|---|---|---|
| #324 | zizmor `unpinned-uses` | error | 25 |
| #323 | zizmor `unpinned-uses` | error | 23 |
| #328 | Scorecard `Pinned-Dependencies` | medium | 25 |
| #327 | Scorecard `Pinned-Dependencies` | medium | 23 |

## Fix

Pin both to the exact SHAs the rest of the repo already uses:

```
actions/checkout    9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
actions/setup-node  820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
```

SHAs cross-verified two ways: grep of the repo's other workflows, and a fresh `gh api repos/actions/*/git/ref/tags/v7.0.0` lookup — both agree.

## Verification

- `grep` for `uses: .*@<non-40-char-sha>` across all workflows: **0 remaining**
- `actionlint .github/workflows/skill-claims-audit.yml`: exit 0
- matches the repo's own `.claude/rules/ci-workflows.md`: "Pin action versions to SHA, not tags"

Closes the four alerts on merge (Scorecard/zizmor re-scan).

This is a CI-config-only change (`ci/` branch), no user-facing surface to playground.