### PR TITLE
fix(docs): gate the README prose counts instead of correcting them

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ OrchestKit is a quality-gate plugin, so its hooks are the product rather than an
 add-on. This section states plainly what they see, where it goes, and how to turn
 each piece off.
 
-**Scope: broad and intentional.** OrchestKit registers 218 hooks across 29
+**Scope: broad and intentional.** OrchestKit registers <!--ork:hooks-->217<!--/ork--> hooks across <!--ork:events-->30<!--/ork-->
 lifecycle events, including `SessionStart`, `UserPromptSubmit`, `PreToolUse`,
 `PostToolUse`, and `Stop`. They are **not** gated to a particular framework or
 project type, because the gates they enforce (secret-write blocking, protected-file

--- a/docs/fix--readme-prose-counts-ungated/index.html
+++ b/docs/fix--readme-prose-counts-ungated/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Four surfaces, four different numbers</title><style>
+:root{--bg:hsl(232 26% 7%);--ink:hsl(220 18% 93%);--muted:hsl(220 14% 64%);--faint:hsl(220 12% 46%);
+--glass:hsl(0 0% 100% / .05);--edge:hsl(0 0% 100% / .18);--accent:hsl(248 84% 68%);--ok:hsl(162 62% 52%);--bad:hsl(354 78% 62%);--warn:hsl(38 92% 62%)}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(54rem 36rem at 88% -6%,hsl(248 70% 26% / .38),transparent 62%),var(--bg);
+background-attachment:fixed;color:var(--ink);font:15px/1.65 -apple-system,system-ui,sans-serif}
+.wrap{max-width:900px;margin-inline:auto;padding:48px 24px 80px}
+.eyebrow{display:inline-block;font-size:11.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;
+color:var(--faint);border:1px solid var(--edge);border-radius:999px;background:var(--glass);padding:6px 12px}
+h1{font-size:clamp(24px,3.6vw,34px);font-weight:700;margin:14px 0 10px}h1 span{color:var(--accent)}
+.lede{color:var(--muted);max-width:66ch;margin:0 0 28px}.lede b{color:var(--ink)}
+h2{font-size:17px;margin:28px 0 8px}
+.card{border:1px solid var(--edge);border-radius:14px;background:var(--glass);padding:16px 18px;margin-top:12px}
+.card h3{margin:0 0 6px;font-size:14.5px}.card p{margin:0 0 8px;font-size:13.5px;color:var(--muted)}
+.card p:last-child{margin-bottom:0}
+code{font-family:ui-monospace,Menlo,monospace;font-size:12px;background:hsl(0 0% 100% / .07);padding:1px 5px;border-radius:5px}
+pre{background:hsl(232 30% 4% / .6);border:1px solid var(--edge);border-radius:12px;padding:12px;overflow-x:auto;font-size:12px;color:var(--muted);font-family:ui-monospace,Menlo,monospace;line-height:1.55}
+.ok{color:var(--ok)}.bad{color:var(--bad)}.warn{color:var(--warn)}.faint{color:var(--faint)}
+table{width:100%;border-collapse:collapse;font-size:13px;border:1px solid var(--edge);border-radius:12px;overflow:hidden;background:var(--glass);margin-top:10px}
+th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.06em;color:var(--faint);padding:9px 11px;border-bottom:1px solid var(--edge)}
+td{padding:9px 11px;border-bottom:1px solid hsl(0 0% 100% / .06)}tr:last-child td{border-bottom:none}
+.foot{margin-top:32px;font-size:12px;color:var(--faint);line-height:1.9}
+</style></head><body><div class="wrap">
+<div class="eyebrow">issue #3397 &middot; alpha.10 &middot; 2026-08-10</div>
+<h1>Four surfaces. <span>Four different numbers.</span></h1>
+<p class="lede">Ground truth at <code>v10.0.0-alpha.10</code> is <b>105 skills, 36 agents, 217 hooks,
+30 lifecycle events</b>. Four places advertise those counts to the public and they do not agree with
+each other — the worst offender is the first thing anyone reads, and it is the one no CI check can
+ever see.</p>
+
+<h2>The disagreement</h2>
+<table><thead><tr><th>surface</th><th>claims</th><th>gated?</th></tr></thead><tbody>
+<tr><td>README markers (L6, L81-83)</td><td class="ok">105 / 36 / 217</td><td class="ok">yes — stamp-counts.sh</td></tr>
+<tr><td><code>marketplace.json</code></td><td class="ok">105 / 36 / 217</td><td class="ok">yes</td></tr>
+<tr><td>README <b>prose</b> (L135)</td><td class="bad">218 hooks, 29 events</td><td class="bad">no</td></tr>
+<tr><td>GitHub <b>About</b> blurb</td><td class="bad">114 / 37 / 212</td><td class="bad">impossible</td></tr>
+</tbody></table>
+
+<h2>Why the prose drifted</h2>
+<div class="card"><h3>The stamper has two strategies and this line fell between them</h3>
+<pre>README / CLAUDE.md   →  &lt;!--ork:KEY--&gt;VALUE&lt;!--/ork--&gt;   marker replacement
+docs/site *.mdx      →  explicit sed phrasings            (MDX renders comments literally)
+README prose L135    →  <span class="bad">bare number, neither path reaches it</span></pre>
+<p>So it was never stamped, and after enough merges it landed wrong in <b>both</b> directions at
+once: 218 against a real 217, and 29 against a real 30. An ungated claim does not drift in a
+consistent direction — it just stops being true.</p></div>
+
+<h2>Fix: gate the number, do not correct the digit</h2>
+<pre>- OrchestKit registers 218 hooks across 29
++ OrchestKit registers &lt;!--ork:hooks--&gt;217&lt;!--/ork--&gt; hooks across &lt;!--ork:events--&gt;30&lt;!--/ork--&gt;</pre>
+<p style="color:var(--muted);font-size:13.5px;margin-top:8px">Plus a new <code>ork:events</code>
+marker in <code>stamp-counts.sh</code>, computed from the distinct event keys in
+<code>hooks.json</code>. Correcting 218&rarr;217 would have been true for exactly as long as it took
+to add hook 218.</p>
+
+<h2>Control — it must actually re-stamp</h2>
+<pre>$ sed -i '' 's/217.*30/999 … 7/' README.md      # corrupt it on purpose
+  L135: registers &lt;!--ork:hooks--&gt;<span class="bad">999</span>&lt;!--/ork--&gt; hooks across &lt;!--ork:events--&gt;<span class="bad">7</span>&lt;!--/ork--&gt;
+
+$ bash scripts/stamp-counts.sh                   # exit 0
+  L135: registers &lt;!--ork:hooks--&gt;<span class="ok">217</span>&lt;!--/ork--&gt; hooks across &lt;!--ork:events--&gt;<span class="ok">30</span>&lt;!--/ork--&gt;</pre>
+<p class="faint" style="font-size:12.5px">Without this step the change is indistinguishable from
+hand-editing two digits, which is the thing that failed the first time.</p>
+
+<h2>The one that cannot be fixed by this PR</h2>
+<div class="card"><h3>GitHub's About blurb lives outside the repository</h3>
+<p>It reads <b>"114 skills, 37 agents, 212 hooks"</b> — wrong on all three, and drifted far enough
+that those numbers predate any recent release. It sits in repo settings, reachable only via
+<code>PATCH /repos/{owner}/{repo}</code>, so no file in the tree contains it and no CI job can
+compare it against <code>validate-counts.sh</code>.</p>
+<p>That makes it a permanent honesty gap rather than a bug with a fix: it needs a one-off update now,
+and it will drift again the next time the counts move. Worth saying plainly in the issue instead of
+closing it as done and letting the next person assume it is gated like the rest.</p></div>
+
+<p class="foot"><b>Why this belongs in milestone #164.</b> The milestone is about machinery that
+claims more than it does, and component counts are the most literal case: a visitor's first
+impression of the project is four numbers, three surfaces disagreeing, and the loudest one wrong by
+nine skills. Nothing was broken in the code. The claim was just never checkable — which is the same
+defect as a hook registered but never dispatched, a guard that cannot observe, or a test whose only
+failing assertion is "valid JSON".</p>
+</div></body></html>

--- a/scripts/stamp-counts.sh
+++ b/scripts/stamp-counts.sh
@@ -36,6 +36,17 @@ HOOKS_SKILL=$SKILL
 # User-invocable skills count
 INVOCABLE=$(grep -rl '^user-invocable: true' "$PROJECT_ROOT/src/skills/" --include='SKILL.md' 2>/dev/null | wc -l | tr -d ' ')
 
+# Distinct lifecycle events registered in hooks.json. README prose claimed
+# "218 hooks across 29 lifecycle events" while the truth was 217 across 30 —
+# both numbers wrong, in opposite directions, because neither was wrapped in a
+# marker and the README path stamps markers only. Gate the number rather than
+# correct the digit, or it drifts again on the next event added.
+EVENTS=$(python3 -c "
+import json
+h = json.load(open('$PROJECT_ROOT/src/hooks/hooks.json'))['hooks']
+print(len(h) if isinstance(h, dict) else len({e.get('event') or e.get('hookEventName') for e in h if isinstance(e, dict)}))
+")
+
 # ── Marker replacement ──────────────────────────────────────────────────────
 
 # Replace <!--ork:KEY-->VALUE<!--/ork--> with updated VALUE
@@ -66,6 +77,7 @@ stamp_file() {
   stamp_marker "$file" "hooks-agent" "$HOOKS_AGENT"
   stamp_marker "$file" "hooks-skill" "$HOOKS_SKILL"
   stamp_marker "$file" "invocable" "$INVOCABLE"
+  stamp_marker "$file" "events" "$EVENTS"
 }
 
 # ── Files with markers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Ground truth at `v10.0.0-alpha.10` is **105 skills, 36 agents, 217 hooks, 30 lifecycle events**. Four public surfaces advertise those counts and they disagree.

| surface | claims | gated? |
|---|---|---|
| README markers (L6, L81-83) | 105 / 36 / 217 | yes — `stamp-counts.sh` |
| `marketplace.json` | 105 / 36 / 217 | yes |
| README **prose** (L135) | "218 hooks across 29 lifecycle events" | **no** |
| GitHub **About** blurb | "114 skills, 37 agents, 212 hooks" | **impossible** |

## Why the prose drifted

`stamp-counts.sh` reaches README/CLAUDE.md through `<!--ork:KEY-->` markers, and docs-site MDX through explicit sed phrasings (MDX renders HTML comments literally). Line 135 was a bare number in README prose, so neither path touched it. It ended up wrong in **both** directions at once — 218 against 217 hooks, 29 against 30 events.

## Fix

```diff
- OrchestKit registers 218 hooks across 29
+ OrchestKit registers <!--ork:hooks-->217<!--/ork--> hooks across <!--ork:events-->30<!--/ork-->
```

Plus a new `ork:events` marker in `stamp-counts.sh`, computed from the distinct event keys in `hooks.json`. Correcting 218 -> 217 by hand would have been true only until hook 218 landed.

## Control

Gating is the claim, so it needs proving:

```
corrupt L135 to '999 hooks across 7'  ->  stamp-counts.sh  ->  restored to 217 / 30 (exit 0)
```

`bin/validate-counts.sh`: PASSED. `npm run build`: clean, no drift beyond the two edited files.

## Not fixed here, and cannot be

The GitHub About blurb lives in repo settings, not the tree — reachable only via `PATCH /repos/{owner}/{repo}`. No file contains it, so no CI job can compare it to `validate-counts.sh`. It needs a one-off update and will drift again. Stated plainly in #3397 rather than closed as if it were gated like the rest.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/fix/readme-prose-counts-ungated/docs/fix--readme-prose-counts-ungated/index.html)** — the four-way disagreement, why the stamper's two strategies both missed this line, and the control run.

Closes #3397

🤖 Generated with [Claude Code](https://claude.com/claude-code)