### PR TITLE
chore(ci): bump internal CI Node pins from EOL Node 20 to 22

### DIFF
--- a/.github/workflows/cc-support-window-bump.yml
+++ b/.github/workflows/cc-support-window-bump.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Compute new floor from matrix
         id: compute

--- a/.github/workflows/claude-release-watch.yml
+++ b/.github/workflows/claude-release-watch.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       # Install the Claude Code CLI used by cc-triage.mjs (`claude -p --bare`).
       # Pinned to MIN_CC_VERSION from src/hooks/src/lib/cc-version-matrix.ts so

--- a/.github/workflows/contract-parity.yml
+++ b/.github/workflows/contract-parity.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Setup Python

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -87,7 +87,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
           cache-dependency-path: |
             package-lock.json

--- a/.github/workflows/eval-index-effectiveness.yml
+++ b/.github/workflows/eval-index-effectiveness.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install eval dependencies
         run: |
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install eval dependencies
         run: |

--- a/.github/workflows/eval-routing.yml
+++ b/.github/workflows/eval-routing.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Run routing-accuracy ratchet
         run: node scripts/eval/route-check.mjs --check

--- a/.github/workflows/hook-contract.yml
+++ b/.github/workflows/hook-contract.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
 
       - name: Install workspace deps

--- a/.github/workflows/import-symbol-watch.yml
+++ b/.github/workflows/import-symbol-watch.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Scan skill imports
         id: scan

--- a/.github/workflows/labs-version-watch.yml
+++ b/.github/workflows/labs-version-watch.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Detect drift
         id: detect

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Setup Node.js for SBOM generation
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6  # zizmor: ignore[cache-poisoning] deps via npm ci, no cache restored
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install production dependencies
         run: npm ci --ignore-scripts --production

--- a/.github/workflows/skill-autobuild.yml
+++ b/.github/workflows/skill-autobuild.yml
@@ -97,7 +97,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v6
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Node 20 has reached end-of-life. This bumps `node-version` from `'20'` to `'22'` in 12 internal CI/tooling workflows. None of these build or publish an npm artifact — the root `orchestkit` package is not published to npm (registry 404s; no main/exports/files/bin/publishConfig), so its `engines` field is advisory for contributors, not a consumer contract.

## What changed vs what was deliberately excluded

| File | Change |
|---|---|
| `eval-routing.yml` | 20 -> 22 |
| `labs-version-watch.yml` | 20 -> 22 |
| `claude-release-watch.yml` | 20 -> 22 |
| `eval-index-effectiveness.yml` | 20 -> 22 (3 occurrences) |
| `cc-support-window-bump.yml` | 20 -> 22 |
| `import-symbol-watch.yml` | 20 -> 22 |
| `contract-parity.yml` | 20 -> 22 |
| `hook-contract.yml` | 20 -> 22 |
| `windows-smoke.yml` | 20 -> 22 |
| `skill-autobuild.yml` | 20 -> 22 |
| `docs.yml` | 20 -> 22 (2 occurrences) |
| `release.yml` | 20 -> 22 (SBOM generation step only) |

**Excluded on purpose:**

| File | Why left alone |
|---|---|
| `publish-hook-contract-npm.yml` | All 5 `setup-node` pins stay at 20. This workflow publishes `@orchestkit/hook-contract` to npm (a real, published consumer contract with `engines >=20.0.0`), and it pins `npm@^11.5.1` deliberately because npm 12 requires a newer Node -- the two pins are coupled by design per an inline incident comment. Changing either alone breaks publishing. |
| `ci.yml` unit-tests matrix `['20', '22']` | Deliberate cross-version compatibility matrix with an explanatory comment. |
| `reusable-test-runner.yml` matrix | Same -- deliberate Node 20/22 compatibility coverage. |
| Any `package.json` `engines` field | Not touched, root or otherwise. `src/hooks/package.json` and `plugins/ork/hooks/package.json` already correctly declare `>=22.5.0` (node:sqlite requirement). |

## Test plan

- [x] `grep -rn "node-version: *['\"]\?20" .github/workflows/` -- remaining hits are only in `publish-hook-contract-npm.yml` (5 pins, by design) and the two deliberate compatibility matrices (which don't match this literal grep pattern since they use `matrix.node-version` / array syntax)
- [x] `git diff --stat` -- exactly the 12 intended files, 15 insertions / 15 deletions
- [x] `git diff` shows zero `package.json` changes
- [x] All 45 workflow YAML files parse successfully via `yaml.safe_load`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
