### PR TITLE
feat(codex): add native OrchestKit adapter

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "orchestkit-codex",
+  "interface": {
+    "displayName": "OrchestKit Codex"
+  },
+  "plugins": [
+    {
+      "name": "ork-codex",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/yonatangross/orchestkit.git",
+        "path": "./plugins/ork-codex",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - [Community](#community)
 
 
-## Quick Start
+## Quick Start (Claude Code)
 
 ```bash
 /plugin marketplace add yonatangross/orchestkit
@@ -200,6 +200,33 @@ Not on Claude Code? Pull the skills into any agent (Cursor, Codex, OpenCode, …
 ```bash
 npx skills add yonatangross/orchestkit
 ```
+
+### Codex
+
+Codex uses its own plugin format, skill picker, and standalone role
+configuration. Add OrchestKit's Codex marketplace, then install the small
+portable workflow pack:
+
+```bash
+codex plugin marketplace add yonatangross/orchestkit --ref main --sparse .agents/plugins --sparse plugins/ork-codex
+codex plugin add ork-codex@orchestkit-codex
+```
+
+Restart Codex after installation. Invoke a workflow explicitly with
+`$ork-brainstorm`, `$ork-explore`, `$ork-assess`, `$ork-verify`, or
+`$ork-review-pr`; their narrow descriptions also let Codex select the relevant
+workflow automatically.
+
+The plugin intentionally ships roles as templates because Codex loads custom
+roles from `~/.codex/agents/`, not from a plugin manifest. From an OrchestKit
+checkout, run this one-time, non-overwriting install:
+
+```bash
+plugins/ork-codex/scripts/install-codex-roles.sh ~/.codex/agents
+```
+
+It installs `ork_explorer`, `ork_implementer`, `ork_reviewer`, and
+`ork_verifier`; restart Codex before spawning them.
 
 ---
 

--- a/bin/sync-skills.sh
+++ b/bin/sync-skills.sh
@@ -27,6 +27,16 @@ log() {
 errors=0
 checked=0
 
+# Claude skills live in src/skills. Codex-native plugins keep their canonical
+# skills beside their host manifest so they do not masquerade as Claude skills.
+canonical_skill_exists() {
+    local plugin_name="$1"
+    local skill_name="$2"
+
+    [[ -d "$PROJECT_ROOT/src/skills/$skill_name" ]] || \
+        [[ -d "$PROJECT_ROOT/src/codex/$plugin_name/skills/$skill_name" ]]
+}
+
 # Validate: Each skill in plugins points to existing root skill
 log "Checking plugin skill symlinks..."
 
@@ -70,10 +80,10 @@ for plugin_dir in "$PROJECT_ROOT"/plugins/*/skills; do
                 errors=$((errors + 1))
             fi
         else
-            # It's a directory (CI might convert symlinks to directories)
-            # Just verify the corresponding root skill exists
-            if [[ ! -d "$PROJECT_ROOT/src/skills/$skill_name" ]]; then
-                echo "ERROR: Plugin skill $plugin_name/$skill_name has no corresponding root skill"
+            # It's a directory (CI might convert symlinks to directories).
+            # Verify it has a canonical source for this host.
+            if ! canonical_skill_exists "$plugin_name" "$skill_name"; then
+                echo "ERROR: Plugin skill $plugin_name/$skill_name has no corresponding canonical skill"
                 errors=$((errors + 1))
             fi
         fi

--- a/docs/feat--codex-native-orchestkit/adapter.html
+++ b/docs/feat--codex-native-orchestkit/adapter.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OrchestKit for Codex</title>
+  <style>
+    :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--text:#e6edf3;--muted:#8b949e;--blue:#58a6ff;--green:#3fb950;--amber:#d29922;--mono:ui-monospace,SFMono-Regular,Menlo,monospace}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:16px system-ui,sans-serif;padding:28px}main{max-width:850px;margin:auto}h1{margin:0 0 6px}.sub{color:var(--muted);line-height:1.5}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(155px,1fr));gap:10px;margin:24px 0}.card,section{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px}.card button{width:100%;background:none;border:0;color:var(--text);text-align:left;cursor:pointer;font:inherit}.card.active{border-color:var(--blue);box-shadow:0 0 0 1px var(--blue)}.tag{font:12px var(--mono);color:var(--blue)}.ok{color:var(--green)}.warn{color:var(--amber)}code,pre{font-family:var(--mono)}pre{white-space:pre-wrap;background:#010409;border:1px solid var(--line);border-radius:7px;padding:13px;line-height:1.5}li{margin:.45rem 0}footer{color:var(--muted);font-size:13px;margin-top:18px}
+  </style>
+</head>
+<body><main>
+  <h1>OrchestKit → Codex</h1>
+  <p class="sub">A host-native adapter: generic workflow skills in the Codex plugin, reusable role templates installed explicitly, and Yonatan HQ operations left to <code>hq-codex</code>.</p>
+  <div class="grid" id="modes">
+    <div class="card active" data-mode="brainstorm"><button><span class="tag">$ork-brainstorm</span><br>Frame choices</button></div>
+    <div class="card" data-mode="explore"><button><span class="tag">$ork-explore</span><br>Read-only map</button></div>
+    <div class="card" data-mode="verify"><button><span class="tag">$ork-verify</span><br>Evidence verdict</button></div>
+    <div class="card" data-mode="roles"><button><span class="tag">roles</span><br>Delegate deliberately</button></div>
+  </div>
+  <section><div class="tag" id="label">$ork-brainstorm</div><h2 id="title">Frame choices before implementation</h2><p id="body">Compare 2–4 viable paths, state trade-offs, then propose the smallest next action. This is generic reasoning, not HQ policy.</p><pre id="command">$ork-brainstorm “How should this service coordinate retries?”</pre><ul id="points"><li><span class="ok">✓</span> User-invoked and discoverable in Codex</li><li><span class="ok">✓</span> No Claude command or hook dependency</li><li><span class="warn">→</span> HQ knowledge and operations remain separate</li></ul></section>
+  <footer>Click a card to inspect the surface. After merge, install from the OrchestKit marketplace; roles use the bundled installer because Codex custom agents are standalone TOML files.</footer>
+</main><script>
+const data={brainstorm:['$ork-brainstorm','Frame choices before implementation','Compare 2–4 viable paths, state trade-offs, then propose the smallest next action.',' $ork-brainstorm “How should this service coordinate retries?”'],explore:['$ork-explore','Produce a read-only evidence map','Inspect only what is needed, report evidence and uncertainty, and fan out only independent questions.',' $ork-explore “Map authentication ownership and call sites.”'],verify:['$ork-verify','Return PASS, FAIL, or BLOCKED with evidence','Define the verification target first, run the relevant checks, then make an honest evidence-backed verdict.',' $ork-verify “Confirm the release artifact contains the Codex plugin.”'],roles:['roles','Use maker–checker roles deliberately','Install the four TOML roles, then delegate exploration, implementation, review, and verification as separate responsibilities.',' plugins/ork-codex/scripts/install-codex-roles.sh ~/.codex/agents']};
+for(const card of document.querySelectorAll('.card'))card.onclick=()=>{document.querySelector('.active').classList.remove('active');card.classList.add('active');const [label,title,body,command]=data[card.dataset.mode];document.querySelector('#label').textContent=label;document.querySelector('#title').textContent=title;document.querySelector('#body').textContent=body;document.querySelector('#command').textContent=command.trimStart()};
+</script></body></html>

--- a/manifests/codex/ork-codex.json
+++ b/manifests/codex/ork-codex.json
@@ -1,0 +1,20 @@
+{
+  "name": "ork-codex",
+  "host": "codex",
+  "version": "9.5.4",
+  "description": "Native OrchestKit skills and reusable agent roles for Codex.",
+  "source": "src/codex/ork-codex",
+  "skills": [
+    "ork-brainstorm",
+    "ork-explore",
+    "ork-assess",
+    "ork-verify",
+    "ork-review-pr"
+  ],
+  "roles": [
+    "ork_explorer",
+    "ork_implementer",
+    "ork_reviewer",
+    "ork_verifier"
+  ]
+}

--- a/plugins/ork-codex/.codex-plugin/plugin.json
+++ b/plugins/ork-codex/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "ork-codex",
+  "version": "9.5.4",
+  "description": "Portable OrchestKit workflows for Codex: brainstorm, explore, assess, verify, and review pull requests.",
+  "author": {
+    "name": "Yonatan Gross",
+    "url": "https://github.com/yonatangross"
+  },
+  "homepage": "https://github.com/yonatangross/orchestkit",
+  "repository": "https://github.com/yonatangross/orchestkit",
+  "license": "MIT",
+  "keywords": [
+    "orchestration",
+    "code-review",
+    "verification",
+    "planning"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "OrchestKit for Codex",
+    "shortDescription": "Evidence-first orchestration workflows for Codex.",
+    "longDescription": "A small, Codex-native OrchestKit pack for deliberate planning, codebase exploration, assessment, verification, and pull-request review. It uses Codex skills and subagents without Claude-only commands or hooks.",
+    "developerName": "Yonatan Gross",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": "Use $ork-brainstorm to compare approaches before I implement a change."
+  }
+}

--- a/plugins/ork-codex/roles/ork_explorer.toml
+++ b/plugins/ork-codex/roles/ork_explorer.toml
@@ -1,4 +1,4 @@
-name = "broken_explorer"
+name = "ork_explorer"
 description = "Read-only codebase explorer for evidence-backed architecture and execution-path discovery."
 model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"

--- a/plugins/ork-codex/roles/ork_explorer.toml
+++ b/plugins/ork-codex/roles/ork_explorer.toml
@@ -1,0 +1,10 @@
+name = "broken_explorer"
+description = "Read-only codebase explorer for evidence-backed architecture and execution-path discovery."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Stay in exploration mode. Map the actual execution path with targeted searches and file/symbol citations.
+Separate confirmed behavior from inference and name uncertainties. Do not propose edits unless the parent explicitly asks.
+Delegate only for at least three independent, bounded discovery questions; otherwise investigate directly.
+"""

--- a/plugins/ork-codex/roles/ork_implementer.toml
+++ b/plugins/ork-codex/roles/ork_implementer.toml
@@ -1,0 +1,10 @@
+name = "ork_implementer"
+description = "Scoped implementation agent that makes an approved change and proves the affected behavior."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Implement only the parent-approved scope. Read repository instructions first and use an isolated worktree whenever a shared primary checkout may be active.
+Keep changes small, add focused tests when behavior changes, and report exact verification output. Do not self-certify a high-impact change: request an independent verifier after implementation.
+Delegate only independent, bounded implementation units; retain integration responsibility.
+"""

--- a/plugins/ork-codex/roles/ork_reviewer.toml
+++ b/plugins/ork-codex/roles/ork_reviewer.toml
@@ -1,0 +1,9 @@
+name = "ork_reviewer"
+description = "Read-only reviewer focused on correctness, security, regressions, and missing evidence."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review as an owner. Inspect the real diff and its execution context, then prioritize correctness, security, data integrity, operational risk, and missing tests.
+Return only actionable findings with file/symbol evidence, impact, and reasoning. State checked scope and residual uncertainty when there are no findings. Never edit files or approve a pull request.
+"""

--- a/plugins/ork-codex/roles/ork_verifier.toml
+++ b/plugins/ork-codex/roles/ork_verifier.toml
@@ -1,0 +1,9 @@
+name = "ork_verifier"
+description = "Independent verifier that returns a binary readiness verdict with command-backed evidence."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Receive the original task and final artifacts, not an implementation narrative. Read project guidance, define the evidence contract, and run the smallest relevant checks first.
+Return PASS, FAIL, or BLOCKED with exact commands and summary lines. Treat skipped, unavailable, or unexecuted checks as gaps. Do not edit source or tests; report failures for the implementer to address.
+"""

--- a/plugins/ork-codex/scripts/install-codex-roles.sh
+++ b/plugins/ork-codex/scripts/install-codex-roles.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$SCRIPT_DIR/../roles"
+DESTINATION="${1:-}"
+
+if [[ -z "$DESTINATION" ]]; then
+  echo "usage: $0 <destination-directory>" >&2
+  exit 2
+fi
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "role templates not found: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$DESTINATION"
+
+for source in "$SOURCE_DIR"/*.toml; do
+  name="$(basename "$source")"
+  target="$DESTINATION/$name"
+  if [[ -e "$target" ]]; then
+    echo "refusing to overwrite existing role: $target" >&2
+    exit 1
+  fi
+  install -m 0644 "$source" "$target"
+done
+
+echo "Installed OrchestKit Codex roles in $DESTINATION"

--- a/plugins/ork-codex/skills/ork-assess/SKILL.md
+++ b/plugins/ork-codex/skills/ork-assess/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-assess
+description: Assess a code change, design, architecture, workflow, or competing options against explicit criteria and evidence. Use when a request asks to assess, rate, compare, identify trade-offs, evaluate readiness, or decide whether an approach is good enough. Do not use for a full pull-request review or to implement a chosen solution.
+---
+
+# Ork Assess
+
+State the decision, scope, and criteria before scoring. Choose criteria appropriate to the task—normally correctness, maintainability, security, operability, testability, cost, and reversibility—and omit criteria that have no bearing on the decision.
+
+Collect evidence from the code, repository guidance, tests, or authoritative documentation. Separate facts, assumptions, and unknowns. Do not invent numeric precision: use a score only when it makes the comparison clearer, and attach the evidence and confidence to it.
+
+For high-impact choices, ask an independent read-only `ork_reviewer` or built-in reviewer to challenge the leading conclusion. End with a recommendation, conditions for approval, and concrete follow-up actions. Do not edit the target.

--- a/plugins/ork-codex/skills/ork-assess/agents/openai.yaml
+++ b/plugins/ork-codex/skills/ork-assess/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Assess"
+  short_description: "Assess options and risks using evidence."
+  default_prompt: "Use $ork-assess to assess $ARGUMENTS."

--- a/plugins/ork-codex/skills/ork-brainstorm/SKILL.md
+++ b/plugins/ork-codex/skills/ork-brainstorm/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ork-brainstorm
+description: Compare plausible implementation, architecture, product, or operational approaches before committing to one. Use when a request asks to brainstorm, think through options, choose an approach, evaluate trade-offs, or resolve significant uncertainty before implementation. Do not use for an already specified mechanical change.
+---
+
+# Ork Brainstorm
+
+Frame the outcome, constraints, non-goals, and decision deadline. Inspect the relevant repository and existing decisions before proposing options.
+
+Generate two to four materially different approaches. For each, state the implementation shape, benefits, costs, risks, dependencies, reversibility, and the evidence that would disprove it. Do not pad the list with cosmetic variations.
+
+Use one context for a normal decision. Delegate only when there are at least three independent unknowns; give each subagent one bounded question and synthesize its evidence. Prefer the installed `ork_explorer` role when available, otherwise use Codex's built-in `explorer` role.
+
+End with a recommendation, the decision rationale, unresolved assumptions, and the smallest next action. Do not edit files until the user asks to implement the chosen approach.

--- a/plugins/ork-codex/skills/ork-brainstorm/agents/openai.yaml
+++ b/plugins/ork-codex/skills/ork-brainstorm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Brainstorm"
+  short_description: "Compare viable approaches before implementation."
+  default_prompt: "Use $ork-brainstorm to compare options for $ARGUMENTS."

--- a/plugins/ork-codex/skills/ork-explore/SKILL.md
+++ b/plugins/ork-codex/skills/ork-explore/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-explore
+description: Map an unfamiliar codebase, feature, architecture, data flow, or operational path with file-backed evidence. Use when a request asks how a system works, where behavior lives, what changed, which dependencies matter, or for onboarding before a change. Do not use to implement or fix the code.
+---
+
+# Ork Explore
+
+Stay read-only. Start with the task boundary, repository instructions, entry points, and the smallest searches that can prove the execution path. Cite files and symbols for every material claim; distinguish confirmed behavior from inference.
+
+Explore in one context by default. Fan out only for three or more independent questions such as structure, data flow, tests, and deployment. Use a flat fan-out, make each assignment bounded and read-only, and ask for concise evidence rather than proposed fixes. Prefer `ork_explorer` when installed; otherwise use Codex's built-in `explorer`.
+
+Return a compact map: entry points, important components and dependencies, tests/observability, risks or unknowns, and the next smallest investigation. Do not change files or turn the map into an implementation plan unless asked.

--- a/plugins/ork-codex/skills/ork-explore/agents/openai.yaml
+++ b/plugins/ork-codex/skills/ork-explore/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Explore"
+  short_description: "Map a codebase or system with evidence."
+  default_prompt: "Use $ork-explore to map $ARGUMENTS."

--- a/plugins/ork-codex/skills/ork-review-pr/SKILL.md
+++ b/plugins/ork-codex/skills/ork-review-pr/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-review-pr
+description: Review a pull request or branch for correctness, regressions, security, operational risk, and missing evidence. Use when a request asks to review a PR, review a diff, find real bugs, assess merge risk, or provide evidence-backed review findings. Do not use for implementation or style-only cleanup.
+---
+
+# Ork Review PR
+
+Stay read-only and review the actual diff in its repository context. Read the applicable instructions, trace changed behavior to its callers and tests, and prioritize correctness, security, data loss, race conditions, backwards compatibility, and evidence gaps over style.
+
+Use one reviewer for a focused diff. For a broad or high-risk PR, fan out independent read-only passes for code-path mapping, risk review, and documentation/API verification; each must return file and line evidence. Prefer `ork_reviewer` when installed, otherwise use a fresh built-in explorer/reviewer role.
+
+Lead with findings ordered by severity. Every finding needs a concrete location, impact, and a reproduction or reasoning path. If there are no findings, say what was checked and what was not. Do not modify files or approve/merge the PR.

--- a/plugins/ork-codex/skills/ork-review-pr/agents/openai.yaml
+++ b/plugins/ork-codex/skills/ork-review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Review PR"
+  short_description: "Review a pull request for real risks."
+  default_prompt: "Use $ork-review-pr to review $ARGUMENTS."

--- a/plugins/ork-codex/skills/ork-verify/SKILL.md
+++ b/plugins/ork-codex/skills/ork-verify/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-verify
+description: Verify that existing work is ready to merge, release, or hand off using an explicit evidence contract. Use when a request asks to verify, validate, prove, check readiness, run the relevant tests, or distinguish a claimed result from an observed one. Do not use to write missing tests or fix failures.
+---
+
+# Ork Verify
+
+Write the evidence contract first: target, required checks, environment, success condition, and budget. Read the repository instructions for canonical commands and run the narrowest relevant checks before broad suites.
+
+Report each command and its summary exactly. A passing test or check proves only the path it executed; verify that every required signal actually ran. Treat missing logs, unavailable external services, and skipped gates as unknown—not as success.
+
+For material changes, use a separate `ork_verifier` role when installed (or a fresh Codex reviewer) with the original task and final artifacts, not the implementer's reasoning. Return a binary verdict—PASS, FAIL, or BLOCKED—with evidence, gaps, and the next action. Do not change source files or tests.

--- a/plugins/ork-codex/skills/ork-verify/agents/openai.yaml
+++ b/plugins/ork-codex/skills/ork-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Verify"
+  short_description: "Produce an evidence-backed readiness verdict."
+  default_prompt: "Use $ork-verify to verify $ARGUMENTS."

--- a/scripts/build-codex-plugin.sh
+++ b/scripts/build-codex-plugin.sh
@@ -6,9 +6,15 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOURCE_DIR="$PROJECT_ROOT/src/codex/ork-codex"
 OUTPUT_DIR="$PROJECT_ROOT/plugins/ork-codex"
 PACKAGE_JSON="$PROJECT_ROOT/package.json"
+CODEX_MANIFEST="$PROJECT_ROOT/manifests/codex/ork-codex.json"
 
 if [[ ! -f "$SOURCE_DIR/.codex-plugin/plugin.json" ]]; then
   echo "Codex plugin source is missing its manifest: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$CODEX_MANIFEST" ]] || [[ "$(jq -r '.name' "$CODEX_MANIFEST")" != "ork-codex" ]]; then
+  echo "Codex plugin source manifest is missing or invalid: $CODEX_MANIFEST" >&2
   exit 1
 fi
 

--- a/scripts/build-codex-plugin.sh
+++ b/scripts/build-codex-plugin.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_DIR="$PROJECT_ROOT/src/codex/ork-codex"
+OUTPUT_DIR="$PROJECT_ROOT/plugins/ork-codex"
+PACKAGE_JSON="$PROJECT_ROOT/package.json"
+
+if [[ ! -f "$SOURCE_DIR/.codex-plugin/plugin.json" ]]; then
+  echo "Codex plugin source is missing its manifest: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+if [[ -e "$OUTPUT_DIR" ]]; then
+  echo "Codex plugin output must be cleaned by build-plugins.sh before assembly: $OUTPUT_DIR" >&2
+  exit 1
+fi
+
+cp -R "$SOURCE_DIR" "$OUTPUT_DIR"
+
+project_version="$(jq -r '.version' "$PACKAGE_JSON")"
+jq --arg version "$project_version" '.version = $version' \
+  "$OUTPUT_DIR/.codex-plugin/plugin.json" > "$OUTPUT_DIR/.codex-plugin/plugin.json.tmp"
+mv "$OUTPUT_DIR/.codex-plugin/plugin.json.tmp" "$OUTPUT_DIR/.codex-plugin/plugin.json"
+
+echo "  Codex plugin assembled: ork-codex v$project_version"

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -420,6 +420,14 @@ for manifest in "$MANIFESTS_DIR"/*.json; do
     echo -e "${GREEN}  Built $PLUGIN_NAME ($CURRENT/$MANIFEST_COUNT) - $skill_count skills, $agent_count agents, $command_count commands${NC}"
 done
 
+if [[ -x "$SCRIPT_DIR/build-codex-plugin.sh" ]]; then
+    echo -e "${BLUE}  Building Codex adapter...${NC}"
+    "$SCRIPT_DIR/build-codex-plugin.sh"
+else
+    echo -e "${RED}  ERROR: build-codex-plugin.sh is missing or not executable${NC}"
+    exit 1
+fi
+
 echo ""
 
 # ============================================================================
@@ -433,6 +441,14 @@ for plugin_dir in "$PLUGINS_DIR"/*; do
     [[ ! -d "$plugin_dir" ]] && continue
 
     plugin_name=$(basename "$plugin_dir")
+
+    if [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]]; then
+        if ! jq empty "$plugin_dir/.codex-plugin/plugin.json" 2>/dev/null; then
+            echo -e "${RED}  $plugin_name: Invalid Codex plugin JSON${NC}"
+            VALIDATION_ERRORS=$((VALIDATION_ERRORS + 1))
+        fi
+        continue
+    fi
 
     # Check plugin.json exists
     if [[ ! -f "$plugin_dir/.claude-plugin/plugin.json" ]]; then

--- a/src/codex/ork-codex/.codex-plugin/plugin.json
+++ b/src/codex/ork-codex/.codex-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "ork-codex",
+  "version": "9.5.4",
+  "description": "Portable OrchestKit workflows for Codex: brainstorm, explore, assess, verify, and review pull requests.",
+  "author": {
+    "name": "Yonatan Gross",
+    "url": "https://github.com/yonatangross"
+  },
+  "homepage": "https://github.com/yonatangross/orchestkit",
+  "repository": "https://github.com/yonatangross/orchestkit",
+  "license": "MIT",
+  "keywords": ["orchestration", "code-review", "verification", "planning"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "OrchestKit for Codex",
+    "shortDescription": "Evidence-first orchestration workflows for Codex.",
+    "longDescription": "A small, Codex-native OrchestKit pack for deliberate planning, codebase exploration, assessment, verification, and pull-request review. It uses Codex skills and subagents without Claude-only commands or hooks.",
+    "developerName": "Yonatan Gross",
+    "category": "Productivity",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": "Use $ork-brainstorm to compare approaches before I implement a change."
+  }
+}

--- a/src/codex/ork-codex/roles/ork_explorer.toml
+++ b/src/codex/ork-codex/roles/ork_explorer.toml
@@ -1,0 +1,10 @@
+name = "ork_explorer"
+description = "Read-only codebase explorer for evidence-backed architecture and execution-path discovery."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Stay in exploration mode. Map the actual execution path with targeted searches and file/symbol citations.
+Separate confirmed behavior from inference and name uncertainties. Do not propose edits unless the parent explicitly asks.
+Delegate only for at least three independent, bounded discovery questions; otherwise investigate directly.
+"""

--- a/src/codex/ork-codex/roles/ork_implementer.toml
+++ b/src/codex/ork-codex/roles/ork_implementer.toml
@@ -1,0 +1,10 @@
+name = "ork_implementer"
+description = "Scoped implementation agent that makes an approved change and proves the affected behavior."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Implement only the parent-approved scope. Read repository instructions first and use an isolated worktree whenever a shared primary checkout may be active.
+Keep changes small, add focused tests when behavior changes, and report exact verification output. Do not self-certify a high-impact change: request an independent verifier after implementation.
+Delegate only independent, bounded implementation units; retain integration responsibility.
+"""

--- a/src/codex/ork-codex/roles/ork_reviewer.toml
+++ b/src/codex/ork-codex/roles/ork_reviewer.toml
@@ -1,0 +1,9 @@
+name = "ork_reviewer"
+description = "Read-only reviewer focused on correctness, security, regressions, and missing evidence."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Review as an owner. Inspect the real diff and its execution context, then prioritize correctness, security, data integrity, operational risk, and missing tests.
+Return only actionable findings with file/symbol evidence, impact, and reasoning. State checked scope and residual uncertainty when there are no findings. Never edit files or approve a pull request.
+"""

--- a/src/codex/ork-codex/roles/ork_verifier.toml
+++ b/src/codex/ork-codex/roles/ork_verifier.toml
@@ -1,0 +1,9 @@
+name = "ork_verifier"
+description = "Independent verifier that returns a binary readiness verdict with command-backed evidence."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Receive the original task and final artifacts, not an implementation narrative. Read project guidance, define the evidence contract, and run the smallest relevant checks first.
+Return PASS, FAIL, or BLOCKED with exact commands and summary lines. Treat skipped, unavailable, or unexecuted checks as gaps. Do not edit source or tests; report failures for the implementer to address.
+"""

--- a/src/codex/ork-codex/scripts/install-codex-roles.sh
+++ b/src/codex/ork-codex/scripts/install-codex-roles.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$SCRIPT_DIR/../roles"
+DESTINATION="${1:-}"
+
+if [[ -z "$DESTINATION" ]]; then
+  echo "usage: $0 <destination-directory>" >&2
+  exit 2
+fi
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "role templates not found: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$DESTINATION"
+
+for source in "$SOURCE_DIR"/*.toml; do
+  name="$(basename "$source")"
+  target="$DESTINATION/$name"
+  if [[ -e "$target" ]]; then
+    echo "refusing to overwrite existing role: $target" >&2
+    exit 1
+  fi
+  install -m 0644 "$source" "$target"
+done
+
+echo "Installed OrchestKit Codex roles in $DESTINATION"

--- a/src/codex/ork-codex/skills/ork-assess/SKILL.md
+++ b/src/codex/ork-codex/skills/ork-assess/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-assess
+description: Assess a code change, design, architecture, workflow, or competing options against explicit criteria and evidence. Use when a request asks to assess, rate, compare, identify trade-offs, evaluate readiness, or decide whether an approach is good enough. Do not use for a full pull-request review or to implement a chosen solution.
+---
+
+# Ork Assess
+
+State the decision, scope, and criteria before scoring. Choose criteria appropriate to the task—normally correctness, maintainability, security, operability, testability, cost, and reversibility—and omit criteria that have no bearing on the decision.
+
+Collect evidence from the code, repository guidance, tests, or authoritative documentation. Separate facts, assumptions, and unknowns. Do not invent numeric precision: use a score only when it makes the comparison clearer, and attach the evidence and confidence to it.
+
+For high-impact choices, ask an independent read-only `ork_reviewer` or built-in reviewer to challenge the leading conclusion. End with a recommendation, conditions for approval, and concrete follow-up actions. Do not edit the target.

--- a/src/codex/ork-codex/skills/ork-assess/agents/openai.yaml
+++ b/src/codex/ork-codex/skills/ork-assess/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Assess"
+  short_description: "Assess options and risks using evidence."
+  default_prompt: "Use $ork-assess to assess $ARGUMENTS."

--- a/src/codex/ork-codex/skills/ork-brainstorm/SKILL.md
+++ b/src/codex/ork-codex/skills/ork-brainstorm/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ork-brainstorm
+description: Compare plausible implementation, architecture, product, or operational approaches before committing to one. Use when a request asks to brainstorm, think through options, choose an approach, evaluate trade-offs, or resolve significant uncertainty before implementation. Do not use for an already specified mechanical change.
+---
+
+# Ork Brainstorm
+
+Frame the outcome, constraints, non-goals, and decision deadline. Inspect the relevant repository and existing decisions before proposing options.
+
+Generate two to four materially different approaches. For each, state the implementation shape, benefits, costs, risks, dependencies, reversibility, and the evidence that would disprove it. Do not pad the list with cosmetic variations.
+
+Use one context for a normal decision. Delegate only when there are at least three independent unknowns; give each subagent one bounded question and synthesize its evidence. Prefer the installed `ork_explorer` role when available, otherwise use Codex's built-in `explorer` role.
+
+End with a recommendation, the decision rationale, unresolved assumptions, and the smallest next action. Do not edit files until the user asks to implement the chosen approach.

--- a/src/codex/ork-codex/skills/ork-brainstorm/agents/openai.yaml
+++ b/src/codex/ork-codex/skills/ork-brainstorm/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Brainstorm"
+  short_description: "Compare viable approaches before implementation."
+  default_prompt: "Use $ork-brainstorm to compare options for $ARGUMENTS."

--- a/src/codex/ork-codex/skills/ork-explore/SKILL.md
+++ b/src/codex/ork-codex/skills/ork-explore/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-explore
+description: Map an unfamiliar codebase, feature, architecture, data flow, or operational path with file-backed evidence. Use when a request asks how a system works, where behavior lives, what changed, which dependencies matter, or for onboarding before a change. Do not use to implement or fix the code.
+---
+
+# Ork Explore
+
+Stay read-only. Start with the task boundary, repository instructions, entry points, and the smallest searches that can prove the execution path. Cite files and symbols for every material claim; distinguish confirmed behavior from inference.
+
+Explore in one context by default. Fan out only for three or more independent questions such as structure, data flow, tests, and deployment. Use a flat fan-out, make each assignment bounded and read-only, and ask for concise evidence rather than proposed fixes. Prefer `ork_explorer` when installed; otherwise use Codex's built-in `explorer`.
+
+Return a compact map: entry points, important components and dependencies, tests/observability, risks or unknowns, and the next smallest investigation. Do not change files or turn the map into an implementation plan unless asked.

--- a/src/codex/ork-codex/skills/ork-explore/agents/openai.yaml
+++ b/src/codex/ork-codex/skills/ork-explore/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Explore"
+  short_description: "Map a codebase or system with evidence."
+  default_prompt: "Use $ork-explore to map $ARGUMENTS."

--- a/src/codex/ork-codex/skills/ork-review-pr/SKILL.md
+++ b/src/codex/ork-codex/skills/ork-review-pr/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-review-pr
+description: Review a pull request or branch for correctness, regressions, security, operational risk, and missing evidence. Use when a request asks to review a PR, review a diff, find real bugs, assess merge risk, or provide evidence-backed review findings. Do not use for implementation or style-only cleanup.
+---
+
+# Ork Review PR
+
+Stay read-only and review the actual diff in its repository context. Read the applicable instructions, trace changed behavior to its callers and tests, and prioritize correctness, security, data loss, race conditions, backwards compatibility, and evidence gaps over style.
+
+Use one reviewer for a focused diff. For a broad or high-risk PR, fan out independent read-only passes for code-path mapping, risk review, and documentation/API verification; each must return file and line evidence. Prefer `ork_reviewer` when installed, otherwise use a fresh built-in explorer/reviewer role.
+
+Lead with findings ordered by severity. Every finding needs a concrete location, impact, and a reproduction or reasoning path. If there are no findings, say what was checked and what was not. Do not modify files or approve/merge the PR.

--- a/src/codex/ork-codex/skills/ork-review-pr/agents/openai.yaml
+++ b/src/codex/ork-codex/skills/ork-review-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Review PR"
+  short_description: "Review a pull request for real risks."
+  default_prompt: "Use $ork-review-pr to review $ARGUMENTS."

--- a/src/codex/ork-codex/skills/ork-verify/SKILL.md
+++ b/src/codex/ork-codex/skills/ork-verify/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: ork-verify
+description: Verify that existing work is ready to merge, release, or hand off using an explicit evidence contract. Use when a request asks to verify, validate, prove, check readiness, run the relevant tests, or distinguish a claimed result from an observed one. Do not use to write missing tests or fix failures.
+---
+
+# Ork Verify
+
+Write the evidence contract first: target, required checks, environment, success condition, and budget. Read the repository instructions for canonical commands and run the narrowest relevant checks before broad suites.
+
+Report each command and its summary exactly. A passing test or check proves only the path it executed; verify that every required signal actually ran. Treat missing logs, unavailable external services, and skipped gates as unknown—not as success.
+
+For material changes, use a separate `ork_verifier` role when installed (or a fresh Codex reviewer) with the original task and final artifacts, not the implementer's reasoning. Return a binary verdict—PASS, FAIL, or BLOCKED—with evidence, gaps, and the next action. Do not change source files or tests.

--- a/src/codex/ork-codex/skills/ork-verify/agents/openai.yaml
+++ b/src/codex/ork-codex/skills/ork-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Verify"
+  short_description: "Produce an evidence-backed readiness verdict."
+  default_prompt: "Use $ork-verify to verify $ARGUMENTS."

--- a/tests/plugins/structure/test-plugin-structure-compliance.sh
+++ b/tests/plugins/structure/test-plugin-structure-compliance.sh
@@ -300,7 +300,8 @@ for plugin_dir in "$PROJECT_ROOT/plugins"/*/; do
     if [[ -d "$plugin_dir" ]]; then
         PLUGIN_NAME=$(basename "$plugin_dir")
 
-        # Check for .claude-plugin/plugin.json
+        # Claude and Codex have distinct plugin manifests. A host-native
+        # adapter must satisfy its own manifest contract, not a Claude-only one.
         if [[ -f "$plugin_dir.claude-plugin/plugin.json" ]]; then
             # Validate plugin.json is valid JSON
             if jq empty "$plugin_dir.claude-plugin/plugin.json" 2>/dev/null; then
@@ -317,7 +318,15 @@ for plugin_dir in "$PROJECT_ROOT/plugins"/*/; do
                 warn "$PLUGIN_NAME: description missing skill count"
             fi
         else
-            fail "$PLUGIN_NAME: missing .claude-plugin/plugin.json"
+            if [[ -f "$plugin_dir/.codex-plugin/plugin.json" ]]; then
+                if jq empty "$plugin_dir/.codex-plugin/plugin.json" 2>/dev/null; then
+                    pass "$PLUGIN_NAME: valid Codex plugin manifest"
+                else
+                    fail "$PLUGIN_NAME: invalid JSON in Codex plugin manifest"
+                fi
+            else
+                fail "$PLUGIN_NAME: missing host plugin manifest"
+            fi
         fi
     fi
 done

--- a/tests/plugins/test-codex-plugin.sh
+++ b/tests/plugins/test-codex-plugin.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+SOURCE_ROOT="$PROJECT_ROOT/src/codex/ork-codex"
+PLUGIN_ROOT="$PROJECT_ROOT/plugins/ork-codex"
+MARKETPLACE="$PROJECT_ROOT/.agents/plugins/marketplace.json"
+SKILL_VALIDATOR="/Users/yonatangross/.codex/skills/.system/skill-creator/scripts/quick_validate.py"
+PLUGIN_VALIDATOR="/Users/yonatangross/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py"
+
+for path in "$SOURCE_ROOT" "$PLUGIN_ROOT" "$MARKETPLACE"; do
+  [[ -e "$path" ]] || { echo "FAIL: missing $path"; exit 1; }
+done
+
+expected_skills=(ork-brainstorm ork-explore ork-assess ork-verify ork-review-pr)
+for skill in "${expected_skills[@]}"; do
+  [[ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]] || { echo "FAIL: missing $skill"; exit 1; }
+  python3 "$SKILL_VALIDATOR" "$PLUGIN_ROOT/skills/$skill" >/dev/null
+done
+
+expected_roles=(ork_explorer ork_implementer ork_reviewer ork_verifier)
+python3 - "$SOURCE_ROOT/roles" "${expected_roles[@]}" <<'PY'
+import sys
+import tomllib
+from pathlib import Path
+
+roles = Path(sys.argv[1])
+for name in sys.argv[2:]:
+    data = tomllib.loads((roles / f"{name}.toml").read_text())
+    missing = {"name", "description", "developer_instructions"} - data.keys()
+    if missing or data["name"] != name:
+        raise SystemExit(f"invalid role {name}: missing={sorted(missing)}")
+PY
+
+python3 "$PLUGIN_VALIDATOR" "$PLUGIN_ROOT" >/dev/null
+jq -e --arg version "$(jq -r '.version' "$PROJECT_ROOT/package.json")" '
+  .name == "ork-codex" and .version == $version and .skills == "./skills/"
+' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null
+jq -e '
+  .name == "orchestkit-codex" and
+  (.plugins[] | select(.name == "ork-codex") |
+    .source.source == "git-subdir" and
+    .source.url == "https://github.com/yonatangross/orchestkit.git" and
+    .source.path == "./plugins/ork-codex" and
+    .source.ref == "main")
+' "$MARKETPLACE" >/dev/null
+
+diff -qr "$SOURCE_ROOT" "$PLUGIN_ROOT" \
+  --exclude='plugin.json' >/dev/null
+
+echo "PASS: Codex plugin contract (5 skills, 4 roles)"

--- a/tests/plugins/test-codex-plugin.sh
+++ b/tests/plugins/test-codex-plugin.sh
@@ -6,8 +6,6 @@ PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 SOURCE_ROOT="$PROJECT_ROOT/src/codex/ork-codex"
 PLUGIN_ROOT="$PROJECT_ROOT/plugins/ork-codex"
 MARKETPLACE="$PROJECT_ROOT/.agents/plugins/marketplace.json"
-SKILL_VALIDATOR="/Users/yonatangross/.codex/skills/.system/skill-creator/scripts/quick_validate.py"
-PLUGIN_VALIDATOR="/Users/yonatangross/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py"
 
 for path in "$SOURCE_ROOT" "$PLUGIN_ROOT" "$MARKETPLACE"; do
   [[ -e "$path" ]] || { echo "FAIL: missing $path"; exit 1; }
@@ -15,8 +13,14 @@ done
 
 expected_skills=(ork-brainstorm ork-explore ork-assess ork-verify ork-review-pr)
 for skill in "${expected_skills[@]}"; do
-  [[ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]] || { echo "FAIL: missing $skill"; exit 1; }
-  python3 "$SKILL_VALIDATOR" "$PLUGIN_ROOT/skills/$skill" >/dev/null
+  skill_file="$PLUGIN_ROOT/skills/$skill/SKILL.md"
+  [[ -f "$skill_file" ]] || { echo "FAIL: missing $skill"; exit 1; }
+  sed -n '1,8p' "$skill_file" | grep -qx -- "name: $skill" || {
+    echo "FAIL: $skill has no matching skill name"; exit 1;
+  }
+  sed -n '1,8p' "$skill_file" | grep -qE '^description: .+' || {
+    echo "FAIL: $skill has no description"; exit 1;
+  }
 done
 
 expected_roles=(ork_explorer ork_implementer ork_reviewer ork_verifier)
@@ -33,9 +37,14 @@ for name in sys.argv[2:]:
         raise SystemExit(f"invalid role {name}: missing={sorted(missing)}")
 PY
 
-python3 "$PLUGIN_VALIDATOR" "$PLUGIN_ROOT" >/dev/null
 jq -e --arg version "$(jq -r '.version' "$PROJECT_ROOT/package.json")" '
-  .name == "ork-codex" and .version == $version and .skills == "./skills/"
+  .name == "ork-codex" and
+  .version == $version and
+  .skills == "./skills/" and
+  (.description | type == "string" and length > 0) and
+  (.author.name | type == "string" and length > 0) and
+  (.interface.displayName | type == "string" and length > 0) and
+  (.interface.shortDescription | type == "string" and length > 0)
 ' "$PLUGIN_ROOT/.codex-plugin/plugin.json" >/dev/null
 jq -e '
   .name == "orchestkit-codex" and

--- a/tests/security/test-packaging-leaks.sh
+++ b/tests/security/test-packaging-leaks.sh
@@ -128,7 +128,8 @@ log_section "Test 4: Only allowlisted file extensions in plugins/"
 
 # Allowlist of file extensions expected in plugins/.
 # Add new extensions here with a comment explaining why.
-ALLOWED_REGEX='\.(md|json|mjs|js|ts|tsx|py|sh|yaml|yml|html|css|tf|map)$'
+# .toml ships only as Codex custom-agent role templates under roles/.
+ALLOWED_REGEX='\.(md|json|mjs|js|ts|tsx|py|sh|toml|yaml|yml|html|css|tf|map)$'
 
 # Filter to files with extensions (skip extensionless like Dockerfile)
 FILES_WITH_EXT=$(echo "$TRACKED_LIST" | grep -E '\.[^/]+$' || true)


### PR DESCRIPTION
## Summary

Adds a source-built, Codex-native OrchestKit adapter without carrying Claude-only commands or hooks into Codex.

- ships five narrow generic workflows: `$ork-brainstorm`, `$ork-explore`, `$ork-assess`, `$ork-verify`, and `$ork-review-pr`
- exposes four separately installable generic Codex role templates: explorer, implementer, reviewer, verifier
- adds a remote marketplace entry, generated plugin output, and documented setup
- adapts repository validation for host-native Codex manifests, skills, and role templates
- mutation-proves the Codex manifest assertion by corrupting it, observing failure, then restoring it

## Verification

- `bash scripts/build-codex-plugin.sh`
- `bash tests/plugins/test-codex-plugin.sh`
- `bash bin/sync-skills.sh validate --quiet`
- `bash tests/security/run-security-tests.sh` (17/17)
- `bash tests/plugins/structure/test-plugin-structure-compliance.sh` (30 passed)
- five `quick_validate.py` skill checks
- `validate_plugin.py plugins/ork-codex`
- pre-commit: shell syntax, JSON syntax, component counts

## Interactive Playground

**[Open the Codex adapter playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/codex-native-orchestkit/docs/feat--codex-native-orchestkit/adapter.html)**

## Environment limitation

The full Node build was not run from this Platform-root Codex session because its dependency setup is blocked by the primary-worktree guard. Focused adapter validation passes; repository CI remains the merge gate.