### PR TITLE
ci(review): skip auto-label on Dependabot PRs (no secret access)

### DIFF
--- a/.github/workflows/auto-label-review.yml
+++ b/.github/workflows/auto-label-review.yml
@@ -37,9 +37,17 @@ concurrency:
 jobs:
   label:
     name: Label sensitive PRs for review
-    # Fork PRs cannot read the App-token secrets and cannot be labelled by a
-    # read-only token; they stay opt-in via an @claude comment from a maintainer.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip when the App-token secrets are unreachable:
+    #  - fork PRs run with a read-only token and no secret access;
+    #  - Dependabot PRs are isolated from repo secrets by GitHub, so the
+    #    "Mint Release Bot token" step below cannot run and the job would fail
+    #    (red) on every sensitive-path Dependabot PR rather than no-op.
+    # These paths stay reviewable via an @claude comment from a maintainer, and
+    # Dependabot PRs are already gated by the required checks (incl. Validate
+    # Renderer) and the semver-major hold.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:


### PR DESCRIPTION
The `Mint Release Bot token` step in auto-label-review.yml failed on every sensitive-path Dependabot PR (#3112, a github-actions group bump touching `.github/workflows`). Cause: GitHub isolates Dependabot runs from repo secrets, so `RELEASE_BOT_APP_ID`/`_PRIVATE_KEY` are unreachable and the step **errors (red)** instead of no-op.

**Fix:** guard the job on `github.actor != 'dependabot[bot]'` so it cleanly skips. Those PRs stay reviewable via an `@claude` comment and are already gated by the required checks (including the now-required `Validate Renderer`) and the semver-major hold.

A regression I introduced in #3104 when enabling auto-review; non-required so it never blocked a merge, but it reds every sensitive Dependabot PR. `actionlint` clean.