### PR TITLE
fix(runner): honour the interpreter and reclaim 56 orphaned tests

### DIFF
--- a/docs/fix--wire-orphaned-tests/index.html
+++ b/docs/fix--wire-orphaned-tests/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Three failures, three causes</title><style>
+:root{--bg:hsl(232 26% 7%);--ink:hsl(220 18% 93%);--muted:hsl(220 14% 64%);--faint:hsl(220 12% 46%);
+--glass:hsl(0 0% 100% / .05);--edge:hsl(0 0% 100% / .18);--accent:hsl(248 84% 68%);--ok:hsl(162 62% 52%);--bad:hsl(354 78% 62%)}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(54rem 36rem at 88% -6%,hsl(248 70% 26% / .38),transparent 62%),var(--bg);
+background-attachment:fixed;color:var(--ink);font:15px/1.65 -apple-system,system-ui,sans-serif}
+.wrap{max-width:900px;margin-inline:auto;padding:48px 24px 80px}
+.eyebrow{display:inline-block;font-size:11.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;
+color:var(--faint);border:1px solid var(--edge);border-radius:999px;background:var(--glass);padding:6px 12px}
+h1{font-size:clamp(24px,3.6vw,34px);font-weight:700;margin:14px 0 10px}h1 span{color:var(--accent)}
+.lede{color:var(--muted);max-width:64ch;margin:0 0 28px}.lede b{color:var(--ink)}
+h2{font-size:17px;margin:28px 0 8px}
+.card{border:1px solid var(--edge);border-radius:14px;background:var(--glass);padding:16px 18px;margin-top:12px}
+.card h3{margin:0 0 6px;font-size:14.5px}.card p{margin:0 0 8px;font-size:13.5px;color:var(--muted)}
+code{font-family:ui-monospace,Menlo,monospace;font-size:12px;background:hsl(0 0% 100% / .07);padding:1px 5px;border-radius:5px}
+pre{background:hsl(232 30% 4% / .6);border:1px solid var(--edge);border-radius:12px;padding:12px;overflow-x:auto;font-size:12px;color:var(--muted)}
+.ok{color:var(--ok)}.bad{color:var(--bad)}
+table{width:100%;border-collapse:collapse;font-size:13px;border:1px solid var(--edge);border-radius:12px;overflow:hidden;background:var(--glass)}
+th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);padding:9px 11px;border-bottom:1px solid var(--edge)}
+td{padding:9px 11px;border-bottom:1px solid hsl(0 0% 100% / .06)}tr:last-child td{border-bottom:none}
+.foot{margin-top:32px;font-size:12px;color:var(--faint);line-height:1.9}
+</style></head><body><div class="wrap">
+<div class="eyebrow">verifying ca1b49aed &middot; 2026-07-31</div>
+<h1>Three failures. <span>Three different causes.</span></h1>
+<p class="lede">ca1b49aed wired 56 reclaimed tests and shipped with a warning: suite behaviour
+unverified, do not open a PR. Verifying it turned up three failures that looked like one problem
+and were not. <b>The reported contradiction was a misread line.</b></p>
+
+<h2>The "mystery"</h2>
+<pre>claimed:  exit=1 but "Failed: 0" in both summaries
+actual:   Total: 99 passed, 2 failed   <- the outer, authoritative tally
+          the "Failed: 0" lines were SUB-RUNNER summaries</pre>
+
+<h2>Cause 1 and 2 &mdash; the runner could not execute them</h2>
+<div class="card"><h3>run_test hardcoded bash</h3>
+<p>Wiring the reclaimed tests introduced <code>.mjs</code> suites for the first time.</p>
+<pre>bash test-import-symbols.mjs  -> syntax error near unexpected token   exit 2
+node test-import-symbols.mjs  -> 28 assertions passed                 exit 0</pre>
+<p>Both files carry <code>#!/usr/bin/env node</code>. run_test now selects the interpreter by
+extension. These tests were <b>orphaned</b>, so nothing had ever caught that the runner could not
+run them.</p></div>
+
+<h2>Cause 3 &mdash; a same-day merge tripped a sanity floor</h2>
+<div class="card"><h3>The gate refused to accuse</h3>
+<pre>ABORT: reference parser looks broken, refusing to accuse anything.
+  agents declaring 'skills:' : 36 (floor 30)   OK
+  distinct wired skill names : 52 (floor 60)   BELOW</pre>
+<p>Not a broken parser. #3221 removed 94 <b>dead</b> preload declarations hours earlier, so the
+count legitimately fell. The gate's own text anticipated it: <i>"or the floors, if the repo
+genuinely shrank."</i></p>
+<table><thead><tr><th>ref</th><th>verdict</th></tr></thead><tbody>
+<tr><td><code>8e6213b4f~1</code> (pre-#3221)</td><td class="ok">exit 0, every skill reachable</td></tr>
+<tr><td>after #3221</td><td class="bad">ABORT on the name floor alone</td></tr>
+</tbody></table>
+<p style="margin-top:10px">Floor 60 &rarr; 45. Then it ran and found 29 unreachable, which is
+exactly what the ratchet in <code>test-skill-reachability.mjs</code> already accepts. Two gates read
+one signal: the ratchet enforces, this one detects. It now runs advisory.</p></div>
+
+<h2>Every fix has a control</h2>
+<pre>floor 45   -> gate runs, 29 found        floor 999  -> still ABORTs   (guard intact)
+advisory=1 -> exit 0                     advisory=0 -> exit 1         (detector intact)</pre>
+
+<h2>Result</h2>
+<pre>EXIT=0   101 passed, 0 failed   522s</pre>
+<p class="foot">Runtime honesty: 522s, not the ~146s estimated when these were wired. That estimate
+excluded the pressure runner and assumed the rest kept their standalone timings, which suite context
+does not preserve. Worth re-scoping the default path before adding more.</p>
+</div></body></html>

--- a/tests/orphans/test-unreachable-skills.sh
+++ b/tests/orphans/test-unreachable-skills.sh
@@ -125,10 +125,19 @@ wired_count="$(grep -c . < "$TMP/wired.txt" | tr -d ' ')"
 # ---- PARSER SELF-CHECK -----------------------------------------------------
 # Every accusation this gate makes is an argument from absence, so a parser
 # that reads nothing would accuse everything. Floors are set far below the
-# real values (36 agents / 96 names as of 2026-07-27) so ordinary churn never
-# trips them, but a broken regex or a moved directory does.
+# real values so ordinary churn never trips them, but a broken regex or a
+# moved directory does.
+#
+# 2026-07-27: 36 agents / 96 names, floors 30 / 60.
+# 2026-07-31: #3221 removed 94 DEAD skill preload declarations from src/agents,
+#   which legitimately cut distinct wired names 96 -> 52 and tripped the 60
+#   floor. Verified both directions: at 8e6213b4f~1 this gate exits 0 with
+#   "Every skill is reachable"; at #3221 it ABORTs on the name floor alone
+#   (agent count held at 36). The repo genuinely shrank, so the floor comes
+#   down. 45 still catches the failure this guard exists for, a parser
+#   returning near-zero, while leaving room for further dead-edge cleanup.
 MIN_AGENTS_DECLARING=30
-MIN_WIRED_NAMES=60
+MIN_WIRED_NAMES=45
 if [[ "$agents_declaring" -lt "$MIN_AGENTS_DECLARING" || "$wired_count" -lt "$MIN_WIRED_NAMES" ]]; then
     echo -e "${RED}${BOLD}ABORT: reference parser looks broken, refusing to accuse anything.${NC}"
     echo "  agents declaring 'skills:'  : $agents_declaring (floor $MIN_AGENTS_DECLARING)"

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -116,11 +116,23 @@ run_test() {
         return 0
     fi
 
+    # Pick the interpreter from the file, do not assume bash. Wiring the
+    # reclaimed tests added .mjs suites here for the first time, and `bash`
+    # on a Node file is a shell syntax error (exit 2), so test-import-symbols
+    # and test-registry-resolve reported FAIL in the suite while passing
+    # standalone. That is the exact "suite context differs" trap, and it looked
+    # like a flaky test rather than a runner bug.
+    local runner=bash
+    case "$script" in
+        *.mjs|*.js) runner=node ;;
+        *.py)       runner=python3 ;;
+    esac
+
     local exit_code=0
     if [[ -n "$VERBOSE" ]]; then
-        bash "$script" $VERBOSE || exit_code=$?
+        "$runner" "$script" $VERBOSE || exit_code=$?
     else
-        bash "$script" 2>&1 || exit_code=$?
+        "$runner" "$script" 2>&1 || exit_code=$?
     fi
 
     echo ""
@@ -379,7 +391,17 @@ if [[ "$RUN_SKILLS" == "true" ]]; then
         run_test "Agent Definitions" "$SCRIPT_DIR/subagents/definition/test-agent-definitions.sh" || true
         # Reachability gate: a skill with no slash command AND model invocation
         # disabled AND no skills: frontmatter wiring cannot be invoked by anyone.
-        run_test "Unreachable Skills" "$SCRIPT_DIR/orphans/test-unreachable-skills.sh" || true  # silent: best-effort (run_test records failures; suite exits non-zero at end)
+        #
+        # ADVISORY here on purpose. Two gates read the same signal and they are
+        # not redundant: tests/skills/structure/test-skill-reachability.mjs is
+        # the RATCHET (UNREACHABLE_BASELINE=29, fails only on an increase), and
+        # this script is the DETECTOR, which has no baseline and exits 1 on any
+        # unreachable skill at all. Running the detector as a hard gate would
+        # fail the suite on the 29 the ratchet has already accepted, i.e. it
+        # would report a regression that did not happen. Enforcement stays with
+        # the ratchet; this reports the current list.
+        ORK_UNREACHABLE_SKILLS_ADVISORY=1 \
+          run_test "Unreachable Skills (advisory)" "$SCRIPT_DIR/orphans/test-unreachable-skills.sh" || true  # silent: best-effort (run_test records failures; suite exits non-zero at end)
         # Policy gate: a workflow that invokes an LLM must be manually
         # triggered. Max-plan OAuth is $0 in dollars but draws on the shared
         # weekly quota, so an automatic run competes with the operator's own

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -189,6 +189,30 @@ if [[ "$RUN_UNIT" == "true" ]]; then
     run_test "ASCII Density Scan (advisory)" "$SCRIPT_DIR/unit/test-ascii-density.sh" || true  # silent: known-noise
     run_test "ASCII i18n Alignment (CJK + Devanagari)" "$SCRIPT_DIR/unit/test-ascii-i18n.sh" || true  # silent: known-noise
 
+    # --- reclaimed by #3220: these existed but no runner referenced them,
+    #     so they had never executed. All verified passing before wiring.
+    run_test "Cc 216 Compliance" "$SCRIPT_DIR/compliance/test-cc-216-compliance.sh" || true
+    run_test "Config System" "$SCRIPT_DIR/config/test-config-system.sh" || true
+    run_test "Bundle No External Deps" "$SCRIPT_DIR/hooks/test-bundle-no-external-deps.sh" || true
+    run_test "Context Injection Budget" "$SCRIPT_DIR/hooks/test-context-injection-budget.sh" || true
+    run_test "Migrations Shipped" "$SCRIPT_DIR/hooks/test-migrations-shipped.sh" || true
+    run_test "Native Binary Compat" "$SCRIPT_DIR/hooks/test-native-binary-compat.sh" || true
+    run_test "Claude Md Injection" "$SCRIPT_DIR/indexes/test-claude-md-injection.sh" || true
+    run_test "Keyword Extraction" "$SCRIPT_DIR/indexes/test-keyword-extraction.sh" || true
+    run_test "Vercel Format" "$SCRIPT_DIR/indexes/test-vercel-format.sh" || true
+    run_test "Cc Version Ceiling" "$SCRIPT_DIR/manifests/test-cc-version-ceiling.sh" || true
+    run_test "Hook Exec Form" "$SCRIPT_DIR/manifests/test-hook-exec-form.sh" || true
+    run_test "Build Drift" "$SCRIPT_DIR/plugins/test-build-drift.sh" || true
+    run_test "Marketplace Structure" "$SCRIPT_DIR/plugins/test-marketplace-structure.sh" || true
+    run_test "Async Hooks" "$SCRIPT_DIR/unit/test-async-hooks.sh" || true
+    run_test "Cdn Video Pipeline" "$SCRIPT_DIR/unit/test-cdn-video-pipeline.sh" || true
+    run_test "Hook Stdin Consumption" "$SCRIPT_DIR/unit/test-hook-stdin-consumption.sh" || true
+    run_test "Import Symbols" "$SCRIPT_DIR/unit/test-import-symbols.mjs" || true
+    run_test "Parse Frontmatter" "$SCRIPT_DIR/unit/test-parse-frontmatter.sh" || true
+    run_test "Registry Resolve" "$SCRIPT_DIR/unit/test-registry-resolve.mjs" || true
+    run_test "Whats New" "$SCRIPT_DIR/unit/test-whats-new.sh" || true
+    run_test "Worktree Discovery" "$SCRIPT_DIR/worktree/test-worktree-discovery.sh" || true
+
     # TypeScript hook tests (vitest)
     if [[ -n "${CI:-}" ]]; then
         echo -e "  ${CYAN}Vitest runs in dedicated CI job (hook-typescript-tests) — skipping here${NC}"
@@ -246,6 +270,10 @@ if [[ "$RUN_SECURITY" == "true" ]]; then
     run_test "Symlink Attack Tests" "$SCRIPT_DIR/security/test-symlink-attacks.sh" || true
     run_test "Input Validation Tests" "$SCRIPT_DIR/security/test-input-validation.sh" || true
     run_test "Additional Security Tests" "$SCRIPT_DIR/security/test-additional-security.sh" || true
+
+    # --- reclaimed by #3220: these existed but no runner referenced them,
+    #     so they had never executed. All verified passing before wiring.
+    run_test "Npm Audit Coverage" "$SCRIPT_DIR/security/test-npm-audit-coverage.sh" || true
     # Mem0 removed — security tests deleted
 fi
 
@@ -294,6 +322,16 @@ if [[ "$RUN_INTEGRATION" == "true" ]]; then
 
     # Feedback System Tests (v4.12.0)
     run_test "Feedback System Tests" "$SCRIPT_DIR/feedback/test-feedback-system.sh" || true
+
+    # --- reclaimed by #3220: these existed but no runner referenced them,
+    #     so they had never executed. All verified passing before wiring.
+    run_test "Output Guard Dispatcher" "$SCRIPT_DIR/integration/hooks/test-output-guard-dispatcher.sh" || true
+    run_test "Cc Backfill Changelog Ref" "$SCRIPT_DIR/integration/test-cc-backfill-changelog-ref.sh" || true
+    run_test "Cc Stale Belowfloor" "$SCRIPT_DIR/integration/test-cc-stale-belowfloor.sh" || true
+    run_test "Context Deferral" "$SCRIPT_DIR/integration/test-context-deferral.sh" || true
+    run_test "Full Mcp Integration" "$SCRIPT_DIR/integration/test-full-mcp-integration.sh" || true
+    run_test "Image Paste Pipeline" "$SCRIPT_DIR/integration/test-image-paste-pipeline.sh" || true
+    run_test "Multi Instance Gates" "$SCRIPT_DIR/integration/test-multi-instance-gates.sh" || true
 fi
 
 # ============================================================
@@ -311,6 +349,10 @@ if [[ "$RUN_E2E" == "true" ]]; then
 
     # Agent Lifecycle E2E Tests (v4.12.0)
     run_test "Agent Lifecycle E2E (New)" "$SCRIPT_DIR/agents/test-agent-lifecycle-e2e.sh" || true
+
+    # --- reclaimed by #3220: these existed but no runner referenced them,
+    #     so they had never executed. All verified passing before wiring.
+    run_test "Progressive Loading" "$SCRIPT_DIR/e2e/test-progressive-loading.sh" || true
 fi
 
 # ============================================================
@@ -370,6 +412,35 @@ if [[ "$RUN_SKILLS" == "true" ]]; then
     # Plugin structure compliance tests (hooks location)
     run_test "Plugin Structure Compliance" "$SCRIPT_DIR/plugins/structure/test-plugin-structure-compliance.sh" || true
     run_test "Hooks Location" "$SCRIPT_DIR/plugins/structure/test-hooks-location.sh" || true
+
+    # --- reclaimed by #3220: these existed but no runner referenced them,
+    #     so they had never executed. All verified passing before wiring.
+    run_test "Agent Context Modes" "$SCRIPT_DIR/agents/test-agent-context-modes.sh" || true
+    run_test "Agent Model Selection" "$SCRIPT_DIR/agents/test-agent-model-selection.sh" || true
+    run_test "Agent Multi Agent Tools" "$SCRIPT_DIR/agents/test-agent-multi-agent-tools.sh" || true
+    run_test "Agent Required Hooks" "$SCRIPT_DIR/agents/test-agent-required-hooks.sh" || true
+    run_test "Agent Skill Validation" "$SCRIPT_DIR/agents/test-agent-skill-validation.sh" || true
+    run_test "Ai Ml Agents" "$SCRIPT_DIR/agents/test-ai-ml-agents.sh" || true
+    run_test "All Agent Skill Refs" "$SCRIPT_DIR/agents/test-all-agent-skill-refs.sh" || true
+    run_test "Auto Mode In Description" "$SCRIPT_DIR/agents/test-auto-mode-in-description.sh" || true
+    run_test "Hook Paths" "$SCRIPT_DIR/agents/test-hook-paths.sh" || true
+    run_test "Script Activation" "$SCRIPT_DIR/skills/scripts/integration/test-script-activation.sh" || true
+    run_test "Script Execution" "$SCRIPT_DIR/skills/scripts/integration/test-script-execution.sh" || true
+    run_test "Command Execution" "$SCRIPT_DIR/skills/scripts/test-command-execution.sh" || true
+    run_test "Script Content" "$SCRIPT_DIR/skills/scripts/test-script-content.sh" || true
+    run_test "Script Structure" "$SCRIPT_DIR/skills/scripts/test-script-structure.sh" || true
+    run_test "Assets Directory" "$SCRIPT_DIR/skills/structure/test-assets-directory.sh" || true
+    run_test "Provenance Sediment" "$SCRIPT_DIR/skills/structure/test-provenance-sediment.sh" || true
+    run_test "Quality Bar" "$SCRIPT_DIR/skills/structure/test-quality-bar.sh" || true
+    run_test "Scripts Directory" "$SCRIPT_DIR/skills/structure/test-scripts-directory.sh" || true
+    run_test "Skill Delta" "$SCRIPT_DIR/skills/structure/test-skill-delta.sh" || true
+    run_test "Cross Skill Refs" "$SCRIPT_DIR/skills/test-cross-skill-refs.sh" || true
+    run_test "Dashboard Specs" "$SCRIPT_DIR/skills/test-dashboard-specs.sh" || true
+    run_test "Frontend Skills" "$SCRIPT_DIR/skills/test-frontend-skills.sh" || true
+    run_test "Remember Memory Integration" "$SCRIPT_DIR/skills/test-remember-memory-integration.sh" || true
+    run_test "Shared Scripts Drift" "$SCRIPT_DIR/skills/test-shared-scripts-drift.sh" || true
+    run_test "Skill Context Modes" "$SCRIPT_DIR/skills/test-skill-context-modes.sh" || true
+    run_test "Storybook Catalog Import" "$SCRIPT_DIR/skills/test-storybook-catalog-import.sh" || true
 fi
 # ============================================================
 

--- a/tests/skills/structure/test-test-discovery.mjs
+++ b/tests/skills/structure/test-test-discovery.mjs
@@ -67,7 +67,7 @@ import { fileURLToPath } from 'node:url';
 const REPO = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 
 // Lower this as tests are wired into a runner. Never raise it.
-const ORPHAN_BASELINE = 57;
+const ORPHAN_BASELINE = 1;
 
 const TEST_EXT = new Set(['sh', 'mjs', 'js']);
 const isCandidate = (name) =>


### PR DESCRIPTION
## Summary

Reclaims 56 orphaned tests into `run-all-tests.sh` and fixes the three failures that verification exposed. The wiring commit shipped with an explicit warning that suite-context behaviour was unverified and no PR should be opened from it; this is that verification.

## The reported contradiction was a misread

The handoff recorded *"exit=1 with `Failed: 0` in both summaries."* The authoritative outer tally read `99 passed, 2 failed` the whole time. The `Failed: 0` lines came from **sub-runner** summaries.

## Three failures, three causes

**1 + 2. The runner could not execute them.** `run_test` hardcoded `bash "$script"`. Wiring the reclaimed tests introduced `.mjs` suites for the first time:

```
bash test-import-symbols.mjs  ->  syntax error near unexpected token   exit 2
node test-import-symbols.mjs  ->  28 assertions passed                 exit 0
```

Both carry `#!/usr/bin/env node`. `run_test` now picks the interpreter by extension. These tests were **orphaned**, so nothing had ever caught that the runner couldn't run them.

**3. A same-day merge tripped a sanity floor.** `test-unreachable-skills.sh` aborted with `wired names 52 (floor 60)`. Not a broken parser: #3221 removed 94 **dead** preload declarations hours earlier.

| ref | verdict |
|---|---|
| `8e6213b4f~1` (pre-#3221) | exit 0, "Every skill is reachable" |
| after #3221 | ABORT on the name floor alone |

Floor 60 → 45. Then the detector ran and found 29 unreachable — exactly the baseline the ratchet in `test-skill-reachability.mjs` already accepts (`UNREACHABLE_BASELINE=29`). Two gates read one signal: the **ratchet enforces**, the **detector reports**. Running the detector as a hard gate would fail the suite on 29 findings that are not a regression, so it now runs advisory.

## Every fix has a control

```
floor 45   -> gate runs, 29 found     floor 999  -> still ABORTs   (guard intact)
advisory=1 -> exit 0                  advisory=0 -> exit 1         (detector intact)
```

## Result

```
EXIT=0   101 passed, 0 failed   522s
```

**Runtime honesty:** 522s, not the ~146s estimated when these were wired. That estimate excluded only the pressure runner and assumed the rest kept their standalone timings, which suite context does not preserve. Worth re-scoping the default path before adding more.

## Interactive Playground

`docs/fix--wire-orphaned-tests/index.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
