### PR TITLE
ci: validate pinned Claude model IDs at commit time

### DIFF
--- a/tests/ci/claude-model-ids.txt
+++ b/tests/ci/claude-model-ids.txt
@@ -1,0 +1,51 @@
+# Servable Claude model IDs — the allowlist for the workflow model-ID gate.
+#
+# WHY THIS FILE EXISTS
+# `claude-health.yml` pinned `claude-sonnet-4-5-20250514` for 40 consecutive
+# nights. That ID never existed: Sonnet 4.5's dated ID is -20250929, and
+# -20250514 belongs to Sonnet 4. The API answers an unknown model ID with
+# 404 not_found_error, so the job died in ~2.5s every night, and because a
+# typo'd ID is indistinguishable from a valid one until runtime, nothing
+# caught it at commit time. This file is what makes that catchable. (#3071)
+#
+# FORMAT
+#   <model-id>              -> ALLOWED, gate passes
+#   <model-id>  # DEPRECATED: retires <date>  -> gate WARNS (still servable)
+# Anything a workflow pins that is absent here FAILS the gate.
+#
+# HOW TO UPDATE
+# When a new model ships, add its ID here in the same commit that pins it.
+# Source of truth is the Models API — do not hand-guess IDs:
+#   client.models.list()      # or: ant models list
+# Never append a date suffix to an alias. `claude-sonnet-5` is complete as
+# written; `claude-sonnet-5-20260101` is not a real ID.
+#
+# Last verified against the model catalog: 2026-07-22
+
+# ---- Current ----
+claude-fable-5
+claude-opus-4-8
+claude-opus-4-7
+claude-opus-4-6
+claude-sonnet-5
+claude-sonnet-4-6
+claude-haiku-4-5
+claude-haiku-4-5-20251001
+
+# ---- Restricted availability (valid, but only for orgs with access) ----
+claude-mythos-5
+
+# ---- Legacy, still servable ----
+claude-opus-4-5
+claude-opus-4-5-20251101
+claude-sonnet-4-5
+claude-sonnet-4-5-20250929
+
+# ---- Deprecated: still servable, but pin something newer ----
+claude-opus-4-1  # DEPRECATED: retires 2026-08-05
+claude-opus-4-1-20250805  # DEPRECATED: retires 2026-08-05
+claude-opus-4-0  # DEPRECATED: retirement TBD
+claude-opus-4-20250514  # DEPRECATED: retirement TBD
+claude-sonnet-4-0  # DEPRECATED: retirement TBD
+claude-sonnet-4-20250514  # DEPRECATED: retirement TBD
+claude-3-haiku-20240307  # DEPRECATED: retires 2026-04-19

--- a/tests/ci/lint.sh
+++ b/tests/ci/lint.sh
@@ -261,6 +261,65 @@ fi
 echo ""
 
 # ============================================================================
+# 6. Workflow Claude Model IDs (#3071)
+# ============================================================================
+# claude-health.yml pinned `claude-sonnet-4-5-20250514` for 40 consecutive
+# nights. That ID never existed (Sonnet 4.5 is -20250929; -20250514 belongs
+# to Sonnet 4), so the API answered 404 not_found_error and the job died in
+# ~2.5s every night writing nothing. A typo'd model ID is indistinguishable
+# from a valid one until runtime — this makes it a commit-time failure.
+echo -e "${BLUE}6. Workflow Claude Model IDs${NC}"
+
+MODEL_ALLOWLIST="$SCRIPT_DIR/claude-model-ids.txt"
+WORKFLOW_DIR="$PROJECT_ROOT/.github/workflows"
+
+if [ ! -f "$MODEL_ALLOWLIST" ]; then
+    fail "Model-ID allowlist missing: tests/ci/claude-model-ids.txt"
+elif [ ! -d "$WORKFLOW_DIR" ]; then
+    warn "No .github/workflows directory to scan for model IDs"
+else
+    # Two pin shapes exist: `--model <id>` (raw `claude -p`) and
+    # `claude_args: "... --model <id>"` (anthropics/claude-code-action); a
+    # bare `model: <id>` YAML key is matched too. src/agents use aliases
+    # (opus|sonnet|haiku|inherit), which the claude-* pattern ignores by design.
+    model_pins=$(grep -rhoE -- "(--model|model:)[[:space:]]+claude-[a-z0-9.-]+" "$WORKFLOW_DIR" \
+                 | sed -E 's/^(--model|model:)[[:space:]]+//' \
+                 | sort -u || true)  # silent: known-noise — no pinned models is a valid state
+
+    model_checked=0
+    model_bad=0
+
+    while IFS= read -r model_id; do
+        [ -n "$model_id" ] || continue
+        model_checked=$((model_checked + 1))
+
+        # Anchored so `claude-sonnet-4-5` cannot be satisfied by the longer
+        # `claude-sonnet-4-5-20250929` entry, and so comment lines never match.
+        allow_line=$(grep -E "^[[:space:]]*${model_id}([[:space:]]|#|\$)" "$MODEL_ALLOWLIST" || true)  # silent: known-noise — absent = the failure we report
+        pinned_in=$(grep -rl -- "$model_id" "$WORKFLOW_DIR" | head -1 || true)  # silent: known-noise — attribution only
+        where=$(basename "${pinned_in:-workflow}")
+
+        if [ -z "$allow_line" ]; then
+            fail "$where pins unknown model ID '$model_id' — the API answers 404 not_found_error at runtime. If this model is genuinely new, add it to tests/ci/claude-model-ids.txt in the same commit."
+            model_bad=$((model_bad + 1))
+        # here-string, not a pipe: `printf | grep -q` SIGPIPEs the producer
+        # under `set -o pipefail` and flips this branch non-deterministically.
+        elif grep -q "DEPRECATED" <<<"$allow_line"; then
+            note=$(sed 's/.*#[[:space:]]*//' <<<"$allow_line")
+            warn "$where pins '$model_id' — $note"
+        fi
+    done <<< "$model_pins"
+
+    if [ "$model_checked" -eq 0 ]; then
+        warn "No pinned Claude model IDs found in .github/workflows — the match pattern may need updating"
+    elif [ "$model_bad" -eq 0 ]; then
+        pass "All $model_checked pinned workflow model ID(s) are servable"
+    fi
+fi
+
+echo ""
+
+# ============================================================================
 # Summary
 # ============================================================================
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
Follow-up to #3071 — closes the *class*, not just the instance.

#3071 shipped and ran **40 consecutive nights** because a typo'd model ID is indistinguishable from a valid one until runtime. This makes it a commit-time failure.

## The bug this prevents

`claude-health.yml` pinned `claude-sonnet-4-5-20250514`. That ID **never existed** — it's a splice:

```
Sonnet 4.5's dated ID  = claude-sonnet-4-5-20250929
-20250514 belongs to     claude-sonnet-4-20250514   (Sonnet 4)
```

An unknown model ID returns **404 `not_found_error`** — immediate, no generation. That's the exact signature we saw: reached the invocation, 2.5s, exit 1, zero output, every night for six weeks.

## What this adds

Section 6 in `tests/ci/lint.sh` — chosen because it's **already wired to the required Static Analysis job**, so it cannot be born dead (the failure mode that killed a previous `.mjs` gate in this repo). Plus a checked-in allowlist, `tests/ci/claude-model-ids.txt`, with three tiers:

| Tier | Behaviour |
|---|---|
| allowed | pass |
| deprecated | **warn**, naming the retirement date |
| anything else | **fail**, with the 404 explanation and how to update |

The deprecated tier is a bonus catch — it currently surfaces `claude-opus-4-1` retiring **2026-08-05** if anything ever pins it.

**Scope is `.github/workflows` only.** `src/agents` pin aliases (`opus`/`sonnet`/`haiku`/`inherit`), not dated IDs, so the `claude-*` pattern ignores them by design.

## Verification — replayed against the real regression

```
current main                  -> PASS  (3 pinned IDs servable)
claude-sonnet-4-5-20250514    -> FAIL  exit 1, names the ID and the 404
claude-opus-4-1 (deprecated)  -> WARN  + retires 2026-08-05, exit 0
shellcheck -S error           -> clean
```

Test 2 is the point: **the gate catches the exact bug that ran for 40 nights.**

## Two silent-failure patterns fixed, not tagged

`check-silent-failures.py` blocked this twice while I was writing it, and both were worth fixing rather than suppressing:

1. `stderr`-to-`/dev/null` on the workflow scan → replaced with an explicit directory guard.
2. `printf … | grep -q` → **SIGPIPEs the producer under `set -o pipefail`**, which would have made the deprecated branch flip non-deterministically under load. Replaced with a here-string. A flaky gate is worse than no gate.

The tags that remain mark grep's no-match exit — which is precisely the state this gate exists to report on.

## Maintenance cost

One line in the allowlist when a new model ships, in the same commit that pins it. The header documents the source of truth (`client.models.list()` / `ant models list`) and the "never append a date suffix to an alias" rule that caused the original bug.

## Branch prefix

On `ci/`, a documented playground-gate exemption (`ci.yml:197`). Two CI-infrastructure files, no user-visible surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
