### PR TITLE
fix(ci): scope What's New --check to PRs, refresh for 8.84.8

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -385,11 +385,18 @@ jobs:
       # The README "What's New" block is derived from CHANGELOG.md by
       # stamp-whats-new.mjs. This fails CI if a normal PR touches CHANGELOG or the
       # block without regenerating it — which is how it previously rotted ~68
-      # versions behind. Skipped on release-please PRs: those add the new CHANGELOG
-      # entry, and release.yml regenerates the block on the release branch as a
-      # best-effort step, so a regen hiccup must never block the release itself.
+      # versions behind.
+      #
+      # pull_request ONLY, and not on release-please branches. On push:main after
+      # a release, the block legitimately lags one release: release.yml's
+      # best-effort regen races release-please's final CHANGELOG update and can
+      # lose, and main is protected so nothing can push a fix there. Enforcing on
+      # push:main just reds main for a doc lag with no way to clear it. On PRs the
+      # gate still bites — the next PR off main carries the stale block, its build
+      # regenerates it, and --check forces that into the PR. So freshness is
+      # guaranteed within one PR, without a red main.
       - name: Check README What's New is fresh
-        if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--') }}
+        if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--') }}
         shell: bash
         run: node scripts/stamp-whats-new.mjs --check
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,13 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 <!-- AUTO-GENERATED from CHANGELOG.md by scripts/stamp-whats-new.mjs — do not hand-edit between the ork:whats-new markers. -->
 <!-- Regenerated on `npm run build`; CI (`--check`) fails if this is stale. Full history: [CHANGELOG.md](CHANGELOG.md). -->
 
+**[v8.84.8](https://github.com/yonatangross/orchestkit/compare/v8.84.7...v8.84.8)** · 2026-07-23
+
+- **hooks:** stop denying local data piped to an interpreter (#3097)
+- **security:** remove privesc in release regen, tighten allowlist (#3102)
+- **demos:** make renderer check gate-able, split remotion bumps (#3105)
+- **review:** auto-run Claude review on sensitive PRs, ban dead gates (#3104)
+
 **[v8.84.7](https://github.com/yonatangross/orchestkit/compare/v8.84.6...v8.84.7)** · 2026-07-23
 
 - **demos:** repair the Remotion renderer, validate it pre-merge (#3099)
@@ -245,14 +252,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 **[v8.84.1](https://github.com/yonatangross/orchestkit/compare/v8.84.0...v8.84.1)** · 2026-07-21
 
 - fix playground gate messaging and release-PR stranding (#3063)
-
-**[v8.84.0](https://github.com/yonatangross/orchestkit/compare/v8.83.1...v8.84.0)** · 2026-07-21
-
-- **evals:** honest verdicts, three new gates, and a budget governor
-- **dream:** stop auto-pruning live memories with out-of-repo refs
-- **evals:** score effective recall over the full positive population (#3049)
-- **cc-watch:** snapshot upstream CHANGELOG (2.1.216) (#3053)
-- add AGENTS.md for AI coding agent discoverability (#3059)
 
 _See [CHANGELOG.md](CHANGELOG.md) for the full release history._
 <!--/ork-->


### PR DESCRIPTION
## The bug

Main went **red** right after releasing 8.84.8. `release.yml`'s best-effort What's New regen races release-please's final CHANGELOG update on the release branch and lost this time, so the README block stayed at **v8.84.7** while CHANGELOG advanced to **v8.84.8**. The `stamp-whats-new --check` step then ran on `push: main` and failed. Main is protected, so nothing can push a fix there — the gate reds main on a doc lag with no way to clear it.

This is the timing race an adversarial assessment flagged earlier (which I'd recorded as refuted). It was real, and it surfaced on the first release after the What's New hardening.

## The fix

`--check` now runs on **pull_request only** (still skipping release-please branches), not on `push: main`.

- On a normal PR touching CHANGELOG: the gate still bites — README must be regenerated.
- On `push: main` after a release: no enforcement, so a one-release doc lag can't red main.
- **Self-heals within one PR:** the next PR off main carries the stale block, its `npm run build` regenerates it, and `--check` forces that into the PR. Freshness is guaranteed within one PR without a red main.

Also regenerates the block to **v8.84.8** now, clearing the current lag.

## Verification

| Check | Result |
|---|---|
| `stamp-whats-new --check` | passes (README top = v8.84.8) |
| `actionlint` | clean (the SC2016 info at :238 pre-dates this) |

## Follow-up (not here)

The regen-on-release-branch approach races release-please by construction. A sturdier design regenerates the block **post-merge** on `push: main` and opens a tiny follow-up PR, rather than stamping the release branch. Tracked for later; this PR stops the bleeding (red main) and keeps the block self-healing.
