### PR TITLE
ci: glob the five orphan test dirs into blocking coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,31 @@ jobs:
       - name: Run index tests
         run: bash scripts/ci/run-tests.sh tests/indexes --verbose
 
+      # The five dirs below had ZERO blocking coverage until 2026-08-02: they sat
+      # outside every run-tests.sh glob, so their gates could go red on main with
+      # nothing failing. tests/plugins/test-command-frontmatter-passthrough.sh did
+      # exactly that — it was red on main naming the dropped `background` key
+      # (#3243) and nobody saw it. tests/fixtures is deliberately NOT globbed:
+      # test-helpers.sh is a sourced helper library whose standalone exit 0 would
+      # read as fake coverage.
+      - name: Run plugin structure tests
+        run: bash scripts/ci/run-tests.sh tests/plugins --verbose
+
+      - name: Run orphan tests
+        env:
+          # unreachable-skills holds a 29-skill baseline tracked in #3215; advisory
+          # here so wiring the OTHER three orphan gates does not import that debt
+          # as a permanent red. Drop this env once #3215 lands.
+          ORK_UNREACHABLE_SKILLS_ADVISORY: '1'
+        run: bash scripts/ci/run-tests.sh tests/orphans --verbose
+
+      - name: Run build, ci, worktree, external tests
+        run: |
+          bash scripts/ci/run-tests.sh tests/build --verbose
+          bash scripts/ci/run-tests.sh tests/ci --verbose
+          bash scripts/ci/run-tests.sh tests/worktree --verbose
+          bash scripts/ci/run-tests.sh tests/external --verbose
+
   # ============================================================================
   # STAGE 7c: Static Analysis Pipeline (eval:static)
   # ============================================================================


### PR DESCRIPTION
## What

Five test directories sat outside every `run-tests.sh` glob in CI, so their 17 test files had **zero blocking coverage** — a gate there could go red on `main` with nothing failing. `tests/plugins/test-command-frontmatter-passthrough.sh` did exactly that: it was red on main naming the dropped `background` key for a full day before #3243 found it by hand.

## Wired (all verified green locally before wiring)

| dir | files | note |
|---|---|---|
| tests/plugins | 9 | includes the passthrough gate that caught #3243 |
| tests/orphans | 4 | `unreachable-skills` runs advisory via `ORK_UNREACHABLE_SKILLS_ADVISORY=1` (29-skill baseline, #3215) so wiring the other three does not import that debt as permanent red |
| tests/build | 1 | |
| tests/ci | 1 | |
| tests/worktree | 1 | |
| tests/external | 1 | |

Deliberately NOT globbed: `tests/fixtures` — `test-helpers.sh` is a sourced helper library whose standalone exit 0 would read as fake coverage.

Steps live in the Manifests & Schemas job, which already builds plugins fresh from source (required by `test-build-drift` and the passthrough gate). `actionlint` clean.

Part of the #3235 dispatch-split cleanup: this is the cheap first step (coverage), separable from the full one-engine refactor (which stays open in #3235).

Refs #3235