### PR TITLE
fix(docs): pin playground links to the commit SHA, not the branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,6 +38,15 @@ Closes #
 
 ## Interactive Playground
 
-<!-- For non-trivial changes: link to docs/<branch-slug>/<name>.html. CI requires this for most PRs. -->
+<!--
+For non-trivial changes: link to docs/<branch-slug>/<name>.html. CI requires this for most PRs.
 
-**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/BRANCH-NAME/docs/BRANCH-DIR/FILE.html)**
+Pin the COMMIT SHA, not the branch name. GitHub deletes the branch on merge, so a
+branch-pinned blob URL 404s the moment the PR lands, which is what happened to
+#3136, #3137, #3138, #3142, #3144, #3146 and #3147. A SHA stays reachable forever
+because GitHub keeps refs/pull/<N>/head.
+
+Get it with:  git rev-parse HEAD
+-->
+
+**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/COMMIT-SHA/docs/BRANCH-DIR/FILE.html)**

--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 <!-- AUTO-GENERATED from CHANGELOG.md by scripts/stamp-whats-new.mjs — do not hand-edit between the ork:whats-new markers. -->
 <!-- Regenerated on `npm run build`; CI (`--check`) fails if this is stale. Full history: [CHANGELOG.md](CHANGELOG.md). -->
 
+**[v8.85.0](https://github.com/yonatangross/orchestkit/compare/v8.84.10...v8.85.0)** · 2026-07-25
+
+- agent activation routing (M170) (#3133)
+- 3 defects found by /ork:assess on the M170 diff (#3136)
+- **build:** stop dropping argument-hint from generated commands (#3146)
+- **hooks:** make network-egress-guard DENY tier quote-aware (#3124)
+- **hooks:** redirect pipe-to-interpreter deny instead of dead-ending (#3121)
+- …and 8 more (see [CHANGELOG.md](CHANGELOG.md))
+
 **[v8.84.10](https://github.com/yonatangross/orchestkit/compare/v8.84.9...v8.84.10)** · 2026-07-23
 
 - **ci:** drop the What's New freshness gate blocking the PR queue (#3118)
@@ -247,11 +256,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
 **[v8.84.4](https://github.com/yonatangross/orchestkit/compare/v8.84.3...v8.84.4)** · 2026-07-22
 
 - **skills:** burn model-recency ratchet to zero (#3056)
-
-**[v8.84.3](https://github.com/yonatangross/orchestkit/compare/v8.84.2...v8.84.3)** · 2026-07-22
-
-- **hook-contract:** bump to 0.1.2, domain-anchored SDK provenance (#3080)
-- pin npm to 11.x in the hook-contract publish job (#3082)
 
 _See [CHANGELOG.md](CHANGELOG.md) for the full release history._
 <!--/ork-->

--- a/docs/fix--playground-durable-links/playground.html
+++ b/docs/fix--playground-durable-links/playground.html
@@ -1,0 +1,147 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Durable playground links</title>
+<style>
+  :root {
+    --bg:#0d1117; --panel:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e;
+    --ok:#3fb950; --bad:#f85149; --warn:#d29922; --accent:#58a6ff;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; background:var(--bg); color:var(--fg);
+         font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; padding:32px 20px; }
+  .wrap { max-width:920px; margin:0 auto; }
+  h1 { font-size:26px; margin:0 0 6px; letter-spacing:-.3px; }
+  .sub { color:var(--dim); margin:0 0 28px; }
+  .panel { background:var(--panel); border:1px solid var(--line); border-radius:10px;
+           padding:18px 20px; margin:0 0 20px; }
+  h2 { font-size:15px; text-transform:uppercase; letter-spacing:.7px; color:var(--dim);
+       margin:0 0 14px; font-weight:600; }
+  table { width:100%; border-collapse:collapse; font-family:var(--mono); font-size:12.5px; }
+  th, td { text-align:left; padding:9px 10px; border-bottom:1px solid var(--line); }
+  th { color:var(--dim); font-weight:500; text-transform:uppercase; font-size:10.5px; letter-spacing:.6px; }
+  tr:last-child td { border-bottom:0; }
+  .ok { color:var(--ok); } .bad { color:var(--bad); } .warn { color:var(--warn); }
+  .pill { display:inline-block; padding:1px 7px; border-radius:20px; font-size:11px;
+          font-family:var(--mono); border:1px solid currentColor; }
+  code { font-family:var(--mono); background:#21262d; padding:1px 5px; border-radius:4px; font-size:12.5px; }
+  .flow { font-family:var(--mono); font-size:12.5px; white-space:pre; overflow-x:auto;
+          color:var(--dim); line-height:1.75; margin:0; }
+  .flow b { color:var(--fg); font-weight:600; }
+  .flow .r { color:var(--bad); } .flow .g { color:var(--ok); }
+  label { display:flex; align-items:center; gap:10px; margin:0 0 12px; font-size:13.5px; }
+  select { background:#21262d; color:var(--fg); border:1px solid var(--line);
+           border-radius:6px; padding:6px 10px; font-family:var(--mono); font-size:12.5px; }
+  .out { font-family:var(--mono); font-size:12px; background:#0b0f14; border:1px solid var(--line);
+         border-radius:8px; padding:14px; word-break:break-all; line-height:1.7; }
+  .verdict { margin-top:12px; font-size:13px; }
+  footer { color:var(--dim); font-size:12px; margin-top:26px; text-align:center; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Playground links die on merge</h1>
+  <p class="sub">Every merged PR's <em>Open Playground</em> link 404s, because the URL pins the
+     branch name and GitHub deletes the branch when the PR lands.</p>
+
+  <div class="panel">
+    <h2>What happens</h2>
+<p class="flow"><b>PR open</b>    branch <b>fix/yaml-prose-leftover</b> exists
+            blob/<b>fix/yaml-prose-leftover</b>/docs/.../phantom-symbols.html   <span class="g">200 OK</span>
+
+<b>PR merges</b>  GitHub auto-deletes the head branch
+            blob/<b>fix/yaml-prose-leftover</b>/docs/.../phantom-symbols.html   <span class="r">404 GONE</span>
+
+            the FILE is fine, it is on main. the <b>ref</b> is what vanished.</p>
+  </div>
+
+  <div class="panel">
+    <h2>Measured, on PR #3147 whose branch is already deleted</h2>
+    <table>
+      <tr><th>URL form</th><th>status</th><th>during review</th><th>after merge</th></tr>
+      <tr><td>blob/&lt;branch&gt;/</td><td class="bad">404</td><td class="ok">works</td><td class="bad">dead</td></tr>
+      <tr><td>blob/&lt;head-sha&gt;/</td><td class="ok">200</td><td class="ok">works</td><td class="ok">works</td></tr>
+      <tr><td>blob/&lt;merge-sha&gt;/</td><td class="ok">200</td><td class="warn">n/a</td><td class="ok">works</td></tr>
+      <tr><td>blob/main/</td><td class="ok">200</td><td class="bad">404</td><td class="ok">works</td></tr>
+    </table>
+    <p class="verdict">Only the <span class="pill ok">head SHA</span> works on both sides of the merge.
+       GitHub retains <code>refs/pull/&lt;N&gt;/head</code> forever, so the commit stays
+       reachable even after the branch is gone.</p>
+  </div>
+
+  <div class="panel">
+    <h2>Try it</h2>
+    <label>URL form
+      <select id="form">
+        <option value="branch">blob/&lt;branch&gt;/ &mdash; today's template</option>
+        <option value="sha" selected>blob/&lt;head-sha&gt;/ &mdash; the fix</option>
+        <option value="main">blob/main/</option>
+      </select>
+    </label>
+    <label>PR state
+      <select id="state">
+        <option value="open">open, under review</option>
+        <option value="merged" selected>merged, branch deleted</option>
+      </select>
+    </label>
+    <div class="out" id="url"></div>
+    <p class="verdict" id="verdict"></p>
+  </div>
+
+  <div class="panel">
+    <h2>Blast radius: merged PRs with a dead link</h2>
+    <table>
+      <tr><th>PR</th><th>branch (deleted)</th></tr>
+      <tr><td>#3147</td><td>fix/yaml-prose-leftover</td></tr>
+      <tr><td>#3146</td><td>fix/command-argument-hint</td></tr>
+      <tr><td>#3144</td><td>chore/currency-followups</td></tr>
+      <tr><td>#3142</td><td>chore/langchain-ecosystem-currency</td></tr>
+      <tr><td>#3138</td><td>fix/skill-eval-scope-and-ask-tier-quotes</td></tr>
+      <tr><td>#3137</td><td>fix/executor-nudge-test-isolation</td></tr>
+      <tr><td>#3136</td><td>fix/assess-m170-findings</td></tr>
+    </table>
+    <p class="verdict">Open PR <strong>#3141</strong> carries the same form and would join this
+       list on merge. <strong>#3145</strong> already uses <code>blob/main/</code>, from
+       <code>labs-version-watch.yml</code>, which got it right.</p>
+  </div>
+
+  <footer>OrchestKit &middot; fix/playground-durable-links</footer>
+</div>
+
+<script>
+  const SLUG = "docs/fix--yaml-prose-leftover/phantom-symbols.html";
+  const SHA  = "1294771ae82d487fc7d3d9fe3f93c0b622b65694";
+  const BR   = "fix/yaml-prose-leftover";
+  const BASE = "https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/";
+
+  const refFor = f => f === "branch" ? BR : f === "sha" ? SHA : "main";
+
+  function live(form, state) {
+    if (form === "branch") return state === "open";   // branch exists only pre-merge
+    if (form === "main")   return state === "merged"; // file reaches main only on merge
+    return true;                                       // sha works either side
+  }
+
+  function render() {
+    const form  = document.getElementById("form").value;
+    const state = document.getElementById("state").value;
+    document.getElementById("url").textContent = BASE + refFor(form) + "/" + SLUG;
+    const ok = live(form, state);
+    const v  = document.getElementById("verdict");
+    v.innerHTML = ok
+      ? '<span class="pill ok">200</span> &nbsp;resolves'
+      : '<span class="pill bad">404</span> &nbsp;' +
+        (form === "branch" ? "the branch was deleted on merge"
+                           : "not on main until the PR merges");
+  }
+
+  document.getElementById("form").addEventListener("change", render);
+  document.getElementById("state").addEventListener("change", render);
+  render();
+</script>
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/create-pr.mdx
+++ b/docs/site/content/docs/reference/skills/create-pr.mdx
@@ -284,13 +284,26 @@ Bash(f'git commit -m "docs: add PR playground for {BRANCH}"')
 Bash(f"git push origin {BRANCH}")
 ```
 
+Resolve the head SHA first, and pin the link to it:
+
+```bash
+Bash("git rev-parse HEAD")   # -> {HEAD_SHA}
+```
+
 Add a "Live Preview" section to the PR body:
 
 ```markdown
 ## Live Preview
 
-**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{BRANCH}/docs/{BRANCH_DIR}/playground.html)**
+**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{HEAD_SHA}/docs/{BRANCH_DIR}/playground.html)**
 ```
+
+> **Pin the SHA, never the branch.** GitHub deletes the head branch on merge, so a
+> `blob/\{BRANCH\}/` URL returns 404 the moment the PR lands. That silently broke the
+> playground link on every merged PR through #3147. A commit SHA stays reachable
+> indefinitely because GitHub retains `refs/pull/&lt;N&gt;/head`, so the same URL works
+> during review and after merge. Verified: branch form 404, SHA form 200, on a PR
+> whose branch was already deleted.
 
 > **Why required:** CI Stage 1d (`playground-check`) blocks merge if `docs/\{branch-dir\}/*.html` is missing. Bot PRs (dependabot, release-please) are exempt.
 

--- a/docs/site/lib/generated/changelog-data.ts
+++ b/docs/site/lib/generated/changelog-data.ts
@@ -17,6 +17,41 @@ export interface ChangelogEntry {
 
 export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
   {
+    "version": "8.85.0",
+    "date": "2026-07-25",
+    "compareUrl": "",
+    "sections": [
+      {
+        "type": "added",
+        "items": [
+          "agent activation routing (M170) ([#3133](https://github.com/yonatangross/orchestkit/issues/3133)) ([af4d6fd](https://github.com/yonatangross/orchestkit/commit/af4d6fdc807c84329035b240908fc8f1f91f4c87))"
+        ]
+      },
+      {
+        "type": "fixed",
+        "items": [
+          "3 defects found by /ork:assess on the M170 diff ([#3136](https://github.com/yonatangross/orchestkit/issues/3136)) ([b8be78c](https://github.com/yonatangross/orchestkit/commit/b8be78c1786e49f9a368b8526ce00cf93eb6e47d))",
+          "**build:** stop dropping argument-hint from generated commands ([#3146](https://github.com/yonatangross/orchestkit/issues/3146)) ([be63597](https://github.com/yonatangross/orchestkit/commit/be635970a637381feb24ee85f655d9b4f8c2b34a))",
+          "**hooks:** make network-egress-guard DENY tier quote-aware ([#3124](https://github.com/yonatangross/orchestkit/issues/3124)) ([357e404](https://github.com/yonatangross/orchestkit/commit/357e4048430d9a70c23f7bd4222004a3ca697182))",
+          "**hooks:** redirect pipe-to-interpreter deny instead of dead-ending ([#3121](https://github.com/yonatangross/orchestkit/issues/3121)) ([c72bf74](https://github.com/yonatangross/orchestkit/commit/c72bf7446aea0dc4e18f431158830ac72b78b147))",
+          "LangChain ecosystem currency + dual-registry version watchdog ([#3142](https://github.com/yonatangross/orchestkit/issues/3142)) ([de60c1b](https://github.com/yonatangross/orchestkit/commit/de60c1b59e019cb3f48e12b5ff047e09062d69e1))",
+          "narrow skill-eval pathspec + close ASK-tier quote gap ([#3138](https://github.com/yonatangross/orchestkit/issues/3138)) ([8355412](https://github.com/yonatangross/orchestkit/commit/8355412b3f9d16ab4544916f3f3e8148b1ed05de))",
+          "**skills:** remove 24 phantom imports found by the import gate ([#3144](https://github.com/yonatangross/orchestkit/issues/3144)) ([cba9633](https://github.com/yonatangross/orchestkit/commit/cba9633bf948f9cec19a079dba4bd848a6fe6e15))",
+          "**skills:** remove phantom-API leftovers the import gate cannot see ([#3147](https://github.com/yonatangross/orchestkit/issues/3147)) ([774ac7b](https://github.com/yonatangross/orchestkit/commit/774ac7b9fec6db7045793edf8ac6bb39fe9c5040))"
+        ]
+      },
+      {
+        "type": "changed",
+        "items": [
+          "**cc-watch:** snapshot upstream CHANGELOG (2.1.218) ([#3120](https://github.com/yonatangross/orchestkit/issues/3120)) ([2414aaf](https://github.com/yonatangross/orchestkit/commit/2414aafa2c500c916bea76d8c6f300450b65e978))",
+          "**cc-watch:** snapshot upstream CHANGELOG (2.1.220) ([#3140](https://github.com/yonatangross/orchestkit/issues/3140)) ([5dc0175](https://github.com/yonatangross/orchestkit/commit/5dc0175c8e32c0e458c032e31c8674608b42d46d))",
+          "**deps-dev:** bump @biomejs/biome from 2.5.4 to 2.5.5 in /src/hooks in the npm-minor-patch group across 1 directory ([#3107](https://github.com/yonatangross/orchestkit/issues/3107)) ([dc50099](https://github.com/yonatangross/orchestkit/commit/dc500998fdfaf7910de1cb1f1f753447baf938e8))",
+          "**deps:** bump postcss from 8.5.16 to 8.5.23 in /orchestkit-demos ([#3143](https://github.com/yonatangross/orchestkit/issues/3143)) ([7edc78e](https://github.com/yonatangross/orchestkit/commit/7edc78ed8ffbdcb8a681e9781a8080c43fc77c3c))"
+        ]
+      }
+    ]
+  },
+  {
     "version": "8.84.10",
     "date": "2026-07-23",
     "compareUrl": "",

--- a/docs/site/lib/generated/skills-data.ts
+++ b/docs/site/lib/generated/skills-data.ts
@@ -1417,7 +1417,7 @@ export const SKILLS: Record<string, SkillMeta> = {
     "name": "create-pr",
     "description": "Creates GitHub pull requests with pre-flight validation, conventional title formatting, and structured summary generation. Runs parallel checks (tests, lint, type-check, security) before opening. Supports feature, bugfix, refactor, and hotfix PR types with milestone assignment via gh CLI. Use when opening PRs or submitting code for review.",
     "version": "2.5.0",
-    "sha256": "192513d14611a3e4325be64c9f50f240a9824912eaa7528ae315ce756ac460c7",
+    "sha256": "b3492982d65fd6ce0e9169085b2711847e633c7135edcbfee12e912f207d128b",
     "author": "OrchestKit",
     "tags": [
       "git",

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -14,11 +14,14 @@ Minimum viable PR playground that satisfies the PR Playground CI check (~2 KB ba
    The CI check derives the expected dir name from the branch, so this has to match.
 2. Fill in the four `[[TODO]]` sections: title, badges, at-a-glance stats, issue/file rows
 3. Force-add (the `docs/{prefix}--*/` dirs are gitignored): `git add -f docs/{prefix}--{branch-slug}/`
-4. Reference from the PR body:
+4. Reference from the PR body, pinning the commit SHA (`git rev-parse HEAD`),
+   never the branch name. GitHub deletes the branch on merge, so a branch-pinned
+   URL 404s as soon as the PR lands; a SHA survives because `refs/pull/<N>/head`
+   is retained.
    ```
    ## Interactive Playground
 
-   **[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/{branch}/docs/{prefix}--{branch-slug}/{short-name}.html)**
+   **[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/{head-sha}/docs/{prefix}--{branch-slug}/{short-name}.html)**
    ```
 
 **When to extend beyond the template:**

--- a/docs/templates/pr-playground.html
+++ b/docs/templates/pr-playground.html
@@ -6,7 +6,12 @@
   placeholders marked [[TODO]], and reference it from the PR body with:
 
     ## Interactive Playground
-    **[Open Playground](https://htmlpreview.github.io/?https://github.com/.../blob/{branch}/docs/feat--{branch-slug}/{name}.html)**
+    **[Open Playground](https://htmlpreview.github.io/?https://github.com/.../blob/{head-sha}/docs/feat--{branch-slug}/{name}.html)**
+
+  Pin the commit SHA (git rev-parse HEAD), never the branch name. GitHub
+  deletes the head branch on merge, so a branch-pinned blob URL 404s the
+  moment the PR lands. A SHA keeps working because refs/pull/<N>/head is
+  retained indefinitely.
 
   That's enough to satisfy the PR Playground CI check. Add interactive
   JS-driven sections only if the PR genuinely benefits from them.

--- a/plugins/ork/commands/create-pr.md
+++ b/plugins/ork/commands/create-pr.md
@@ -273,13 +273,26 @@ Bash(f'git commit -m "docs: add PR playground for {BRANCH}"')
 Bash(f"git push origin {BRANCH}")
 ```
 
+Resolve the head SHA first, and pin the link to it:
+
+```bash
+Bash("git rev-parse HEAD")   # -> {HEAD_SHA}
+```
+
 Add a "Live Preview" section to the PR body:
 
 ```markdown
 ## Live Preview
 
-**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{BRANCH}/docs/{BRANCH_DIR}/playground.html)**
+**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{HEAD_SHA}/docs/{BRANCH_DIR}/playground.html)**
 ```
+
+> **Pin the SHA, never the branch.** GitHub deletes the head branch on merge, so a
+> `blob/{BRANCH}/` URL returns 404 the moment the PR lands. That silently broke the
+> playground link on every merged PR through #3147. A commit SHA stays reachable
+> indefinitely because GitHub retains `refs/pull/<N>/head`, so the same URL works
+> during review and after merge. Verified: branch form 404, SHA form 200, on a PR
+> whose branch was already deleted.
 
 > **Why required:** CI Stage 1d (`playground-check`) blocks merge if `docs/{branch-dir}/*.html` is missing. Bot PRs (dependabot, release-please) are exempt.
 

--- a/plugins/ork/skills/create-pr/SKILL.md
+++ b/plugins/ork/skills/create-pr/SKILL.md
@@ -296,13 +296,26 @@ Bash(f'git commit -m "docs: add PR playground for {BRANCH}"')
 Bash(f"git push origin {BRANCH}")
 ```
 
+Resolve the head SHA first, and pin the link to it:
+
+```bash
+Bash("git rev-parse HEAD")   # -> {HEAD_SHA}
+```
+
 Add a "Live Preview" section to the PR body:
 
 ```markdown
 ## Live Preview
 
-**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{BRANCH}/docs/{BRANCH_DIR}/playground.html)**
+**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{HEAD_SHA}/docs/{BRANCH_DIR}/playground.html)**
 ```
+
+> **Pin the SHA, never the branch.** GitHub deletes the head branch on merge, so a
+> `blob/{BRANCH}/` URL returns 404 the moment the PR lands. That silently broke the
+> playground link on every merged PR through #3147. A commit SHA stays reachable
+> indefinitely because GitHub retains `refs/pull/<N>/head`, so the same URL works
+> during review and after merge. Verified: branch form 404, SHA form 200, on a PR
+> whose branch was already deleted.
 
 > **Why required:** CI Stage 1d (`playground-check`) blocks merge if `docs/{branch-dir}/*.html` is missing. Bot PRs (dependabot, release-please) are exempt.
 

--- a/src/skills/create-pr/SKILL.md
+++ b/src/skills/create-pr/SKILL.md
@@ -296,13 +296,26 @@ Bash(f'git commit -m "docs: add PR playground for {BRANCH}"')
 Bash(f"git push origin {BRANCH}")
 ```
 
+Resolve the head SHA first, and pin the link to it:
+
+```bash
+Bash("git rev-parse HEAD")   # -> {HEAD_SHA}
+```
+
 Add a "Live Preview" section to the PR body:
 
 ```markdown
 ## Live Preview
 
-**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{BRANCH}/docs/{BRANCH_DIR}/playground.html)**
+**[Open Interactive Playground](https://htmlpreview.github.io/?https://github.com/{OWNER}/{REPO}/blob/{HEAD_SHA}/docs/{BRANCH_DIR}/playground.html)**
 ```
+
+> **Pin the SHA, never the branch.** GitHub deletes the head branch on merge, so a
+> `blob/{BRANCH}/` URL returns 404 the moment the PR lands. That silently broke the
+> playground link on every merged PR through #3147. A commit SHA stays reachable
+> indefinitely because GitHub retains `refs/pull/<N>/head`, so the same URL works
+> during review and after merge. Verified: branch form 404, SHA form 200, on a PR
+> whose branch was already deleted.
 
 > **Why required:** CI Stage 1d (`playground-check`) blocks merge if `docs/{branch-dir}/*.html` is missing. Bot PRs (dependabot, release-please) are exempt.
 


### PR DESCRIPTION
## Problem

Every merged PR's **Open Playground** link is dead. The templates emit
`blob/<branch-name>/`, and GitHub deletes the head branch on merge, so the URL
404s the moment the PR lands. The HTML file is fine and sits on `main`; only the
ref disappears.

## Measured on #3147, whose branch is already deleted

| URL form | status | during review | after merge |
|---|---|---|---|
| `blob/<branch>/` | **404** | works | **dead** |
| `blob/<head-sha>/` | **200** | works | **works** |
| `blob/<merge-sha>/` | 200 | n/a | works |
| `blob/main/` | 200 | **404** | works |

Only the head SHA works on **both** sides of the merge. The branch form dies on
merge; the `main` form 404s during review because the file is not on main yet.
A SHA stays reachable indefinitely because GitHub retains `refs/pull/<N>/head`,
which is why that SHA still resolves with its branch long gone.

## Already broken

#3136, #3137, #3138, #3142, #3144, #3146, #3147.

Open PR #3141 carries the same form and would join them on merge. #3145 was
already correct, via `labs-version-watch.yml`, which uses `blob/main`.

## Change

Four source templates: the PR template, the `create-pr` skill, `docs/templates/README.md`,
and the playground HTML scaffold. The docs-site mdx regenerates from the skill.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/9d155e7dcc7a7342883fed5ea3580f5cb3adb9c3/docs/fix--playground-durable-links/playground.html)**

(pinned to the SHA, per the change itself)

