### PR TITLE
docs: fix nonexistent scripts/hooks path in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,7 @@ Out of scope:
 
 Hooks are the highest-privilege surface here: they run shell or Node/Python on
 your machine on agent events. If you are evaluating OrchestKit for a team, read
-`src/hooks/` and `scripts/hooks/README.md` first. Every hook is designed to
+`src/hooks/` and `src/hooks/README.md` first. Every hook is designed to
 **fail open** — an error must never block your work — and none should ever
 transmit repository contents off-machine. A hook that violates either property is
 a security bug under this policy; please report it.


### PR DESCRIPTION
SECURITY.md (line 71) points readers to `scripts/hooks/README.md`, but that file does not exist — there is no `scripts/hooks/` directory in the repo. The hooks README is at `src/hooks/README.md`, and the same sentence already references `src/hooks/`. This corrects the path from `scripts` to `src` so the reference resolves.