### PR TITLE
ci(demos): make renderer check gate-able, split remotion bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -130,8 +130,29 @@ updates:
     labels:
       - "dependencies"
     groups:
+      # Remotion is split OUT of the minor-patch bundle. #3086: a remotion
+      # 4.0.484 -> 4.0.489 *patch* removed a Config API and, buried in a
+      # 21-package group PR, shipped invisibly and broke 27 releases. Remotion
+      # does not follow semver for its config/CLI surface, so even its patch
+      # bumps need to arrive as their own reviewable PR (now also gated by
+      # demos-validate.yml).
+      remotion:
+        patterns:
+          - "remotion"
+          - "@remotion/*"
       npm-minor-patch:
+        exclude-patterns:
+          - "remotion"
+          - "@remotion/*"
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Remotion 4.x cannot build under TypeScript 7 (@remotion/bundler needs the
+      # legacy ts.sys / ts.readConfigFile the Go rewrite dropped). #3099 pinned
+      # this tree to ^6.0.3; without this ignore Dependabot re-proposes the TS 7
+      # major every week and each maintainer rediscovers the break. Revisit when
+      # Remotion ships TS 7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 5

--- a/.github/workflows/demos-validate.yml
+++ b/.github/workflows/demos-validate.yml
@@ -14,15 +14,14 @@
 #                                  (ts.sys / ts.readConfigFile are undefined in TS 7)
 #
 # `remotion compositions` loads remotion.config.ts AND bundles the project with
-# the TypeScript toolchain, so it would have caught BOTH at review time. Running
-# it on any PR that touches the demos tree moves that signal from post-release to
-# pre-merge, including on Dependabot PRs.
+# the TypeScript toolchain, so it would have caught BOTH at review time.
 #
-# SCOPE, honestly: this job is NOT in main's required status checks, so a red run
-# here does not by itself block a merge — including a Dependabot auto-merge, which
-# is how #3086 got in. It surfaces the breakage at review time rather than after
-# the next release. To make it actually gate, add "Validate Renderer" to the
-# branch-protection required contexts for main.
+# This runs on EVERY pull_request (no paths filter) and cheaply early-exits when
+# orchestkit-demos is untouched. That is deliberate: a required status check must
+# report on every PR, or PRs that never trigger it stay permanently BLOCKED on a
+# context that never appears. With this shape, "Validate Renderer" can be added
+# to main's branch protection (see #3086 follow-up) so a Dependabot bump that
+# breaks the renderer can no longer auto-merge — the gap that let #3086 in.
 #
 # Deliberately a separate workflow rather than a pull_request trigger on
 # release-video.yml: that workflow's jobs read release-event data and would fail
@@ -32,9 +31,6 @@ name: Validate Demos Renderer
 
 on:
   pull_request:
-    paths:
-      - 'orchestkit-demos/**'
-      - '.github/workflows/demos-validate.yml'
   workflow_dispatch:
 
 permissions: {}
@@ -51,6 +47,7 @@ jobs:
     name: Validate Renderer
     permissions:
       contents: read
+      pull-requests: read  # gh api …/files to detect whether demos changed
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -58,11 +55,37 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6  # zizmor: ignore[cache-poisoning] deps via npm ci, no cache restored
+      # Cheap gate so this can be a required check without paying the ~15-min
+      # render-bundle cost on every unrelated PR. workflow_dispatch always runs.
+      - name: Does this PR touch the demos tree?
+        id: changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename')
+          if printf '%s\n' "$files" \
+               | grep -qE '^(orchestkit-demos/|\.github/workflows/demos-validate\.yml)'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::orchestkit-demos untouched — renderer validation not needed. Reporting success."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Node
+        if: steps.changed.outputs.run == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6  # zizmor: ignore[cache-poisoning] deps via npm ci, no cache restored
         with:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Install demo dependencies
+        if: steps.changed.outputs.run == 'true'
         working-directory: orchestkit-demos
         run: npm ci
 
@@ -70,12 +93,14 @@ jobs:
       # calling a removed API, or a TypeScript major that the bundler cannot
       # use, fails here rather than silently on the next 27 releases.
       - name: Bundle and enumerate compositions
+        if: steps.changed.outputs.run == 'true'
         working-directory: orchestkit-demos
         run: npx remotion compositions
 
       # The two compositions release-video.yml actually renders must exist. A
       # rename would otherwise only surface post-release.
       - name: Assert the release-notes compositions are registered
+        if: steps.changed.outputs.run == 'true'
         working-directory: orchestkit-demos
         run: |
           set -euo pipefail

--- a/.github/workflows/demos-validate.yml
+++ b/.github/workflows/demos-validate.yml
@@ -70,8 +70,10 @@ jobs:
             exit 0
           fi
           files=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename')
-          if printf '%s\n' "$files" \
-               | grep -qE '^(orchestkit-demos/|\.github/workflows/demos-validate\.yml)'; then
+          # Here-string, not `printf | grep -q`: under pipefail, grep -q's
+          # early-exit SIGPIPEs the producer (exit 141) and flips the result
+          # non-deterministically. A here-string has no producer process.
+          if grep -qE '^(orchestkit-demos/|\.github/workflows/demos-validate\.yml)' <<<"$files"; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "::notice::orchestkit-demos untouched — renderer validation not needed. Reporting success."
@@ -106,7 +108,7 @@ jobs:
           set -euo pipefail
           out=$(npx remotion compositions)
           for id in TPL-ReleaseNotes TPL-ReleaseNotesSquare; do
-            if ! printf '%s\n' "$out" | grep -qE "^${id}\b"; then
+            if ! grep -qE "^${id}\b" <<<"$out"; then
               echo "::error::Composition ${id} is not registered — release-video.yml renders it and would fail after the next release."
               exit 1
             fi


### PR DESCRIPTION
Closes the gating gap behind #3086: the renderer validation existed but could not block the Dependabot auto-merge that broke it, and the grouping that hid the breaking bump was unchanged. P1 from the improvement plan.

## 1. Make "Validate Renderer" gate-able

The check ran only on `orchestkit-demos/**` PRs and was **not** a required status check, so a red run could not block a merge — including the Dependabot auto-merge that caused #3086.

The trap: you cannot simply add a path-scoped check to branch protection. A required check that never triggers on an unrelated PR leaves that PR permanently `BLOCKED` on a context that never appears. So the workflow now runs on **every** `pull_request` and cheaply early-exits when `orchestkit-demos` is untouched (a `gh api …/files` check, then the ~15-min install/bundle steps are skipped). One stable `Validate Renderer` context on every PR, real work only when demos change.

**Follow-up, not in this PR:** once this lands and the always-run is confirmed to report success on a non-demos PR, add `Validate Renderer` to main's branch protection. Requiring it before it reliably runs would block every PR in the repo, so that step is gated on verification.

## 2. Stop the grouping that hid the breaking bump

`#3086`'s breaking change was `remotion 4.0.484 -> 4.0.489` — a **patch** — buried in a 21-package `npm-minor-patch` group PR where no one saw it. Remotion does not follow semver for its config/CLI surface.

- **Split remotion into its own Dependabot group** (`remotion` + `@remotion/*`), excluded from `npm-minor-patch`. Remotion bumps now arrive as their own reviewable PR, gated by demos-validate.
- **Ignore the `typescript` semver-major** on this tree. Remotion 4.x cannot build under TS 7 (#3099 pinned `^6.0.3`); without the ignore, Dependabot re-proposes TS 7 weekly and the break is rediscovered each time.

## Verification

| Check | Result |
|---|---|
| `actionlint` demos-validate.yml | clean |
| `dependabot.yml` parses | remotion group + minor-patch exclusion + typescript-major ignore all present |
