### PR TITLE
docs: mark the gap register resolved and document the four gates

### DIFF
--- a/docs/catalog-currency-audit/GAPS.md
+++ b/docs/catalog-currency-audit/GAPS.md
@@ -1,8 +1,44 @@
 # OrchestKit Gap Register
 
-**Compiled** 2026-07-21 · **Branch** `test/trigger-evals-testing-family` · **Assess verdict** FAIL (C, 5.86), security blocker
+**Compiled** 2026-07-21 · **Assess verdict at time of writing** FAIL (C, 5.86), security blocker
 
 Every gap below was verified at `file:line` during the audit. Items marked ✅ VERIFIED were reproduced or read directly; items marked 🔬 REPRODUCED were executed live.
+
+---
+
+## ⚠️ RESOLUTION STATUS (read this first)
+
+**Most of this register is CLOSED.** It was compiled *before* remediation and the tables below describe the state at audit time, not now. Merged to `main` as `a1490b022`, 2026-07-21.
+
+| section | status |
+|---|---|
+| **A. Security** | ✅ closed — A1/A2 `node:20` (0 refs), A4 OWASP 2021→2025, A6 `curl\|sh`, A7 crypto label, A8 `passlib`→`argon2-cffi`, A9 pyjwt floor, A10 Argon2id. **A5 supply-chain** shipped as `security-patterns/rules/supply-chain.md` |
+| **B. Correctness** | ✅ closed — B1/B2 `gh` flags (0 live usages), B3-B6 Storybook (0 `@storybook/test`), B7 Pydantic v2, B8 Tailwind v4, B9 `motion` rename, B10 `gemini-2.5-pro` (0 refs) |
+| **C. Consistency** | ✅ closed — C1 LangGraph unified on 1.2. C2-C5 re-examined and found to be **legitimate history**, not drift (see below) |
+| **D. Stale** | ✅ closed — D1 guide deleted, D3 superlatives replaced with an alias pointer |
+| **E. Detection** | ✅ closed — E1 `test-model-recency.sh`, E2 `test-targets-floor-agreement.mjs`, E3 resolved |
+| **F. Eval harness** | 🟡 partial — F2 budget governor shipped. F1/F3 remain open |
+
+### A3 was a FALSE POSITIVE, do not "fix" it
+
+A3 claimed 3 of 5 OWASP IDs were mis-mapped in `owasp-top10-fixes.md`. **They were already correct.** That file is explicitly built on OWASP Top 10:**2025** (its title and body say so); the finding was validated against the **2021** list by mistake. Renumbering would have introduced the bug. A remediation agent correctly refused this instruction.
+
+### C2-C5 are mostly legitimate history
+
+A later pass found the remaining Playwright 1.58 / Biome 2.0 / pgvector 0.7 references are a link to release notes and "feature landed in version X" statements, not competing floors. A prose-based detector for this was built, measured at near-zero precision, and **deleted rather than shipped**. `test-targets-floor-agreement.mjs` checks only `targets:` frontmatter, which is unambiguous.
+
+### Still open
+
+| # | gap | why |
+|---|---|---|
+| F1 | `implement` trigger recall never measured | needs a run; see the routing caveat below |
+| F3 | 36 agent eval specs, 0 workflows reference them | cost decision, not code |
+| — | 37 model-recency, 7 collisions, 15 unreachable | all **ratcheted**, can only improve |
+| — | `assess-verdict.json` holds a foreign assessment | needs a merge/discard call |
+
+### ⚠️ Caveat on the whole trigger-eval direction
+
+2026 routing research (SkillRouter, Alibaba 2026-04; *Multi-Agent Routing as Set-Valued Prediction*, arXiv 2606.28925) finds routing keys on the skill **body** more than metadata, and is **set-valued multi-label** rather than per-skill binary. The "trigger contradictions" check in `test-skill-coverage.sh` therefore encodes the wrong model: a prompt legitimately claimed by two skills is normal, not a defect. It reports 0 today. Drop or invert it before it fires.
 
 ---
 

--- a/docs/catalog-currency-audit/GATES.md
+++ b/docs/catalog-currency-audit/GATES.md
@@ -1,0 +1,72 @@
+# Deterministic catalog gates
+
+Four gates added 2026-07-21 (merged as `a1490b022`). All are **$0**: no LLM calls, no network, no quota, no 1Password prompt. Together they took deterministic coverage from **31 of 114 skills to 114 of 114**.
+
+They exist because the paid eval path could not cover them. Background skills activate by description matching, and **skill activation is not observable** in `claude -p` output: the `system/init` event lists AVAILABLE skills, but nothing reports which was SELECTED. For most of the corpus a static gate is the only coverage that can exist.
+
+---
+
+## Why they are ratchets
+
+Three of the four carry a committed baseline and fail only when a count **increases**. Pre-existing findings therefore do not redden every PR, and the number can only be driven down. Same contract as `scripts/eval/route-check.mjs`.
+
+`--update-baseline` regenerates, and should only be run when a finding is genuinely resolved.
+
+| gate | file | baseline | today |
+|---|---|---|---|
+| skill coverage | `tests/skills/triggering/test-skill-coverage.sh` | `skill-coverage-baseline.json` | 7 collisions, 15 unreachable, 0 contradictions |
+| model recency | `tests/skills/structure/test-model-recency.sh` | `model-recency-baseline.json` | 37 across 23 files |
+| targets floor | `tests/skills/structure/test-targets-floor-agreement.mjs` | none, **hard gate at 0** | 25 libraries, 3 shared, 0 conflicts |
+| budget governor | `tests/evals/scripts/lib/budget-governor.sh` | n/a, runtime guard | 15/15 self-test |
+
+All are named `test-*.sh` / `test-*.mjs` so `scripts/ci/run-tests.sh` discovers them, which `ci.yml` already runs for `tests/skills`. **Naming is what makes them live rather than dead** — a prior `.mjs` gate in this repo sat unrun because the runner globbed only `test-*.sh`.
+
+---
+
+## 1. Skill coverage
+
+Three checks over all 114 skills:
+
+- **description collisions** — two skills competing for the same prompts. An n-gram must carry a token appearing in ≤5 descriptions, and structural words (`use`, `when`, `this`, `skill`, `looking`) are excluded by name. Rarity alone was not enough: `"use this skill when"` survived because the literal word "skill" is rare in descriptions. That filter took the count from 9 to 7 and removed both false positives.
+- **reachability** — no slash command, no model invocation, and no agent `skills:` entry.
+- **trigger contradictions** — one prompt claimed `should_trigger: true` by two skills.
+
+> ⚠️ **The contradictions check encodes the wrong model.** 2026 routing research treats routing as set-valued multi-label: one prompt legitimately needs several skills. It reports 0 today, so it is harmless, but drop or invert it before it fires on a corpus improvement. See `GAPS.md`.
+
+## 2. Model recency
+
+`test-model-id-vocab.sh` validates model tokens against `fullIds ∪ historicalIds`. That checks whether an ID is **known**, never whether it is **current**, so a superseded model passes forever.
+
+`models.vocab.json` already carried the answer: `aliases` is documented as *"shortName → current latest full ID per channel"*. **No test read it** — a grep for `aliases` across `tests/` returned one comment.
+
+This gate consumes `aliases` and reports tokens in `fullIds` that are not their channel's current target. Superseded IDs are legitimate in migration ladders, historical changelogs, monitoring patterns and multi-model pricing tables, so only recommendation-shaped references count, history paths are skipped, and an inline `model-recency-ok:` marker opts a line out.
+
+## 3. Targets floor agreement
+
+Fails when two skills declare different floors for one library in `targets:` frontmatter. LangGraph once carried four floors across four files and nothing detected it: `check-labs-versions.mjs` compares a pin against real **upstream**, `test-upstream-version-drift.mjs` compares a skill's prose against its **own** pin, and neither compares two skills to each other.
+
+**It deliberately ignores prose.** A first attempt scanned for `"Lib N.N"` and reported four divergent libraries; every one was legitimate (a link to Playwright 1.58 release notes, `"type-aware rules (Biome 2.0+)"`, `"halfvec (pgvector 0.7+)"`, `"MessageGraph is deprecated in LangGraph v1.0.0"`). A lexical scan cannot separate *"requires >= X"* from *"feature Y landed in X"*. That version was deleted rather than baselined into noise.
+
+## 4. Budget governor
+
+Not a test. A runtime guard sourced by `run-skill-eval.sh` and `run-quality-eval.sh`.
+
+- `record_cap_exhausted()` persists the observation when a generation is classified HTTP 429, parsing the reset time when the message carries one.
+- `budget_check()` gates a run before it commits to N calls. On a live cap it exits **2**, the harness's established "could not measure" code, so an unaffordable run reads INCONCLUSIVE rather than as a failure.
+
+**Deliberately conservative:** it refuses only with a parsed reset time still in the future. An unparseable message proceeds, and dry runs are never gated. A governor that blocks on a guess would silently stop measurement for the wrong reason.
+
+State lives under `tests/evals/results/`, already gitignored. Clear a stale block with `rm tests/evals/results/.budget-state.json`.
+
+---
+
+## Running them
+
+```bash
+bash tests/skills/triggering/test-skill-coverage.sh
+bash tests/skills/structure/test-model-recency.sh
+node tests/skills/structure/test-targets-floor-agreement.mjs
+bash tests/evals/test-budget-governor.sh          # governor self-test, 15 cases
+```
+
+Add `--update-baseline` to the two ratchets only when a finding is genuinely fixed.

--- a/docs/docs--gap-register-resolution/index.html
+++ b/docs/docs--gap-register-resolution/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Gap register resolution</title>
+<style>
+:root{--bg:hsl(232 26% 7%);--ink:hsl(220 18% 93%);--muted:hsl(220 12% 64%);
+--faint:hsl(220 10% 46%);--glass:hsl(0 0% 100% / .05);--edge:hsl(0 0% 100% / .18);
+--ok:hsl(152 52% 50%);--warn:hsl(43 88% 60%);--bad:hsl(2 68% 58%);--r:16px}
+*{box-sizing:border-box;margin:0;padding:0}
+body{background:radial-gradient(900px 600px at 12% 4%,hsl(248 70% 40% / .20),transparent 60%),var(--bg);
+color:var(--ink);font:400 15px/1.6 ui-sans-serif,-apple-system,"Segoe UI",Inter,system-ui,sans-serif;padding:48px 24px 96px}
+.wrap{max-width:920px;margin:0 auto}
+.eyebrow{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--faint);font-weight:600;margin-block-end:12px}
+h1{font-size:30px;font-weight:700;letter-spacing:-.3px;line-height:1.15}
+.lede{color:var(--muted);margin-block-start:12px;max-width:70ch}
+.card{background:var(--glass);border:1px solid var(--edge);border-radius:var(--r);padding:22px;margin-block-start:24px}
+h2{font-size:18px;font-weight:650;margin-block-end:14px}
+table{width:100%;border-collapse:collapse;font-size:14px}
+th{text-align:left;font-size:11px;letter-spacing:.09em;text-transform:uppercase;color:var(--faint);padding:0 10px 10px 0}
+td{padding:9px 10px 9px 0;border-block-start:1px solid hsl(0 0% 100% / .07);vertical-align:top}
+.ok{color:var(--ok);font-weight:650}.warn{color:var(--warn);font-weight:650}.bad{color:var(--bad);font-weight:650}
+.mono{font-family:ui-monospace,Menlo,monospace}
+.note{margin-block-start:16px;padding:12px 14px;border-radius:9px;background:hsl(0 0% 100% / .08);
+border-inline-start:3px solid var(--warn);font-size:14px;color:hsl(43 60% 82%)}
+</style></head><body><div class="wrap">
+<div class="eyebrow">docs only · follow-up to a1490b022</div>
+<h1>Gap register: what is actually closed</h1>
+<p class="lede">GAPS.md was compiled before remediation and described everything as open. Anyone reading it would redo finished work. This marks each section resolved and documents the four new gates, which lived in zero markdown files.</p>
+
+<div class="card"><h2>Resolution</h2>
+<table><thead><tr><th>Section</th><th>Status</th><th>Evidence</th></tr></thead><tbody>
+<tr><td>A. Security</td><td class="ok">closed</td><td class="mono">node:20 → 0 refs · OWASP 2025 · supply-chain rule added</td></tr>
+<tr><td>B. Correctness</td><td class="ok">closed</td><td class="mono">gh flags → 0 · @storybook/test → 0 · gemini-2.5-pro → 0</td></tr>
+<tr><td>C. Consistency</td><td class="ok">closed</td><td class="mono">LangGraph unified on 1.2</td></tr>
+<tr><td>D. Stale</td><td class="ok">closed</td><td class="mono">2.1.47 guide deleted · superlatives replaced</td></tr>
+<tr><td>E. Detection</td><td class="ok">closed</td><td class="mono">3 new gates, 114/114 skills covered</td></tr>
+<tr><td>F. Eval harness</td><td class="warn">partial</td><td class="mono">governor shipped · F1/F3 open</td></tr>
+</tbody></table></div>
+
+<div class="card"><h2>Two corrections the register got wrong</h2>
+<table><thead><tr><th>Claim</th><th>Reality</th></tr></thead><tbody>
+<tr><td class="mono">A3: 3 of 5 OWASP IDs mis-mapped</td><td class="bad">FALSE POSITIVE — the file is built on Top 10:2025 where those headings are already correct. Validated against the 2021 list by mistake.</td></tr>
+<tr><td class="mono">C2-C5: version drift</td><td class="warn">Mostly legitimate history: a release-notes link and "feature landed in X" statements, not competing floors.</td></tr>
+</tbody></table></div>
+
+<div class="card"><h2>The four gates, now documented</h2>
+<table><thead><tr><th>Gate</th><th>Catches</th><th>Shape</th></tr></thead><tbody>
+<tr><td class="mono">test-skill-coverage</td><td>collisions, reachability, contradictions</td><td>ratchet</td></tr>
+<tr><td class="mono">test-model-recency</td><td>valid but not latest for its channel</td><td>ratchet</td></tr>
+<tr><td class="mono">test-targets-floor-agreement</td><td>two skills, one library, two floors</td><td>hard gate at 0</td></tr>
+<tr><td class="mono">budget-governor</td><td>a run the weekly cap cannot pay for</td><td>runtime guard</td></tr>
+</tbody></table>
+<div class="note">All four are $0: no LLM calls, no network, no quota. Together they took deterministic coverage from 31 of 114 skills to 114 of 114.</div></div>
+
+<div class="card"><h2>Caveat carried into both docs</h2>
+<p class="lede">2026 routing research (SkillRouter; Multi-Agent Routing as Set-Valued Prediction) finds routing keys on the skill <strong>body</strong> more than metadata, and is <strong>set-valued multi-label</strong> rather than per-skill binary. The "trigger contradictions" check therefore encodes the wrong model: a prompt legitimately claimed by two skills is normal, not a defect. It reports 0 today. Drop or invert it before it fires.</p></div>
+</div></body></html>


### PR DESCRIPTION
Docs only. Follow-up to `a1490b022`.

## Why

`GAPS.md` was compiled **before** remediation and still described everything as open. Anyone reading it would redo finished work: `node:20`, the `gh` flags, the Storybook imports, `gemini-2.5-pro` and the 2.1.47 guide are all fixed and on main.

Three of the four new gates were referenced in **zero** markdown files, so a contributor had no way to learn they exist, why they are ratchets, or how to update a baseline.

## What changed

- `GAPS.md` gains a resolution status per section, pinned to the merge SHA
- `GATES.md` is new: what each gate catches, its false-positive defences, and how to run it

## Two corrections the register got wrong

**A3 was a false positive.** It claimed 3 of 5 OWASP IDs were mis-mapped in `owasp-top10-fixes.md`. That file is explicitly built on OWASP Top 10:**2025**, where those headings are already correct; the finding was validated against the **2021** list by mistake. A remediation agent refused the instruction, correctly. Renumbering would have introduced the bug.

**C2-C5 are mostly legitimate history.** The remaining Playwright 1.58 / Biome 2.0 / pgvector 0.7 references are a release-notes link and "feature landed in version X" statements, not competing floors.

## Caveat now recorded in both docs

2026 routing research (SkillRouter, Alibaba 2026-04; *Multi-Agent Routing as Set-Valued Prediction*, arXiv 2606.28925) finds routing keys on the skill **body** more than metadata, and is **set-valued multi-label** rather than per-skill binary.

The "trigger contradictions" check in `test-skill-coverage.sh` therefore encodes the wrong model: a prompt legitimately claimed by two skills is normal, not a defect. It reports 0 today so it is harmless, but it should be dropped or inverted before it fires on a corpus improvement.

## Playground

`docs/docs--gap-register-resolution/index.html` — resolution status, the two corrections, and the four gates.
