### PR TITLE
ci: make nightly health failures diagnosable

### DIFF
--- a/.github/workflows/claude-health.yml
+++ b/.github/workflows/claude-health.yml
@@ -83,9 +83,38 @@ jobs:
           " \
           --output-format json \
           --max-turns 10 \
-          --model claude-sonnet-4-5-20250514 \
+          --model claude-sonnet-5 \
           --allowedTools "Read,Grep,Glob,Bash(npm audit:*),Bash(gh issue list:*),Bash(gh pr list:*),Bash(gh run list:*),Bash(cat:*),Bash(wc:*)" \
-          > /tmp/health-report.json
+          > /tmp/health-report.json 2> /tmp/health-stderr.log || RC=$?
+
+          # Never let the report redirect swallow the failure.
+          #
+          # This step failed 40 consecutive nights (2026-06-13 -> 2026-07-22)
+          # emitting nothing but "Process completed with exit code 1": stdout
+          # went into the report file and stderr was never surfaced, so the
+          # cause was unknowable from the run log. The job still "ran" nightly
+          # and wrote nothing. Surface both streams on failure, always.
+          RC=${RC:-0}
+          if [ "$RC" -ne 0 ] || [ ! -s /tmp/health-report.json ]; then
+            echo "::error::health assessment failed (exit ${RC}) — no usable report written"
+            {
+              echo "## Nightly Health Report — FAILED (exit ${RC})"
+              echo ""
+              echo "**stderr**"
+              echo '```'
+              tail -c 2000 /tmp/health-stderr.log 2>/dev/null || echo "(none captured)"
+              echo '```'
+              echo "**stdout (first 2KB of the report file)**"
+              echo '```'
+              head -c 2000 /tmp/health-report.json 2>/dev/null || echo "(empty)"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "----- stderr -----"
+            tail -c 2000 /tmp/health-stderr.log 2>/dev/null || true
+            echo "----- stdout -----"
+            head -c 2000 /tmp/health-report.json 2>/dev/null || true
+            exit 1
+          fi
 
       - name: Parse and display report
         run: |


### PR DESCRIPTION
Closes #3071

`Nightly Health Report` has failed **40 consecutive nights** (2026-06-13 → 2026-07-22) emitting nothing but `Process completed with exit code 1`.

## The proven defect

The assessment step ended with `> /tmp/health-report.json`. stdout went into the report file, stderr was never surfaced — so when `claude -p` failed, the entire diagnostic disappeared. Run `29887416561`:

```
03:03:10.19  ##[endgroup]          <- step reached the invocation, secrets present
03:03:12.68  ##[error]Process completed with exit code 1.
```

2.5 seconds, zero output. Six weeks of nightly runs produced no evidence about their own failure. **That** is the bug this PR fixes.

## What I could and could not prove

| Hypothesis | Verdict | Evidence |
|---|---|---|
| Dead OAuth token | **refuted** | `claude-release-watch.yml` uses the same secret, green at 04:04 — an hour after health failed at 03:03 |
| Retired model id | **unproven** | `claude-triage.yml` pins `claude-haiku-4-5-20251001`, a *current* id, and also fails — so another failure mode exists |

I'm not shipping a guess-fix dressed as a root cause. The model id is updated because `claude-sonnet-4-5-20250514` is genuinely not a current id, **not** because it's proven causal.

## Changes

- capture stderr separately + capture the exit code; on failure dump stderr and the first 2KB of stdout to **both** the run log and the step summary
- treat an **empty report** as failure — `exit 0` with a zero-byte file is the same silent-failure class and currently reaches the parse step
- update the stale pinned model id

## Verification

```
actionlint ........ exit 0  (SC2086 infos are pre-existing, in the parse step)
YAML .............. parses
guard behaviour ... rc=0 + report present  -> continues   ✅
                    rc=1                   -> exits 1     ✅
                    rc=0 + EMPTY report    -> exits 1     ✅
```

## Outcome either way

If the model id was the trigger, tonight's run goes green. If it wasn't, we get a legible error instead of a 41st silent night. Both are strictly better than today.

## Related, not fixed here

`claude-triage.yml` fails with a current model id (separate cause), `skill-eval.yml`'s failures are the known 429 weekly-cap outage, and `claude-review.yml` pins `claude-sonnet-4-6` (also not current) but its recent runs are skipped/cancelled so it's untested. Deliberately out of scope.

## Branch prefix

On `ci/`, one of the playground gate's documented config-only exemptions (`ci.yml:197`). Single workflow file, no user-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
