### PR TITLE
fix(ci): scope Claude workflow tools, gate triage on author

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,4 +66,11 @@ jobs:
             | Security | PASS/WARN/FAIL | ... |
             | Tests | PASS/WARN/FAIL | ... |
             | Types | PASS/WARN/FAIL | ... |
-          claude_args: "--max-turns 5 --model claude-sonnet-4-6"
+          # Tool allowlist matches the convention already used by claude-health.yml.
+          # This job holds pull-requests:write and issues:write while reviewing a diff
+          # that, on the pull_request trigger, is authored by whoever opened the PR.
+          # Restrict the model to reading the code and the PR metadata it reviews.
+          claude_args: >-
+            --max-turns 5
+            --model claude-sonnet-4-6
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Bash(gh pr view:*),Bash(gh pr diff:*)"

--- a/.github/workflows/claude-triage.yml
+++ b/.github/workflows/claude-triage.yml
@@ -23,6 +23,17 @@ concurrency:
 
 jobs:
   triage:
+    # Defense in depth. claude-code-action already fails closed for actors without
+    # write access (its OIDC-to-app-token exchange 401s before the model runs, as it
+    # did on 2026-07-22), but that leaves a red failed run on every outside-contributor
+    # issue. This turns that into a clean skip and states the trust boundary in the
+    # workflow instead of relying on the action's internal check.
+    # workflow_dispatch already requires write access, and github.event.issue is null
+    # there, so it needs its own disjunct.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
+               github.event.issue.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -69,4 +80,14 @@ jobs:
 
             IMPORTANT: Do NOT add labels or assign milestones automatically.
             Only suggest them in the comment. The maintainer will apply them.
-          claude_args: "--max-turns 3 --model claude-haiku-4-5-20251001"
+          # Tool allowlist matches the convention already used by claude-health.yml.
+          # The issue body is attacker-influenceable even when the author is trusted
+          # (maintainers routinely paste external stack traces and user reports), and
+          # the run carries a GITHUB_TOKEN with issues:write. The "do NOT apply labels"
+          # instruction in the prompt above is advisory text that injected content can
+          # override; this allowlist is the part that actually enforces it -- the two
+          # read-only gh calls the prompt needs, and nothing that can mutate the repo.
+          claude_args: >-
+            --max-turns 3
+            --model claude-haiku-4-5-20251001
+            --allowedTools "Read,Grep,Glob,Bash(gh label list:*),Bash(gh api repos/:owner/:repo/milestones:*)"


### PR DESCRIPTION
## What

Two changes to the Claude CI workflows, both from a security triage of a failing
`Claude Issue Triage` run.

1. Add `--allowedTools` to `claude-triage.yml` and `claude-review.yml`.
2. Add an `author_association` gate to the `triage` job.

## Why

### Tool scoping

Both workflows run a model with a `GITHUB_TOKEN` carrying `issues: write`
(`claude-review.yml` also holds `pull-requests: write`), and neither passed
`--allowedTools`. `claude-health.yml:87` already establishes the convention, so
these two were the outliers against the repo's own pattern.

Issue and PR bodies are attacker-influenceable even when the author is trusted,
because maintainers routinely paste external stack traces, user reports and
Discord messages. The line in the triage prompt that says

> IMPORTANT: Do NOT add labels or assign milestones automatically.

is advisory prompt text, and injected content can override it. The allowlist is
the part that actually enforces it. Each workflow now receives only the
read-only calls its own prompt needs.

### Author gate

This is defense in depth, not a new control. `claude-code-action` already fails
closed for actors without write access: its OIDC to app-token exchange returns
401 before the model runs, which is exactly what happened when an outside
contributor opened an issue on 2026-07-22. The model never executed.

The gate converts that red failed run into a clean skip, and states the trust
boundary in the workflow rather than leaving it implicit in the action's
internals. `workflow_dispatch` needs its own disjunct because
`github.event.issue` is null there.

## What this deliberately does NOT do

It does not remove `id-token: write`. That permission looks redundant next to
`claude_code_oauth_token`, and an initial review flagged it as dead capability.
That is wrong. The OAuth secret authenticates to the Anthropic API;
`id-token: write` is what `claude-code-action` uses to mint the GitHub App
token. Run logs show the full chain:

```
Requesting OIDC token...
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token successfully obtained
Using GITHUB_TOKEN from OIDC
```

Removing it would leave both workflows with no GitHub token at all.

## Residual gaps, not addressed here

- `workflow_dispatch` accepts an arbitrary `issue_number`, so a write-holder can
  still dispatch triage against an issue authored by anyone. Closing that needs
  a step that re-fetches the target issue and checks its own author association.
- The gate authenticates who pulled the trigger, never whose bytes reach the
  prompt. Trusted-actor laundering is unaffected by design.
- `MEMBER` never matches on a personal-account repo, and the repo currently has
  no invited collaborators, so the effective trusted set today is the owner.

## Verification

- `actionlint` on both files: clean, exit 0.
- Both files parsed to confirm the folded `>-` `claude_args` scalars resolve to a
  single argument line.
- Pre-commit workflow lint passed.

No playground: the `ci/` branch prefix is exempt by design, since this changes
only `.github/workflows/` and has no user-visible surface.
