### PR TITLE
fix(security): correct audit-gate id reporting, allowlist hono

### DIFF
--- a/.claude/audit-allowlist.json
+++ b/.claude/audit-allowlist.json
@@ -1,8 +1,12 @@
 {
   "_schema": {
-    "description": "npm audit gate allowlist. Add advisory IDs with a reason and an optional expiry date (YYYY-MM-DD). An expired entry fails the test so exceptions get revisited.",
+    "description": "npm audit gate allowlist. Keys are the NUMERIC npm advisory id (the `source` field of an npm audit `via` entry), not the GHSA string, because that is what tests/security/test-npm-audit.sh matches on. Add a reason and an optional expiry date (YYYY-MM-DD). An expired entry fails the test so exceptions get revisited.",
     "example": {
-      "GHSA-xxxx-yyyy-zzzz": { "reason": "no upstream fix yet", "until": "2026-07-01" }
+      "1234567": { "reason": "no upstream fix yet", "until": "2026-07-01" }
     }
+  },
+  "1124006": {
+    "reason": "GHSA-frvp-7c67-39w9, @hono/node-server <2.0.5 path traversal in serve-static on Windows via encoded backslash. Transitive via @modelcontextprotocol/sdk, whose newest release (1.29.0) still pins the vulnerable range, so there is no upstream fix; npm's only remedy is a breaking downgrade to sdk 1.24.3. Not reachable here: src/mcp-server/src/index.ts and docs-server.ts both use StdioServerTransport only, never an HTTP transport, so serve-static is never instantiated. Revisit when the MCP SDK bumps @hono/node-server.",
+    "until": "2026-09-01"
   }
 }

--- a/tests/security/test-npm-audit.sh
+++ b/tests/security/test-npm-audit.sh
@@ -65,6 +65,11 @@ fi
 
 is_allowlisted() {
   local target="$1"
+  # `local` is load-bearing. Bash uses dynamic scoping, so an unscoped loop
+  # variable named `id` here reassigns the CALLER's `id` (audit_project declares
+  # one). Without it, every failure message printed the last allowlist key
+  # instead of the offending advisory, pointing readers at the wrong ID.
+  local id
   for id in "${ACTIVE_IDS[@]}"; do
     [[ "$id" == "$target" ]] && return 0
   done


### PR DESCRIPTION
## Context

Found while triaging why `npm run test:security` fails locally on a tree that CI
reports green. The divergence turned out to be real, and the gate had two bugs of
its own.

## Fix 1: `is_allowlisted()` clobbered the caller's variable

```bash
is_allowlisted() {
  local target="$1"
  for id in "${ACTIVE_IDS[@]}"; do   # <-- unscoped
```

Bash uses dynamic scoping, so this `id` reassigned `audit_project`'s own `id`
local. Every failure message printed the last allowlist key instead of the
offending advisory. Concretely, the hono finding reported as:

```
src/mcp-server: _schema [moderate] Node.js Adapter for Hono: ...
```

`_schema` is the allowlist file's own documentation key. Anyone acting on that
message would have allowlisted the wrong entry. After the fix the gate prints
real ids:

```
docs/site: 1124066 [high] sharp inherited vulnerabilities in libvips ...
src/mcp-server: 1124006 [moderate] Node.js Adapter for Hono ... allowlisted
```

## Fix 2: allowlist the hono advisory

`1124006` / `GHSA-frvp-7c67-39w9`, `@hono/node-server <2.0.5`, path traversal in
`serve-static` on Windows via encoded backslash.

- **No upstream fix.** It arrives transitively via `@modelcontextprotocol/sdk`,
  and the newest SDK release (1.29.0) still pins the vulnerable range. npm's only
  offered remedy is `npm audit fix --force`, which downgrades the SDK to 1.24.3, a
  breaking change.
- **Not reachable here.** `src/mcp-server/src/index.ts` and
  `src/mcp-server/src/docs-server.ts` both construct `StdioServerTransport` and
  never an HTTP transport, so `serve-static` is never instantiated.
- Expires `2026-09-01` so it gets revisited rather than becoming permanent.

The schema docstring is also corrected: the gate matches the numeric npm advisory
id (the `source` field of a `via` entry), but the example showed a `GHSA-` string,
which could never match.

## Deliberately NOT fixed here

`audit_project` treats a missing `node_modules` as a pass:

```bash
if [[ ! -d "$dir/node_modules" ]]; then
  warn "$label: node_modules not installed, skipping"
  return 0
fi
```

`.github/actions/setup` installs only the root and `src/hooks`, so in CI both
`docs/site` and `src/mcp-server` are silently skipped. The gate's own header
claims it "blocks on moderate+ CVEs across the four package.json" paths; in CI it
checks two of four. That is why CI is green while local is red.

The consequence is not theoretical: `docs/site` currently carries **5 high**
severity `sharp`/`libvips` advisories (`1124066`,
CVE-2026-33327/33328/35590/35591) that this gate has never once reported.
GitHub's own Dependabot does see them.

Fixing the skip requires either pinning `sharp` through an `overrides` entry or
accepting a red gate, plus installing the two missing trees in CI. That needs a
build verification pass, so it is left for a follow-up rather than bundled here.

## Verification

- `bash tests/security/test-npm-audit.sh` run locally: 3 of 4 trees pass, the
  remaining failure is the genuine `docs/site` sharp finding described above.
- `jq empty .claude/audit-allowlist.json` passes; pre-commit shell and JSON syntax
  checks pass.

No playground: the `ci/` prefix is exempt by design, and this changes only a CI
gate script and its allowlist data.
