### PR TITLE
fix(security): let the DYLD probe observe instead of aborting

### DIFF
--- a/docs/fix--dyld-probe-observes/playground.html
+++ b/docs/fix--dyld-probe-observes/playground.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1"><title>The gate that could never pass</title>
+<style>
+:root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--ink:#e6edf3;--dim:#8b949e;--ok:#3fb950;--bad:#f85149;--warn:#d29922;--acc:#58a6ff;--mono:ui-monospace,SFMono-Regular,Menlo,monospace}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:32px 20px}
+.wrap{max-width:940px;margin:0 auto}h1{font-size:22px;margin:0 0 4px}.sub{color:var(--dim);margin:0 0 26px;font-size:14px}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:20px;margin-bottom:20px}
+h2{font-size:16px;margin:0 0 10px}code,pre{font-family:var(--mono);font-size:13px}
+pre{background:#0b0f14;border:1px solid var(--line);border-radius:6px;padding:12px;overflow-x:auto;margin:10px 0}
+.ok{color:var(--ok)}.bad{color:var(--bad)}.warn{color:var(--warn)}.dim{color:var(--dim)}
+table{border-collapse:collapse;width:100%;font-size:13px;margin-top:10px}
+th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line)}th{color:var(--dim);font-weight:500}
+td.m{font-family:var(--mono)}
+.note{border-left:3px solid var(--warn);padding:10px 14px;background:rgba(210,153,34,.07);border-radius:0 6px 6px 0;font-size:13px;margin-top:14px}
+.row{display:flex;gap:8px;flex-wrap:wrap;margin:12px 0}
+button{background:#21262d;color:var(--ink);border:1px solid var(--line);border-radius:6px;padding:7px 13px;cursor:pointer;font-size:13px;font-family:var(--mono)}
+button:hover{border-color:var(--acc)}button[aria-pressed="true"]{background:var(--acc);color:#0d1117;font-weight:600}
+.out{border-left:3px solid var(--line);padding:12px 14px;background:#0b0f14;border-radius:0 6px 6px 0;margin-top:12px}
+</style></head><body><div class="wrap"><h1>The gate that could never pass</h1><p class="sub">One probe killed node before it started, and took the whole security suite with it.</p>
+<div class="card"><h2>Before / after</h2><pre>FIXED tree    run-security-tests.sh   rc=0   18 passed  0 failed
+CONTROL main  run-security-tests.sh   rc=1   17 passed  1 failed
+
+test-additional-security.sh alone:
+  here   82 lines, rc=0     &#9664; reaches the end
+  main   51 lines, rc=134   &#9664; dies at section 6
+  &rArr; 31 lines of assertions had NEVER executed</pre></div>
+ <div class="card"><h2>Why it was invisible</h2>
+ <pre>DYLD_INSERT_LIBRARIES=/nope/evil.dylib node -e 1   -&gt; 134   macOS
+node -e 1                                          -&gt;   0   control
+LD_PRELOAD=/nope/evil.so node -e 1                 -&gt;   0   linux</pre>
+ <p>macOS dyld <b>terminates the process</b> when an inserted library cannot load &mdash; before node&rsquo;s first instruction. On Linux the variable is meaningless, so CI stayed green while every macOS developer&rsquo;s <code>pre-push</code> died.</p></div>
+ <div class="card"><h2>Three outcomes, not two</h2><pre>rc 0    + verdict unchanged  -&gt; pass    property holds
+rc 0    + verdict changed    -&gt; fail    property broke
+rc &gt;=128                      -&gt; fail    measured NOTHING; say so   &#9664; NEW</pre>
+ <p>Plus the payload now points at a <b>real</b> dylib (<code>/usr/lib/libSystem.B.dylib</code>) so node starts and the verdict is observable. A missing library only tested dyld&rsquo;s error path.</p></div>
+</div></body></html>

--- a/tests/security/test-additional-security.sh
+++ b/tests/security/test-additional-security.sh
@@ -449,9 +449,25 @@ else
   log_fail "baseline is wrong before env testing even starts: got $CLEAN_DENY"
 fi
 
+# Every loader payload below points at a library that RESOLVES. That is
+# deliberate and must stay that way: DYLD_INSERT_LIBRARIES naming a missing
+# .dylib makes macOS dyld abort node with SIGABRT before node's first
+# instruction, so the probe measures dyld's error path instead of the guard's
+# invariance — and under `set -e` it took the whole suite down with it (the
+# 11 tests after this section never ran, while Linux CI stayed green because
+# the variable is inert there). /usr/lib/libSystem.B.dylib resolves from the
+# dyld shared cache, node actually starts, and the verdict becomes observable.
+# A real inserted library is also the realistic attack shape.
+#
+# A probe that could not observe must never read as a silent pass, so a
+# signal death is captured explicitly and graded as a FAILURE, not skipped.
 env_invariance() { # env_invariance <env assignment> <label>
-  local out got
-  out="$(raw_hook 'pretool/bash/dangerous-command-blocker' "$(bash_input 'rm -rf /')" "$1")"
+  local out got rc=0
+  out="$(raw_hook 'pretool/bash/dangerous-command-blocker' "$(bash_input 'rm -rf /')" "$1")" || rc=$?
+  if (( rc >= 128 )); then
+    log_fail "$2 — probe killed by signal $((rc - 128)); invariance NOT measured"
+    return 0
+  fi
   got="$(verdict_of "$out")"
   if [[ "$got" == "$CLEAN_DENY" ]]; then
     log_pass "$2 (-> $got, unchanged)"
@@ -462,7 +478,7 @@ env_invariance() { # env_invariance <env assignment> <label>
 
 env_invariance "LD_PRELOAD=$SANDBOX_OUTSIDE/evil.so"               'LD_PRELOAD set'
 env_invariance "LD_LIBRARY_PATH=$SANDBOX_OUTSIDE"                  'LD_LIBRARY_PATH set'
-env_invariance "DYLD_INSERT_LIBRARIES=$SANDBOX_OUTSIDE/evil.dylib" 'DYLD_INSERT_LIBRARIES set'
+env_invariance "DYLD_INSERT_LIBRARIES=/usr/lib/libSystem.B.dylib"  'DYLD_INSERT_LIBRARIES set'
 env_invariance "PATH=$SANDBOX_OUTSIDE:$PATH"                       'attacker dir prepended to PATH'
 env_invariance "IFS=/"                                             'IFS repointed to a path separator'
 


### PR DESCRIPTION
## Summary

`tests/security/test-additional-security.sh` has **never completed on macOS**. It exits **134 (SIGABRT)** partway through and takes the whole suite with it via `set -e` — so `bin/git-hooks/pre-push`, which CLAUDE.md says gates every push, has never been able to pass on the platform this repo is developed on.

```
this branch    run-security-tests.sh   rc=0   18 passed   0 failed   ✅
origin/main    run-security-tests.sh   rc=1   17 passed   1 failed   ❌ DO NOT MERGE

test-additional-security.sh alone:
  here    82 lines, rc=0     ← reaches the end
  main    51 lines, rc=134   ← dies at section 6
  ⇒ 31 lines of assertions had NEVER executed
```

## Root cause

Section 6 asserts that a hostile loader environment does not change a hook's verdict, and probed it with:

```bash
env_invariance "DYLD_INSERT_LIBRARIES=$SANDBOX_OUTSIDE/evil.dylib" ...
```

That dylib is never created. macOS dyld **terminates the process** when an inserted library cannot be loaded, before node's first instruction — so node never ran and the invariance the probe exists to measure was never measured.

```
DYLD_INSERT_LIBRARIES=/nope/evil.dylib node -e 'console.log(1)'   -> 134
node -e 'console.log(1)'                                          ->   0   (control)
LD_PRELOAD=/nope/evil.so node -e 'console.log(1)'                 ->   0   (linux equiv)
```

On Linux the variable is meaningless, node runs, the probe passes, CI stays green. **The break was invisible in CI and fatal locally.** Not a bash-version issue — bash 3.2 and 5.3 abort at the identical point.

## The fix, two parts

**1. Payload.** Point at `/usr/lib/libSystem.B.dylib`, a real library that resolves from the dyld shared cache. node now starts and the verdict is observable:

```
DYLD_INSERT_LIBRARIES=/usr/lib/libSystem.B.dylib  ->  rc=0, verdict=deny
```

A *missing* library only tested dyld's error path. A *real* inserted library is also the realistic attack shape — an attacker inserts something that works.

**2. Handling.** `env_invariance` modelled two outcomes and needed three. It now captures the exit code explicitly and reports `"probe killed by signal N; invariance NOT measured"` for anything `>= 128`, then returns 0 so the suite continues.

```
  rc 0    + verdict unchanged  -> pass    the property holds
  rc 0    + verdict changed    -> fail    the property broke
  rc >=128                     -> fail    we measured NOTHING; say so   ◀ NEW
```

A probe that could not observe must never read as a silent pass, and must not abort every test after it.

## Verification

```
this branch  test-additional-security.sh  rc=0,  82 lines
             run-security-tests.sh         rc=0,  18/18
control      run-security-tests.sh         rc=1,  17/18
shellcheck -S error                        clean
```

Isolated to one file, 19 insertions / 3 deletions, cherry-picked onto current `main` so it is not blocked by any other in-flight work.

Same defect class as the rest of the v10 milestone: **a check that answers without the thing it measures ever running.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/fix/dyld-probe-observes/docs/fix--dyld-probe-observes/playground.html)**

`docs/fix--dyld-probe-observes/playground.html` &mdash; the evidence behind this change, rendered.
