### PR TITLE
ci(demos): report Validate Renderer to the merge queue

### DIFF
--- a/.github/workflows/demos-validate.yml
+++ b/.github/workflows/demos-validate.yml
@@ -31,6 +31,11 @@ name: Validate Demos Renderer
 
 on:
   pull_request:
+  # Required checks must also report for a queued entry. Without this the
+  # merge queue never sees "Validate Renderer", the entry can never satisfy
+  # branch protection, and the queue stalls indefinitely (#3189). This is a
+  # no-op until a queue exists, since nothing else emits merge_group events.
+  merge_group:
   workflow_dispatch:
 
 permissions: {}
@@ -63,13 +68,24 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
+          EVENT: ${{ github.event_name }}
+          MG_BASE: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD: ${{ github.event.merge_group.head_sha }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$EVENT" = "workflow_dispatch" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          files=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename')
+          # A merge_group entry has no pull_request.number, so the pulls/…/files
+          # call below would build "repos/OWNER/REPO/pulls//files" and fail the
+          # step under `set -e` — turning a stalled queue into a red one. Diff
+          # the queued range instead; `compare` needs no deep checkout.
+          if [ "$EVENT" = "merge_group" ]; then
+            files=$(gh api "repos/${REPO}/compare/${MG_BASE}...${MG_HEAD}" --jq '.files[].filename')
+          else
+            files=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename')
+          fi
           # Here-string, not `printf | grep -q`: under pipefail, grep -q's
           # early-exit SIGPIPEs the producer (exit 141) and flips the result
           # non-deterministically. A here-string has no producer process.


### PR DESCRIPTION
## What and why

Prerequisite for #3189. Mapping all 18 required contexts to their producing
workflows found exactly one that could not report to a merge queue:

```
 required contexts                     18
   ready (workflow has merge_group)    17
   GAP  (workflow lacks it)             1   <- Validate Renderer
```

`demos-validate.yml` declares only `pull_request` and `workflow_dispatch`. A
required check whose workflow lacks `merge_group` **never runs for a queued
entry**, so the entry can never satisfy branch protection and the queue stalls
indefinitely.

## ⚠️ Adding the trigger alone would have been worse than the stall

On a `merge_group` event there is no `github.event.pull_request.number`, so the
existing change-detection step would have built

```
 repos/OWNER/REPO/pulls//files
```

and failed under `set -euo pipefail` — converting a queue that *hangs* into a
queue whose required check is *red*. Same blast radius, harder to diagnose.

The step now diffs the queued range via the compare API, which needs no deep
checkout:

```bash
if [ "$EVENT" = "merge_group" ]; then
  files=$(gh api "repos/${REPO}/compare/${MG_BASE}...${MG_HEAD}" --jq '.files[].filename')
else
  files=$(gh api "repos/${REPO}/pulls/${PR}/files" --paginate --jq '.[].filename')
fi
```

The cheap change-detection gate is preserved: a queued entry that does not touch
`orchestkit-demos` still reports success without paying the ~15-minute render.

## 🎯 Safe to land independently

This is a **no-op until a merge queue exists**, since nothing else emits
`merge_group` events. It does not enable anything, change branch protection, or
alter CI spend today. It turns #3189 from "needs investigation" into a straight
yes or no.

## ✅ Verification

```
 YAML parses · triggers        pull_request, merge_group, workflow_dispatch
 actionlint (pre-commit)       OK
 empty-PR URL unreachable      the pulls/ call is inside the else branch
 concurrency group             falls back to github.ref when no PR number
```

No playground: this PR touches only `.github/`, which is inert under #3196 — so
the gate should skip it. That is also a live check of that fix.
