### PR TITLE
ci: fix playground gate messaging and release-PR stranding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -716,7 +716,7 @@ jobs:
           echo "Lint: ${{ needs.lint.result }}"
           echo "Security Audit: ${{ needs.security-audit.result }}"
           echo "Secret Scanning: ${{ needs.secret-scanning.result }}"
-          echo "PR Playground: ${{ needs.playground-check.result }}  (advisory, non-blocking)"
+          echo "PR Playground: ${{ needs.playground-check.result }}  (required check — gates merge on its own; not re-aggregated here)"
           echo "Unit Tests: ${{ needs.unit-tests.result }}"
           echo "Hook TS Tests: ${{ needs.hook-typescript-tests.result }}"
           echo "Security Tests: ${{ needs.security-tests.result }}"
@@ -732,14 +732,18 @@ jobs:
           # ADVISORY jobs are reported above but MUST NOT fail this summary.
           #
           # playground-check asks for a hand-authored HTML playground per PR.
-          # It is not in the repo's required-status-checks list, so it reads as
-          # advisory — but it was included in the blocking loop below, and this
-          # summary IS required. A docs/tooling PR with no user-visible surface
-          # therefore hit: playground-check fails -> CI Summary fails ->
-          # required check red -> unmergeable, with nothing actually broken.
-          # An advisory gate should not become load-bearing by aggregation.
+          # It IS in the repo's required-status-checks list, so a red
+          # playground-check already makes the PR unmergeable on its own.
+          # This summary is ALSO required, so counting playground-check in the
+          # blocking loop below would fail the same PR twice for one cause and
+          # obscure which gate actually needs attention. It is therefore
+          # reported here but deliberately NOT re-aggregated.
+          #
+          # Do not describe this gate as "advisory" — it blocks. The exemptions
+          # are branch-based (bot PRs, and the dependabot/ release-please/
+          # renovate/ chore-cc-snapshot-/ ci/ prefixes), not severity-based.
           if [[ "${{ needs.playground-check.result }}" == "failure" ]]; then
-            echo "::warning title=PR Playground (advisory)::No playground found for this PR. Not blocking the CI Summary. Add docs/<branch-slug>/*.html when the change has a user-visible surface worth demonstrating."
+            echo "::warning title=PR Playground::No playground found for this PR. The PR Playground check is REQUIRED and will block merge until this is resolved (this summary does not re-aggregate it). Add docs/<branch-slug>/*.html, or use a documented exempt branch prefix if the change has no user-visible surface."
           fi
 
           # Fail only on explicit failures (skipped jobs are OK - they use path filters)

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -78,12 +78,57 @@ jobs:
       # (avoids hard-failing CI for older runner images).
       - name: Validate plugin tag (CC 2.1.118+)
         if: ${{ steps.release.outputs.release_created == 'true' }}
+        # justify: best-effort https://github.com/yonatangross/orchestkit/issues/3062
+        # Dry-run validation only; the tag itself is created by release-please's
+        # GitHub Release step, so a runner without the claude CLI must not fail
+        # an otherwise-good release.
         continue-on-error: true
         run: |
           if command -v claude >/dev/null 2>&1; then
             claude plugin tag "${{ steps.release.outputs.version }}" --dry-run
           else
             echo "::notice::claude CLI not present on runner — skipping plugin tag validation"
+          fi
+
+      # Keep an open release PR mergeable (#3062).
+      #
+      # `.release-please-config.json` sets exclude-paths: ["docs"], so a
+      # docs-only merge is correctly a no-op for the release ("PR #N remained
+      # the same") and release-please does NOT force-push the release branch.
+      # main moves on regardless, so the release PR drifts BEHIND — and main
+      # requires up-to-date branches, which silently strands the release until
+      # someone runs update-branch by hand. A run of docs-only merges can hold
+      # a release indefinitely with nothing surfacing why.
+      #
+      # Idempotent and self-limiting: it only acts when the PR is actually
+      # BEHIND, and whenever release-please does regenerate the branch it
+      # force-pushes anyway, harmlessly discarding this merge.
+      - name: Keep open release PR up to date
+        # justify: best-effort https://github.com/yonatangross/orchestkit/issues/3062
+        # Convenience only — it must never fail a release run. The outcome is
+        # always announced via ::notice/::warning below, so a no-op is visible
+        # in the log rather than silent.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -uo pipefail
+          PR=$(gh pr list --state open \
+                 --json number,headRefName,mergeStateStatus \
+                 --jq '[.[] | select(.headRefName | startswith("release-please--"))][0]' 2>/dev/null || echo "")
+          if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+            echo "::notice::No open release PR — nothing to update."
+            exit 0
+          fi
+          NUM=$(printf '%s' "$PR" | jq -r '.number')
+          STATE=$(printf '%s' "$PR" | jq -r '.mergeStateStatus')
+          echo "::notice::Open release PR #${NUM} is ${STATE}"
+          if [ "$STATE" = "BEHIND" ]; then
+            echo "::notice::Release PR #${NUM} is BEHIND main — bringing it up to date."
+            gh pr update-branch "$NUM" \
+              || echo "::warning::update-branch failed for #${NUM}; update it manually before merging."
+          else
+            echo "::notice::Release PR #${NUM} is not BEHIND — no update needed."
           fi
 
   # NOTE: Version sync to manifests, pyproject.toml, and CLAUDE.md is handled


### PR DESCRIPTION
Closes #3061
Closes #3062

Two CI messaging/mechanism mismatches, both hit for real in one session. Neither changes gate behaviour — one makes the workflow stop asserting something false about itself, the other automates the manual step that a correct-but-silent release-please decision leaves behind.

## #3061 — a required gate described as advisory

`CI Summary` printed `PR Playground: … (advisory, non-blocking)` on the stated premise that it *"is not in the repo's required-status-checks list."*

That premise is false:

```
$ gh api repos/.../branches/main/protection/required_status_checks/contexts
[..., "CI Summary", "Agents & Skills", "CC Plugin Validate",
 "Manifests & Schemas", "PR Playground"]
```

`PR Playground` **is** required, so a red `playground-check` blocks merge on its own. I read that comment, concluded the gate was advisory, skipped the playground on a one-file docs PR (#3059), and it went `BLOCKED`. I had also told the operator twice it was advisory — wrong both times, sourced from this wording.

There's a second trap worth knowing: `gh pr view --json statusCheckRollup` reports `isRequired: null` for it, because that field reflects **rulesets**, not **classic** branch protection. So the natural programmatic check agrees with the wrong answer.

**What changed:** wording only. The deliberate non-aggregation stays — counting a required gate inside a required summary fails one PR twice for one cause. The warning now names the real consequence (it blocks) and the real exemptions (branch-prefix based: bot PRs and `dependabot/`, `release-please`, `renovate/`, `chore/cc-snapshot-`, `ci/`), not a severity that doesn't exist.

## #3062 — release PRs strand BEHIND on docs-only merges

`.release-please-config.json` sets `exclude-paths: ["docs"]`, so a docs-only merge is correctly a no-op for the release:

```
found 1 open release pull requests.
PR .../pull/3050 remained the same
```

Correct — but `main` moved, so the release PR drifts `BEHIND`, and `main` requires up-to-date branches:

```
X Pull request #3050 is not mergeable: the head branch is not up to date with the base branch.
```

release-please won't fix it (it only force-pushes when *releasable* commits appear), and nothing surfaces the problem. Two docs-only PRs (#3055, #3060) did precisely this to 8.84.0 today; it needed a manual `gh pr update-branch` that nothing prompted.

**What changed:** a best-effort step that updates an open release PR **only when it is actually `BEHIND`**. Idempotent — release-please force-pushes the branch whenever it does regenerate, harmlessly discarding the merge. Every outcome is announced via `::notice`/`::warning`, so a no-op is visible in the log rather than silent.

That last point is deliberate: `check-silent-failures.py` blocked this step until justified, citing the M134 watchdog that "ran green while not recovering" — the same shape as the release-please no-op that caused #3062. The pre-existing `continue-on-error` on the plugin-tag step was also missing a justification; it now has one.

## Verification

```
actionlint ......... exit 0 on both workflows (+ pre-commit's own pass: OK)
YAML ............... both files parse
new step logic ..... executed against LIVE gh -> no open release PR ->
                     clean ::notice, exit 0
                     replayed vs #3050's recorded head ref + BEHIND ->
                     selects #3050, ignores unrelated open PRs
```

## Note on the branch prefix

This is on `ci/`, which is one of the playground gate's own documented exemptions for config-only branches (`ci.yml:197` — "`.github/` … nothing user-facing to playground"). Flagging it explicitly since this PR is *about* that gate: the change is two workflow files with no user-visible surface, so the exemption is being used for its stated purpose, not to dodge the gate I just documented as blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

