### PR TITLE
fix(ci): drop the What's New freshness gate blocking the PR queue

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -382,23 +382,17 @@ jobs:
         shell: bash
         run: bash scripts/stamp-counts.sh --check
 
-      # The README "What's New" block is derived from CHANGELOG.md by
-      # stamp-whats-new.mjs. This fails CI if a normal PR touches CHANGELOG or the
-      # block without regenerating it — which is how it previously rotted ~68
-      # versions behind.
-      #
-      # pull_request ONLY, and not on release-please branches. On push:main after
-      # a release, the block legitimately lags one release: release.yml's
-      # best-effort regen races release-please's final CHANGELOG update and can
-      # lose, and main is protected so nothing can push a fix there. Enforcing on
-      # push:main just reds main for a doc lag with no way to clear it. On PRs the
-      # gate still bites — the next PR off main carries the stale block, its build
-      # regenerates it, and --check forces that into the PR. So freshness is
-      # guaranteed within one PR, without a red main.
-      - name: Check README What's New is fresh
-        if: ${{ github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release-please--') }}
-        shell: bash
-        run: node scripts/stamp-whats-new.mjs --check
+      # NOTE: there is deliberately no "What's New freshness" gate here.
+      # An earlier version ran `stamp-whats-new.mjs --check`, but the only thing
+      # that changes CHANGELOG is release-please (whose branches were exempt), so
+      # the gate could never enforce the case it was written for — and every
+      # release loses a race in release.yml's best-effort regen, leaving main's
+      # README one release behind. A required --check then failed on EVERY PR off
+      # that main (including all Dependabot PRs, which do not regenerate the
+      # block), wedging the whole queue over a cosmetic doc lag. The block still
+      # auto-updates via scripts/stamp-whats-new.mjs in build-plugins.sh and the
+      # best-effort release-branch regen; a lag is cosmetic and self-heals on the
+      # next build. Freshness is not worth blocking merges for.
 
   # Job 7: Skills Validation (flat structure)
   skills-validation:

--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 <!-- AUTO-GENERATED from CHANGELOG.md by scripts/stamp-whats-new.mjs — do not hand-edit between the ork:whats-new markers. -->
 <!-- Regenerated on `npm run build`; CI (`--check`) fails if this is stale. Full history: [CHANGELOG.md](CHANGELOG.md). -->
 
+**[v8.84.9](https://github.com/yonatangross/orchestkit/compare/v8.84.8...v8.84.9)** · 2026-07-23
+
+- **ci:** scope What's New --check to PRs, refresh for 8.84.8 (#3113)
+- **review:** allow the release bot to trigger a review (#3114)
+- **review:** skip auto-label on Dependabot PRs (no secret access) (#3116)
+
 **[v8.84.8](https://github.com/yonatangross/orchestkit/compare/v8.84.7...v8.84.8)** · 2026-07-23
 
 - **hooks:** stop denying local data piped to an interpreter (#3097)
@@ -248,10 +254,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 - **deps:** bump fast-uri from 3.1.2 to 3.1.4 in /src/mcp-server (#3074)
 - **deps:** bump hono from 4.12.25 to 4.12.31 in /src/mcp-server (#3075)
 - …and 2 more (see [CHANGELOG.md](CHANGELOG.md))
-
-**[v8.84.1](https://github.com/yonatangross/orchestkit/compare/v8.84.0...v8.84.1)** · 2026-07-21
-
-- fix playground gate messaging and release-PR stranding (#3063)
 
 _See [CHANGELOG.md](CHANGELOG.md) for the full release history._
 <!--/ork-->


### PR DESCRIPTION
The 8.84.9 release hit `release.yml`'s regen race again: main's README stayed at **8.84.8** while CHANGELOG advanced to **8.84.9**. The `--check` step (required via Component Counts) then failed on **every** PR off that main — all 6 open Dependabot PRs at once, since bot PRs never regenerate the block. The queue wedged over a cosmetic one-release doc lag.

## Why remove rather than patch again

I already tried scoping it (#3113: PR-only, self-heal on next PR). That assumed the next PR regenerates the block via its build — but Dependabot PRs don't, so they all fail it. The gate **never enforced the case it was written for**: the only thing that changes CHANGELOG is release-please, whose branches are exempt. So it caught nothing real and blocked everything unrelated after each release. Net-negative — remove it.

## What stays

The block still auto-updates:
- `scripts/stamp-whats-new.mjs` in `build-plugins.sh` (any src-touching PR)
- the best-effort release-branch regen in `release.yml`

A lag is cosmetic and self-heals on the next build. Also refreshes README to **8.84.9** now.

## Unblocks

All 6 Dependabot PRs (#3107–#3112) were failing Component Counts on this gate. This clears them.

`actionlint` clean (the SC2016 info at :238 pre-dates this).