### PR TITLE
ci(review): allow the release bot to trigger a review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,6 +51,13 @@ jobs:
           persist-credentials: false
       - uses: anthropics/claude-code-action@af0559ee4f514d1ef21826982bed13f7edc3c35e  # v1.0.178
         with:
+          # The action refuses a run triggered by a bot unless it is allow-listed.
+          # auto-label-review.yml applies needs-claude-review with the Release Bot
+          # App token (GITHUB_TOKEN-added labels do not cascade), so the labeled
+          # event that fires this review has orchestkit-release-bot as its actor.
+          # Allow just that bot — not '*' — so a review is still only triggered by
+          # our own automation or a trusted human, never an arbitrary bot.
+          allowed_bots: "orchestkit-release-bot"
           # Auth via the Max-plan OAuth token (CLAUDE_CODE_OAUTH_TOKEN) instead of
           # metered console credits — $0 spend. Rotate with `claude setup-token`
           # then `gh secret set CLAUDE_CODE_OAUTH_TOKEN` if a run 401s.


### PR DESCRIPTION
Enabling auto-review surfaced the final block. The action refuses a bot-triggered run unless allow-listed:

```
Action failed: Workflow initiated by non-human actor: orchestkit-release-bot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

`auto-label-review.yml` applies `needs-claude-review` with the Release Bot **App token** (a GITHUB_TOKEN-added label does not cascade to trigger other workflows), so the `labeled` event that fires the review has `orchestkit-release-bot` as its actor and the action aborts.

**Fix:** `allowed_bots: "orchestkit-release-bot"` — just that bot, not `*`. A review is still only ever triggered by our own automation (which also carries the label for Dependabot PRs) or a trusted human, never an arbitrary bot.

This is the third GitHub-mechanics trap in the auto-review chain, each real: self-cancelling event bursts → decoupled workflows; GITHUB_TOKEN labels don't cascade → App token; **App-token labels are bot-triggered → allow_bots**. With this, the first actual posted auto-review should land on the next sensitive PR.

`actionlint` clean.