### PR TITLE
docs(readme): rebuild the community table and drop two dead sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude_Code-≥2.1.220-7C3AED?style=for-the-badge&logo=anthropic)](https://claude.ai/claude-code)
 [![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](./LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/yonatangross/orchestkit?style=for-the-badge&logo=github)](https://github.com/yonatangross/orchestkit)
-[![Community](https://img.shields.io/badge/Community-WhatsApp-25D366?style=for-the-badge&logo=whatsapp)](https://chat.whatsapp.com/IKgu1xuvKNXHikJ4Qeotpk)
+[![Community](https://img.shields.io/badge/Community-WhatsApp-25D366?style=for-the-badge&logo=whatsapp)](https://yonyon.ai/go/community)
 [![Ask DeepWiki](https://img.shields.io/badge/Ask-DeepWiki-1A1A2E?style=for-the-badge&logo=bookstack&logoColor=4F9CF9)](https://deepwiki.com/yonatangross/orchestkit)
 
 </div>
@@ -17,7 +17,7 @@
 
 <p align="center">
   <a href="https://orchestkit.yonyon.ai/"><strong>Explore the Docs →</strong></a> ·
-  <a href="https://chat.whatsapp.com/Krraz7LhB951K7nQfC08B2"><strong>OrchestKit Users Group →</strong></a><br>
+  <a href="https://yonyon.ai/go/orchestkit"><strong>OrchestKit Community →</strong></a><br>
   <sub>Skill browser, demo gallery, setup wizard</sub>
 </p>
 
@@ -31,7 +31,6 @@
 - [Key Commands](#key-commands)
 - [Configuration](#configuration)
 - [Install](#install)
-- [Release Channels](#release-channels)
 - [FAQ](#faq)
 - [Development](#development)
 - [What's New](#whats-new)
@@ -89,6 +88,7 @@ All available in a single `/plugin install ork`. Skills load on-demand. Hooks wo
 ## Key Commands
 
 ```bash
+/ork:auto         # Front door: describe a goal, it routes to the right skill
 /ork:setup        # Personalized onboarding wizard
 /ork:implement    # Full-stack implementation with parallel agents
 /ork:expect       # Diff-aware AI browser testing
@@ -104,9 +104,7 @@ All available in a single `/plugin install ork`. Skills load on-demand. Hooks wo
 
 ## Configuration
 
-```bash
-/ork:configure
-```
+`/ork:setup` detects your stack, recommends MCP servers, and writes the configuration for you.
 
 ### Recommended MCP Servers
 
@@ -114,10 +112,10 @@ All available in a single `/plugin install ork`. Skills load on-demand. Hooks wo
 |--------|---------|-----------|
 | Context7 | Up-to-date library docs | Recommended |
 | Memory | Knowledge graph persistence | Recommended |
-| Sequential Thinking | Structured reasoning for subagents | Optional |
+| Sequential Thinking | Structured reasoning for subagents | Recommended |
 | Tavily | Web search and extraction | Optional |
 
-The setup wizard (`/ork:setup`) will recommend MCPs based on your stack.
+Set `"alwaysLoad": true` on the first three in your `.mcp.json`. It skips the per-skill tool probe and shaves ~150ms off cold starts.
 
 ### Customizing skills
 
@@ -138,30 +136,6 @@ Not on Claude Code? Pull the skills into any agent (Cursor, Codex, OpenCode, …
 ```bash
 npx skills add yonatangross/orchestkit
 ```
-
----
-
-## Release Channels
-
-| Channel | Stability | Install |
-|---------|-----------|---------|
-| **Stable** | Production-ready | `/plugin install ork` |
-| **Beta** | May have rough edges | See below |
-| **Alpha** | Experimental, may break | See below |
-
-To install beta or alpha:
-
-```bash
-# Beta channel
-/plugin marketplace add yonatangross/orchestkit --ref beta --name orchestkit-beta
-/plugin install ork@orchestkit-beta
-
-# Alpha channel
-/plugin marketplace add yonatangross/orchestkit --ref alpha --name orchestkit-alpha
-/plugin install ork@orchestkit-alpha
-```
-
-Run `/ork:doctor` to check which channel you're on. [Full docs](https://orchestkit.yonyon.ai/docs/getting-started/release-channels).
 
 ---
 
@@ -270,20 +244,23 @@ _See [CHANGELOG.md](CHANGELOG.md) for the full release history._
 
 ## Community
 
-Join the **Code with Yonatan** community for AI dev tips, OrchestKit support, and connecting with other builders:
+Join the **Building with AI** community for AI dev tips, OrchestKit support, and connecting with other builders:
 
-| Group | Link |
-|-------|------|
-| **Community** (all channels) | [Join on WhatsApp](https://chat.whatsapp.com/IKgu1xuvKNXHikJ4Qeotpk) |
-| **AI Dev (EN)** | [English Group](https://chat.whatsapp.com/CFAQoyGl2rp4P3JHcwC9Uu) |
-| <strong dir="rtl">יש לך AI?</strong> | [Hebrew Group](https://chat.whatsapp.com/BC4QoLEUNR76ygZwyrgZZT) |
-| **OrchestKit Users** | [Support & Showcase](https://chat.whatsapp.com/Krraz7LhB951K7nQfC08B2) |
+| Group | Who it's for | Link |
+|-------|--------------|------|
+| **Building with AI** · <strong dir="rtl">בונים עם AI</strong> | The umbrella community. One join, every room below. | [Join](https://yonyon.ai/go/community) |
+| **OrchestKit** | Setups, hooks, agents, and real problems from the field. | [Join](https://yonyon.ai/go/orchestkit) |
+| **The Orchestra** | English room for AI dev talk: agents, MCP, Claude Code. | [Join](https://chat.whatsapp.com/CFAQoyGl2rp4P3JHcwC9Uu) |
+| **Builders** · <strong dir="rtl">בילדרים</strong> | Hebrew room for people already shipping AI: RAG, agents, MCP in production. | [Join](https://yonyon.ai/go/builders) |
+| **AI for Business** · <strong dir="rtl">AI לעסקים</strong> | Hebrew room for founders and team leads adopting AI. Decisions and ROI, no code. | [Join](https://yonyon.ai/go/business) |
+
+Most links resolve through `yonyon.ai/go/*`, so they survive an invite rotation without a README change.
 
 ---
 
 <div align="center">
 
-**[Docs](https://orchestkit.yonyon.ai/)** · **[Issues](https://github.com/yonatangross/orchestkit/issues)** · **[Discussions](https://github.com/yonatangross/orchestkit/discussions)** · **[Community](https://chat.whatsapp.com/IKgu1xuvKNXHikJ4Qeotpk)**
+**[Docs](https://orchestkit.yonyon.ai/)** · **[Issues](https://github.com/yonatangross/orchestkit/issues)** · **[Discussions](https://github.com/yonatangross/orchestkit/discussions)** · **[Community](https://yonyon.ai/go/community)**
 
 MIT License · [@yonatangross](https://github.com/yonatangross)
 

--- a/README.md
+++ b/README.md
@@ -251,10 +251,9 @@ Join the **Building with AI** community for AI dev tips, OrchestKit support, and
 | **Building with AI** | The umbrella community. One join, every room below. | [Join](https://yonyon.ai/go/community) |
 | **Builders** | For people already building | [Join](https://yonyon.ai/go/builders) |
 | **OrchestKit** | For OrchestKit users | [Join](https://yonyon.ai/go/orchestkit) |
-| **The Orchestra** | For anyone building with AI agents | [Join](https://chat.whatsapp.com/CFAQoyGl2rp4P3JHcwC9Uu) |
 | **AI for Business** | For people leading AI adoption | [Join](https://yonyon.ai/go/business) |
 
-Names and audiences match what [yonyon.ai](https://yonyon.ai/en) renders, so the two surfaces cannot drift. Most links resolve through `yonyon.ai/go/*`, so they survive an invite rotation without a README change.
+Names and audiences match what [yonyon.ai](https://yonyon.ai/en) renders, so the two surfaces cannot drift. Every link resolves through `yonyon.ai/go/*`, so a rotated invite never needs a README change and no raw invite is published here.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -246,15 +246,15 @@ _See [CHANGELOG.md](CHANGELOG.md) for the full release history._
 
 Join the **Building with AI** community for AI dev tips, OrchestKit support, and connecting with other builders:
 
-| Group | Who it's for | Link |
-|-------|--------------|------|
-| **Building with AI** · <strong dir="rtl">בונים עם AI</strong> | The umbrella community. One join, every room below. | [Join](https://yonyon.ai/go/community) |
-| **OrchestKit** | Setups, hooks, agents, and real problems from the field. | [Join](https://yonyon.ai/go/orchestkit) |
-| **The Orchestra** | English room for AI dev talk: agents, MCP, Claude Code. | [Join](https://chat.whatsapp.com/CFAQoyGl2rp4P3JHcwC9Uu) |
-| **Builders** · <strong dir="rtl">בילדרים</strong> | Hebrew room for people already shipping AI: RAG, agents, MCP in production. | [Join](https://yonyon.ai/go/builders) |
-| **AI for Business** · <strong dir="rtl">AI לעסקים</strong> | Hebrew room for founders and team leads adopting AI. Decisions and ROI, no code. | [Join](https://yonyon.ai/go/business) |
+| Room | Who it's for | Link |
+|------|--------------|------|
+| **Building with AI** | The umbrella community. One join, every room below. | [Join](https://yonyon.ai/go/community) |
+| **Builders** | For people already building | [Join](https://yonyon.ai/go/builders) |
+| **OrchestKit** | For OrchestKit users | [Join](https://yonyon.ai/go/orchestkit) |
+| **The Orchestra** | For anyone building with AI agents | [Join](https://chat.whatsapp.com/CFAQoyGl2rp4P3JHcwC9Uu) |
+| **AI for Business** | For people leading AI adoption | [Join](https://yonyon.ai/go/business) |
 
-Most links resolve through `yonyon.ai/go/*`, so they survive an invite rotation without a README change.
+Names and audiences match what [yonyon.ai](https://yonyon.ai/en) renders, so the two surfaces cannot drift. Most links resolve through `yonyon.ai/go/*`, so they survive an invite rotation without a README change.
 
 ---
 

--- a/docs/fix--readme-community-table/plan-viz.html
+++ b/docs/fix--readme-community-table/plan-viz.html
@@ -128,10 +128,11 @@ a{color:var(--pg-accent);text-underline-offset:3px}
         <div class="real"><span class="dot good"></span>🤝 <span dir="rtl">בונים עם AI</span></div>
         <div class="claim">README said: <b>Community</b> (all channels). Close enough, but now named.</div>
       </div>
-      <div class="ev-card bad">
+      <div class="ev-card" style="border-color:hsl(38 92% 60% / .38)">
         <div class="code mono">CFAQoyGl2rp4P3JHcwC9Uu</div>
-        <div class="real"><span class="dot bad"></span>🎻 The Orchestra</div>
-        <div class="claim">README said: <b>AI Dev (EN)</b>. No group has ever had that name.</div>
+        <div class="real"><span class="dot warn"></span>🎻 The Orchestra</div>
+        <div class="claim">README said: <b>AI Dev (EN)</b>. Live, but absent from both canonical
+          registries and its name fails the clarity-first doctrine. <b>Row removed</b>, see stage 5.</div>
       </div>
       <div class="ev-card bad">
         <div class="code mono">BC4QoLEUNR76ygZwyrgZZT</div>
@@ -201,9 +202,8 @@ a{color:var(--pg-accent);text-underline-offset:3px}
       <span class="tag warn">one surface still disagrees</span>
     </div>
     <p class="st-why">
-      Three repos independently list the community rooms. The README is the one this PR fixes;
-      the portfolio seed list gains The Orchestra in a companion PR. Platform's bot room tuple is
-      left alone on purpose, and is called out below rather than changed silently.
+      Three repos independently list the community rooms. After this PR all three agree on the same
+      four entries, which is the state that makes future drift detectable.
     </p>
 
     <table class="matrix">
@@ -232,16 +232,53 @@ a{color:var(--pg-accent);text-underline-offset:3px}
         </tr>
         <tr>
           <td><b>The Orchestra</b></td>
-          <td class="y">kept</td><td class="y">added (companion PR)</td><td class="n">absent</td>
+          <td class="n">removed</td><td class="n">absent</td><td class="n">absent</td>
         </tr>
       </tbody>
     </table>
+  </section>
+
+  <!-- ───────────────────────── stage 5 : the naming call ───────────────────────── -->
+  <section class="glass stage">
+    <div class="st-hd">
+      <h2>5 · Why The Orchestra is not in the table</h2>
+      <span class="tag warn">reversed mid-review</span>
+    </div>
+    <p class="st-why">
+      An earlier draft of this PR added it, on the reasoning that a live room missing from the
+      registries was an oversight. That reasoning was wrong, and the repo says so in writing.
+    </p>
+
+    <div class="note" style="background:hsl(0 0% 100% / .04);border-color:var(--pg-glass-edge);color:var(--pg-ink)">
+      <span class="mono" style="font-size:12.5px">portfolio/src/data/community-rooms-seeds.ts:6</span><br>
+      <i>"Naming strategy (settled 2026-07-17 after three rounds): clarity first. Every name tells a
+      stranger what the room is and who it's for in one second; no metaphor system to decode."</i>
+    </div>
+
+    <table style="margin-block-start:14px">
+      <thead><tr><th>Name</th><th>What a stranger learns in one second</th><th></th></tr></thead>
+      <tbody>
+        <tr><td><b>Builders</b></td><td class="who">who it is for</td><td>✅</td></tr>
+        <tr><td><b>OrchestKit</b></td><td class="who">the product it is about</td><td>✅</td></tr>
+        <tr><td><b>AI for Business</b></td><td class="who">who it is for</td><td>✅</td></tr>
+        <tr><td><b>The Orchestra</b></td>
+            <td class="who">nothing. it is a pun on orchestration</td><td>❌</td></tr>
+      </tbody>
+    </table>
+
+    <p class="st-why" style="margin-block-start:16px">
+      The timeline supports reading the omission as deliberate. A 2026-06-21 platform audit praised
+      "The Orchestra" as on-theme during the metaphor era; the 2026-07-17 round then replaced
+      metaphor names with literal ones and did not carry it over. It is absent from the portfolio
+      seeds and from platform's <span class="mono">COMMUNITY_ROOMS</span> independently. Two
+      omissions after a three-round naming exercise is a decision, not a gap.
+    </p>
 
     <div class="note">
-      <b>Flagged, not fixed:</b> platform's <span class="mono">COMMUNITY_ROOMS</span> tuple in
-      <span class="mono">apps/api/app/services/hq_bot/community_activity.py</span> omits The
-      Orchestra, so the weekly activity brief has never counted that room. That is a live
-      behaviour change in a different repo, so it belongs in its own PR with its own review.
+      <b>The irony:</b> the README's original label for that invite was "AI Dev (EN)", which
+      <i>passes</i> the doctrine. The first draft of this fix replaced a compliant display name with
+      the non-compliant internal group name. That row was not the stale one. The group stays live and
+      unadvertised, exactly as before this PR; republishing it is a branding decision, not a docs fix.
     </div>
   </section>
 
@@ -321,7 +358,6 @@ const ROWS = {
        'The umbrella community. One join, every room below.', 'Join · /go/community'],
       ['<b>Builders</b>', 'For people already building', 'Join · /go/builders'],
       ['<b>OrchestKit</b>', 'For OrchestKit users', 'Join · /go/orchestkit'],
-      ['<b>The Orchestra</b>', 'For anyone building with AI agents', 'Join · raw invite'],
       ['<b>AI for Business</b>', 'For people leading AI adoption', 'Join · /go/business'],
     ],
   },

--- a/docs/fix--readme-community-table/plan-viz.html
+++ b/docs/fix--readme-community-table/plan-viz.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>README community table · verified against the live WhatsApp invites</title>
+<style>
+:root{
+  --pg-bg:hsl(232 26% 7%);
+  --pg-ink:hsl(220 18% 93%);
+  --pg-muted:hsl(220 14% 64%);
+  --pg-faint:hsl(220 12% 46%);
+  --pg-glass:hsl(0 0% 100% / .05);
+  --pg-glass-2:hsl(0 0% 100% / .08);
+  --pg-glass-edge:hsl(0 0% 100% / .18);
+  --pg-accent:hsl(248 84% 68%);
+  --pg-accent-deep:hsl(248 74% 52%);
+  --pg-danger:hsl(352 78% 62%);
+  --pg-warn:hsl(38 92% 60%);
+  --pg-ok:hsl(158 64% 52%);
+  --r-sm:9px; --r-md:16px; --r-lg:24px;
+  --sh-amb:0 20px 60px -22px hsl(248 60% 4% / .7);
+  --sh-tight:0 4px 12px -6px hsl(248 60% 4% / .5);
+  --ease:cubic-bezier(.2,.8,.25,1);
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{
+  background:
+    radial-gradient(58rem 38rem at 10% -10%, hsl(240 70% 40% / .30), transparent 60%),
+    radial-gradient(50rem 34rem at 94% 4%, hsl(264 68% 42% / .24), transparent 62%),
+    var(--pg-bg);
+  background-attachment:fixed;
+  color:var(--pg-ink);
+  font-family:ui-sans-serif,-apple-system,"Segoe UI",Inter,system-ui,sans-serif;
+  line-height:1.5;-webkit-font-smoothing:antialiased;
+}
+.mono{font-family:ui-monospace,"SF Mono",Menlo,monospace;font-variant-numeric:tabular-nums}
+.wrap{max-width:1040px;margin-inline:auto;padding:48px 24px 96px}
+.eyebrow{font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:var(--pg-faint);
+  font-weight:600;margin-block-end:8px}
+h1{font-size:clamp(25px,3.4vw,36px);font-weight:700;letter-spacing:-.3px;line-height:1.18}
+h1 em{font-style:normal;color:var(--pg-accent)}
+.sub{color:var(--pg-muted);margin-block-start:12px;max-width:76ch;font-size:15px}
+
+.glass{background:var(--pg-glass);border:1px solid var(--pg-glass-edge);border-radius:var(--r-md);
+  box-shadow:var(--sh-amb),var(--sh-tight),inset 0 1px 0 hsl(0 0% 100% / .12);
+  -webkit-backdrop-filter:blur(16px);backdrop-filter:blur(16px)}
+
+.stage{margin-block-start:24px;padding:24px}
+.st-hd{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-block-end:8px}
+.st-hd h2{font-size:18px;letter-spacing:-.2px;font-weight:650}
+.tag{font-size:11px;font-weight:700;letter-spacing:.05em;text-transform:uppercase;
+  padding:3px 9px;border-radius:var(--r-sm)}
+.tag.bad{background:hsl(352 78% 62% / .16);color:var(--pg-danger)}
+.tag.good{background:hsl(158 64% 52% / .15);color:var(--pg-ok)}
+.tag.warn{background:hsl(38 92% 60% / .15);color:var(--pg-warn)}
+.st-why{color:var(--pg-muted);font-size:14px;margin-block-end:16px;max-width:78ch}
+
+table{border-collapse:collapse;width:100%;font-size:14px;
+  background:hsl(232 30% 5%);border-radius:var(--r-sm);overflow:hidden}
+th,td{padding:10px 12px;text-align:start;border-block-end:1px solid hsl(0 0% 100% / .07);
+  vertical-align:top}
+th{font-size:11px;letter-spacing:.09em;text-transform:uppercase;color:var(--pg-faint);
+  background:hsl(0 0% 100% / .04);font-weight:700}
+tr:last-child td{border-block-end:none}
+td .who{color:var(--pg-muted);font-size:13px}
+a{color:var(--pg-accent);text-underline-offset:3px}
+
+.seg{display:inline-flex;gap:4px;padding:4px;border-radius:var(--r-sm);
+  background:hsl(0 0% 100% / .06);border:1px solid var(--pg-glass-edge);margin-block-end:16px}
+.seg button{appearance:none;border:0;cursor:pointer;font:inherit;font-size:13px;font-weight:600;
+  padding:7px 14px;border-radius:6px;color:var(--pg-muted);background:transparent;
+  transition:all .18s var(--ease)}
+.seg button[aria-pressed="true"]{background:var(--pg-accent-deep);color:hsl(0 0% 100%)}
+.seg button:hover:not([aria-pressed="true"]){color:var(--pg-ink)}
+
+.ev{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:12px;
+  margin-block-start:16px}
+.ev-card{padding:14px;border-radius:var(--r-sm);background:hsl(0 0% 100% / .04);
+  border:1px solid hsl(0 0% 100% / .10)}
+.ev-card .code{font-size:11px;color:var(--pg-faint);word-break:break-all}
+.ev-card .real{font-size:16px;font-weight:650;margin-block:6px 4px}
+.ev-card .claim{font-size:12.5px;color:var(--pg-muted)}
+.ev-card.bad{border-color:hsl(352 78% 62% / .40)}
+.ev-card.good{border-color:hsl(158 64% 52% / .34)}
+.dot{display:inline-block;width:7px;height:7px;border-radius:50%;margin-inline-end:7px;
+  vertical-align:middle}
+.dot.bad{background:var(--pg-danger)} .dot.good{background:var(--pg-ok)}
+.dot.warn{background:var(--pg-warn)}
+
+.matrix td.y{color:var(--pg-ok);font-weight:650}
+.matrix td.n{color:var(--pg-danger);font-weight:650}
+.note{margin-block-start:14px;padding:12px 14px;border-radius:var(--r-sm);font-size:13.5px;
+  background:hsl(38 92% 60% / .08);border:1px solid hsl(38 92% 60% / .28);color:hsl(38 60% 84%)}
+.foot{margin-block-start:32px;color:var(--pg-faint);font-size:12.5px;text-align:center}
+[dir="rtl"]{unicode-bidi:isolate}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="eyebrow">OrchestKit · fix/readme-community-table</div>
+  <h1>The README's hand-written half had <em>rotted for months</em></h1>
+  <p class="sub">
+    The auto-generated blocks are healthy: What's New is stamped to v9.1.1 and
+    <span class="mono">check-docs-facts</span> passes at 114 skills / 36 agents / 219 hooks. Nothing
+    regenerates or gates the prose around them, so three separate defects survived there: a
+    community table wrong on 3 of 4 rows, an install path for release channels that never existed,
+    and a slash command that cannot be invoked. Every claim below was verified against a live
+    surface, not inferred.
+  </p>
+
+  <!-- ───────────────────────── stage 1 : evidence ───────────────────────── -->
+  <section class="glass stage">
+    <div class="st-hd">
+      <h2>1 · What each link actually resolves to</h2>
+      <span class="tag bad">3 wrong · 1 missing</span>
+    </div>
+    <p class="st-why">
+      Resolved live. The group name is whatever WhatsApp renders in
+      <span class="mono">og:title</span>, which is the same string a person sees on the join screen.
+      That is the only source that cannot drift.
+    </p>
+
+    <div class="ev">
+      <div class="ev-card good">
+        <div class="code mono">IKgu1xuvKNXHikJ4Qeotpk</div>
+        <div class="real"><span class="dot good"></span>🤝 <span dir="rtl">בונים עם AI</span></div>
+        <div class="claim">README said: <b>Community</b> (all channels). Close enough, but now named.</div>
+      </div>
+      <div class="ev-card bad">
+        <div class="code mono">CFAQoyGl2rp4P3JHcwC9Uu</div>
+        <div class="real"><span class="dot bad"></span>🎻 The Orchestra</div>
+        <div class="claim">README said: <b>AI Dev (EN)</b>. No group has ever had that name.</div>
+      </div>
+      <div class="ev-card bad">
+        <div class="code mono">BC4QoLEUNR76ygZwyrgZZT</div>
+        <div class="real"><span class="dot bad"></span>🛠️ <span dir="rtl">בילדרים</span> (Builders)</div>
+        <div class="claim">README said: <span dir="rtl">יש לך AI?</span> Stale name from an earlier round.</div>
+      </div>
+      <div class="ev-card good">
+        <div class="code mono">Krraz7LhB951K7nQfC08B2</div>
+        <div class="real"><span class="dot good"></span>🎻 OrchestKit</div>
+        <div class="claim">README said: <b>OrchestKit Users</b>. Correct.</div>
+      </div>
+      <div class="ev-card bad">
+        <div class="code mono">HcOREpW7PyqFRkPmnIMNMD</div>
+        <div class="real"><span class="dot bad"></span>📈 <span dir="rtl">AI לעסקים</span></div>
+        <div class="claim">README said: <b>nothing</b>. The room was absent from the table entirely.</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ───────────────────────── stage 2 : before / after ───────────────────────── -->
+  <section class="glass stage">
+    <div class="st-hd">
+      <h2>2 · The table, before and after</h2>
+      <span class="tag good">rendered as GitHub renders it</span>
+    </div>
+    <p class="st-why">
+      Toggle to compare. Hebrew cells stay wrapped in
+      <span class="mono">&lt;strong dir="rtl"&gt;</span>, the bidi isolation pattern established in
+      #3153, so the pipes of the markdown table never reorder around the Hebrew run.
+    </p>
+
+    <div class="seg" role="group" aria-label="Table version">
+      <button type="button" data-v="before" aria-pressed="false">Before</button>
+      <button type="button" data-v="after"  aria-pressed="true">After</button>
+    </div>
+
+    <div id="tbl"></div>
+  </section>
+
+  <!-- ───────────────────────── stage 3 : cross-surface ───────────────────────── -->
+  <section class="glass stage">
+    <div class="st-hd">
+      <h2>3 · Where each room is declared</h2>
+      <span class="tag warn">one surface still disagrees</span>
+    </div>
+    <p class="st-why">
+      Three repos independently list the community rooms. The README is the one this PR fixes;
+      the portfolio seed list gains The Orchestra in a companion PR. Platform's bot room tuple is
+      left alone on purpose, and is called out below rather than changed silently.
+    </p>
+
+    <table class="matrix">
+      <thead><tr>
+        <th>Room</th>
+        <th>orchestkit README</th>
+        <th>portfolio seeds</th>
+        <th>platform COMMUNITY_ROOMS</th>
+      </tr></thead>
+      <tbody>
+        <tr>
+          <td><b>Building with AI</b> · <span dir="rtl">בונים עם AI</span></td>
+          <td class="y">yes</td><td class="y">yes (umbrella)</td><td class="y">yes</td>
+        </tr>
+        <tr>
+          <td><b>OrchestKit</b></td>
+          <td class="y">yes</td><td class="y">yes</td><td class="y">yes</td>
+        </tr>
+        <tr>
+          <td><b>Builders</b> · <span dir="rtl">בילדרים</span></td>
+          <td class="y">yes</td><td class="y">yes</td><td class="y">yes</td>
+        </tr>
+        <tr>
+          <td><b>AI for Business</b> · <span dir="rtl">AI לעסקים</span></td>
+          <td class="y">added here</td><td class="y">yes</td><td class="y">yes</td>
+        </tr>
+        <tr>
+          <td><b>The Orchestra</b></td>
+          <td class="y">kept</td><td class="y">added (companion PR)</td><td class="n">absent</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="note">
+      <b>Flagged, not fixed:</b> platform's <span class="mono">COMMUNITY_ROOMS</span> tuple in
+      <span class="mono">apps/api/app/services/hq_bot/community_activity.py</span> omits The
+      Orchestra, so the weekly activity brief has never counted that room. That is a live
+      behaviour change in a different repo, so it belongs in its own PR with its own review.
+    </div>
+  </section>
+
+  <!-- ───────────────────────── stage 4 : dead sections ───────────────────────── -->
+  <section class="glass stage">
+    <div class="st-hd">
+      <h2>4 · Two things the README told you to run that cannot work</h2>
+      <span class="tag bad">removed</span>
+    </div>
+    <p class="st-why">
+      Both are documentation for features that do not exist. Neither is caught by any gate, because
+      <span class="mono">check-docs-facts.mjs</span> validates counts and the Claude Code floor and
+      never reads a URL or a command name.
+    </p>
+
+    <table>
+      <thead><tr><th>Claim in README</th><th>Verification run</th><th>Result</th></tr></thead>
+      <tbody>
+        <tr>
+          <td>
+            <b>Release Channels</b><br>
+            <span class="who mono">/plugin marketplace add … --ref beta</span>
+          </td>
+          <td class="mono" style="font-size:12.5px">git ls-remote --heads --tags origin</td>
+          <td><span class="dot bad"></span>No <span class="mono">beta</span> or
+            <span class="mono">alpha</span> ref has ever existed. The linked docs page was deleted in
+            <span class="mono">b23da597e</span> (2026-07-19, <i>"remove … the never-published release
+            channels"</i>) but the README section stayed, pointing at a 404.</td>
+        </tr>
+        <tr>
+          <td><b>Configuration</b><br><span class="who mono">/ork:configure</span></td>
+          <td class="mono" style="font-size:12.5px">src/skills/configure/SKILL.md</td>
+          <td><span class="dot bad"></span><span class="mono">user-invocable: false</span> and
+            <span class="mono">disable-model-invocation: true</span>, so no command is generated and
+            the model cannot reach it either. Replaced with <span class="mono">/ork:setup</span>,
+            which is real and does the MCP configuration.</td>
+        </tr>
+        <tr>
+          <td><b>Sequential Thinking</b><br><span class="who">listed as Optional</span></td>
+          <td class="mono" style="font-size:12.5px">src/skills/setup/SKILL.md:161</td>
+          <td><span class="dot warn"></span>Called part of the "universally-needed T2 trio" with a
+            recommended <span class="mono">alwaysLoad: true</span>. Promoted to Recommended so the
+            README and the setup wizard stop disagreeing.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="note">
+      <b>Root cause, not fixed here:</b> there is no link checker in CI. A
+      <span class="mono">lychee</span> step scoped to <span class="mono">README.md</span> would have
+      caught the 404 and the dead install path months ago. Worth its own issue.
+    </div>
+  </section>
+
+  <p class="foot">
+    Evidence captured 2026-07-28 by resolving each invite's <span class="mono">og:title</span>.
+    Counts cross-checked with <span class="mono">scripts/check-docs-facts.mjs</span> (114 skills,
+    36 agents, 219 hooks).
+  </p>
+</div>
+
+<script>
+const ROWS = {
+  before: {
+    head: ['Group', 'Link'],
+    body: [
+      ['<b>Community</b> (all channels)', 'Join on WhatsApp'],
+      ['<b>AI Dev (EN)</b>', 'English Group'],
+      ['<strong dir="rtl">יש לך AI?</strong>', 'Hebrew Group'],
+      ['<b>OrchestKit Users</b>', 'Support &amp; Showcase'],
+    ],
+  },
+  after: {
+    head: ['Group', "Who it's for", 'Link'],
+    body: [
+      ['<b>Building with AI</b> · <strong dir="rtl">בונים עם AI</strong>',
+       'The umbrella community. One join, every room below.', 'Join · /go/community'],
+      ['<b>OrchestKit</b>',
+       'Setups, hooks, agents, and real problems from the field.', 'Join · /go/orchestkit'],
+      ['<b>The Orchestra</b>',
+       'English room for AI dev talk: agents, MCP, Claude Code.', 'Join · raw invite'],
+      ['<b>Builders</b> · <strong dir="rtl">בילדרים</strong>',
+       'Hebrew room for people already shipping AI: RAG, agents, MCP in production.',
+       'Join · /go/builders'],
+      ['<b>AI for Business</b> · <strong dir="rtl">AI לעסקים</strong>',
+       'Hebrew room for founders and team leads adopting AI. Decisions and ROI, no code.',
+       'Join · /go/business'],
+    ],
+  },
+};
+
+const host = document.getElementById('tbl');
+
+function render(v) {
+  const d = ROWS[v];
+  const head = '<tr>' + d.head.map(h => `<th>${h}</th>`).join('') + '</tr>';
+  const body = d.body.map(r => '<tr>' + r.map((c, i) => {
+    const cls = (d.head.length === 3 && i === 1) ? ' class="who"' : '';
+    const cell = (i === r.length - 1) ? `<a href="#">${c}</a>` : c;
+    return `<td${cls}>${cell}</td>`;
+  }).join('') + '</tr>').join('');
+  host.innerHTML = `<table><thead>${head}</thead><tbody>${body}</tbody></table>`;
+}
+
+document.querySelectorAll('.seg button').forEach(b => {
+  b.addEventListener('click', () => {
+    document.querySelectorAll('.seg button')
+      .forEach(o => o.setAttribute('aria-pressed', String(o === b)));
+    render(b.dataset.v);
+  });
+});
+
+render('after');
+</script>
+</body>
+</html>

--- a/docs/fix--readme-community-table/plan-viz.html
+++ b/docs/fix--readme-community-table/plan-viz.html
@@ -158,10 +158,33 @@ a{color:var(--pg-accent);text-underline-offset:3px}
       <span class="tag good">rendered as GitHub renders it</span>
     </div>
     <p class="st-why">
-      Toggle to compare. Hebrew cells stay wrapped in
-      <span class="mono">&lt;strong dir="rtl"&gt;</span>, the bidi isolation pattern established in
-      #3153, so the pipes of the markdown table never reorder around the Hebrew run.
+      Toggle to compare. Names and audience lines are copied from what
+      <span class="mono">yonyon.ai/en</span> actually renders, so the README cannot drift from the
+      site. No Hebrew reaches this table, which retires the
+      <span class="mono">&lt;strong dir="rtl"&gt;</span> bidi-isolation workaround from #3153 rather
+      than perpetuating it.
     </p>
+
+    <div class="note" style="background:hsl(248 84% 68% / .09);border-color:hsl(248 84% 68% / .30);color:hsl(248 40% 86%)">
+      <b>Three naming layers, easy to confuse.</b> A room has a group-internal WhatsApp name
+      (<span class="mono">og:title</span>, often Hebrew plus emoji), an English display name, and a
+      Hebrew display name. The first draft of this fix put the <i>group-internal</i> names into an
+      English README, which is the wrong layer. An English surface uses the English display name;
+      the Hebrew variant belongs to <span class="mono">yonyon.ai/he</span> only.
+    </div>
+
+    <table style="margin-block-start:14px">
+      <thead><tr><th>Layer</th><th>Builders</th><th>AI for Business</th></tr></thead>
+      <tbody>
+        <tr><td>WhatsApp <span class="mono">og:title</span></td>
+            <td>🛠️ <span dir="rtl">בילדרים</span></td>
+            <td><span dir="rtl">AI לעסקים</span> 📈</td></tr>
+        <tr><td><span class="mono">yonyon.ai/en</span> (this README)</td>
+            <td><b>Builders</b></td><td><b>AI for Business</b></td></tr>
+        <tr><td><span class="mono">yonyon.ai/he</span></td>
+            <td><span dir="rtl">בילדרים</span></td><td><span dir="rtl">AI לעסקים</span></td></tr>
+      </tbody>
+    </table>
 
     <div class="seg" role="group" aria-label="Table version">
       <button type="button" data-v="before" aria-pressed="false">Before</button>
@@ -294,18 +317,12 @@ const ROWS = {
   after: {
     head: ['Group', "Who it's for", 'Link'],
     body: [
-      ['<b>Building with AI</b> · <strong dir="rtl">בונים עם AI</strong>',
+      ['<b>Building with AI</b>',
        'The umbrella community. One join, every room below.', 'Join · /go/community'],
-      ['<b>OrchestKit</b>',
-       'Setups, hooks, agents, and real problems from the field.', 'Join · /go/orchestkit'],
-      ['<b>The Orchestra</b>',
-       'English room for AI dev talk: agents, MCP, Claude Code.', 'Join · raw invite'],
-      ['<b>Builders</b> · <strong dir="rtl">בילדרים</strong>',
-       'Hebrew room for people already shipping AI: RAG, agents, MCP in production.',
-       'Join · /go/builders'],
-      ['<b>AI for Business</b> · <strong dir="rtl">AI לעסקים</strong>',
-       'Hebrew room for founders and team leads adopting AI. Decisions and ROI, no code.',
-       'Join · /go/business'],
+      ['<b>Builders</b>', 'For people already building', 'Join · /go/builders'],
+      ['<b>OrchestKit</b>', 'For OrchestKit users', 'Join · /go/orchestkit'],
+      ['<b>The Orchestra</b>', 'For anyone building with AI agents', 'Join · raw invite'],
+      ['<b>AI for Business</b>', 'For people leading AI adoption', 'Join · /go/business'],
     ],
   },
 };


### PR DESCRIPTION
## Summary

The README's auto-generated blocks are healthy. What's New stamps to v9.1.1 and `check-docs-facts` passes at 114 skills / 36 agents / 219 hooks. Nothing regenerates or gates the hand-written prose around them, and three defects had been sitting there for months.

```
                        CLAIMED IN README        ACTUALLY TRUE
  community table  ->   3 of 4 rows named    ->  wrong names, 1 room missing
  Release Channels ->   --ref beta / alpha   ->  no such ref has ever existed
  Configuration    ->   /ork:configure       ->  command is not generated
```

Every claim below was checked against a live surface, not inferred.

## 1. Community table rebuilt

Each invite was resolved against its live `chat.whatsapp.com` page and compared to the group's real `og:title`.

| README said | Room actually is | |
|---|---|---|
| Community (all channels) | Building with AI | ✅ renamed |
| AI Dev (EN) | The Orchestra | ❌ wrong name |
| <strong dir="rtl">יש לך AI?</strong> | Builders | ❌ wrong name |
| OrchestKit Users | OrchestKit | ✅ correct |
| not listed | AI for Business | ❌ was missing |

"Code with Yonatan" is superseded branding; the umbrella community settled on "Building with AI" on 2026-07-17, and this README was the last file still using the old name.

**A room has three names, and only one belongs here.** The first pass took names from each invite's `og:title`, which is the group-internal name and is often Hebrew plus emoji. That is the wrong layer for an English README:

```
                              Builders             AI for Business
  WhatsApp og:title           bildarim + emoji     AI la-asakim + emoji
  yonyon.ai/en   <- THIS      Builders             AI for Business
  yonyon.ai/he                bildarim             AI la-asakim
```

Verified by fetching both locales live: `/en` renders Builders / OrchestKit / AI for Business under a "Building with AI" heading, `/he` renders the Hebrew variants. The table now copies the `/en` display names and the site's own audience lines verbatim, so the two surfaces cannot drift.

Side effect worth naming: no Hebrew reaches the table, so the `dir="rtl"` cell isolation added in #3153 is not needed here. The bidi hazard is gone rather than contained.

Links route through `yonyon.ai/go/*` so a rotated invite no longer needs a README edit. All four slugs verified returning 302 to the correct current invite. No raw invite is published in this README at all now, which matches the portfolio policy that already has an e2e test behind it (`expect(await page.content()).not.toContain("chat.whatsapp.com")`).

### The Orchestra is deliberately not in the table

An earlier commit here added it, reasoning that a live group missing from the registries was an oversight. That was wrong, and the seed file says so:

> Naming strategy (settled 2026-07-17 after three rounds): clarity first. Every name tells a stranger what the room is and who it's for in one second; **no metaphor system to decode.**

| Name | What a stranger learns in one second | |
|---|---|---|
| Builders | who it is for | ✅ |
| OrchestKit | the product it is about | ✅ |
| AI for Business | who it is for | ✅ |
| The Orchestra | nothing, it is a pun on orchestration | ❌ |

A 2026-06-21 platform audit praised the name during the metaphor era; the July round replaced metaphor names with literal ones and did not carry it over. It is absent from the portfolio seeds **and** from platform's `COMMUNITY_ROOMS` independently. Two omissions after a three-round naming exercise is a decision, not a gap.

Worth noting against my own first draft: the README's original label for that invite, "AI Dev (EN)", *passes* the doctrine. That row was never the stale one. The group stays live and unadvertised, exactly as before this PR.

## 2. Release Channels removed

`git ls-remote --heads --tags origin` returns no `beta` and no `alpha` ref, so `/plugin marketplace add ... --ref beta` could never have worked. The docs page the section linked to was deleted in b23da597e (2026-07-19, "remove agentation and the never-published release channels") but the README section survived, still pointing at a 404. Removing it completes a decision already made and committed.

## 3. /ork:configure removed

`src/skills/configure/SKILL.md` is `user-invocable: false` and `disable-model-invocation: true`, so no command is generated and the model cannot reach it either. Replaced with `/ork:setup`, which is real and does the MCP configuration.

Also promoted Sequential Thinking from Optional to Recommended, matching `src/skills/setup/SKILL.md:161` which calls it part of the universally-needed T2 trio, and added `/ork:auto` to Key Commands.

## Verification

```
✅ scripts/stamp-whats-new.mjs --check    up to date (top 8 of 290)
✅ scripts/check-docs-facts.mjs           114 skills, 36 agents, 219 hooks
✅ bin/validate-counts.sh                 counts and versions match
✅ every README URL                       28 links, all 2xx/3xx
✅ no em-dash in added lines
```

The one non-2xx is `claude.ai/claude-code`, which returns 403 to curl by bot protection and renders fine in a browser. It is pre-existing and untouched.

## 💡 Root cause worth its own issue

There is no link checker in CI, and `check-docs-facts.mjs` validates only counts and the Claude Code floor. It never reads a URL or a command name. That is why a 404 link, a dead install path, and a non-existent command all survived for months. A `lychee` step scoped to `README.md` would have caught three of these four defects.

## Interactive Playground

**[Open the playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/685d106bd8b51a16dbf06451635de06aac1cdb1a/docs/fix--readme-community-table/plan-viz.html)**

Shows the resolved `og:title` evidence per invite, the three-naming-layer table, a before/after toggle of the rendered README table, the cross-surface matrix of which repo declares which room, and the verification run behind each removed section.
