### PR TITLE
ci: pin npm to 11.x in the hook-contract publish job

### DIFF
--- a/.github/workflows/publish-hook-contract-npm.yml
+++ b/.github/workflows/publish-hook-contract-npm.yml
@@ -240,7 +240,15 @@ jobs:
 
       - name: Ensure npm supports OIDC trusted publishing
         # Trusted publishing (OIDC) landed in npm 11.5.1; runners bundle npm 10.
-        run: npm install -g npm@latest
+        #
+        # Pinned to the 11.x line on purpose. This step used to install
+        # `npm@latest`, which silently broke the 0.1.2 publish on 2026-07-22:
+        # npm 12 shipped with engines `node ^22.22.2 || ^24.15.0 || >=26.0.0`
+        # and this job pins node 20, so `npm@latest` resolved to 12.0.1 and
+        # died with EBADENGINE *after* build/test/smoke had all passed.
+        # An unpinned npm against a pinned node is the bug; keep the two in
+        # step. Bump this range (and node above) together, deliberately.
+        run: npm install -g "npm@^11.5.1"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v6.0.0
         with:


### PR DESCRIPTION
## What broke

The `@orchestkit/hook-contract@0.1.2` publish failed at its final step:

```
npm error code EBADENGINE
npm error Not compatible with your version of node/npm: npm@12.0.1
npm error Required: node ^22.22.2 / ^24.15.0 / >=26.0.0
npm error Actual:   npm 10.8.2, node v20.20.2
```

The publish job pins `node-version: "20"` but ran an unpinned `npm install -g npm@latest`. npm 12 shipped and dropped Node 20, so the step broke the moment upstream moved. Parity, build, vitest and the tarball smoke-install had **all passed** first; only the publish died.

## Fix

Pin npm to the line that actually matches the stated requirement:

```
- run: npm install -g npm@latest
+ run: npm install -g "npm@^11.5.1"
```

An unpinned npm against a pinned node is the root bug. The range resolves to **11.18.0**, whose engines allow node 20.17+, and which still has OIDC trusted publishing (landed in 11.5.1) — the only reason the step exists.

## Verified

| resolves to | engines allow node 20.20.2 |
|---|---|
| `npm@^11.5.1` -> 11.18.0 | yes |
| `npm@latest` -> 12.0.1 | no, this was the breakage |

`actionlint` clean. This is the only workflow in the repo using the unpinned latest npm (grep-confirmed), so blast radius is this one job.

## Follow-up

PyPI `orchestkit-hook-contract@0.1.2` published successfully and is live serving the domain homepage. After this merges, the npm side re-runs via `workflow_dispatch` with `tag=hook-contract-npm/v0.1.2` — no retag needed.
