### PR TITLE
ci: tee probe diagnostics to stdout, not just the step summary

### DIFF
--- a/.github/workflows/cc-contract-probe.yml
+++ b/.github/workflows/cc-contract-probe.yml
@@ -99,6 +99,13 @@ jobs:
       # Unconditional, and printed BEFORE the check runs. If the check reports
       # CANNOT-OBSERVE, this listing is the only evidence of where the binary
       # actually went, and without it the next person repeats this experiment.
+      #
+      # `tee` to BOTH stdout and the summary, not just the summary. Measured on
+      # run 31400567250: the first version wrote only to $GITHUB_STEP_SUMMARY,
+      # which is invisible to `gh run view --log` AND absent from the check-run
+      # API's output.summary — so the probe failed exactly as designed and its
+      # diagnosis was unreadable from the CLI. A diagnostic that only renders in
+      # a browser is not a diagnostic for an agent.
       - name: Report where the binary landed
         run: |
           set -uo pipefail
@@ -115,7 +122,7 @@ jobs:
               fi
             done
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
       - name: Derive the contract and compare to the committed snapshot
         run: |
@@ -145,5 +152,7 @@ jobs:
             echo '```'
             cat /tmp/contract.txt
             echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+            echo ''
+            echo "derive-cc-output-keys exit code: ${rc}"
+          } | tee -a "$GITHUB_STEP_SUMMARY"
           exit "$rc"

--- a/docs/fix--3308-probe-stdout-diagnostics/index.html
+++ b/docs/fix--3308-probe-stdout-diagnostics/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>A diagnostic only a browser could read</title><style>
+:root{--bg:hsl(232 26% 7%);--ink:hsl(220 18% 93%);--muted:hsl(220 14% 64%);--faint:hsl(220 12% 46%);
+--glass:hsl(0 0% 100% / .05);--edge:hsl(0 0% 100% / .18);--accent:hsl(248 84% 68%);--ok:hsl(162 62% 52%);--bad:hsl(354 78% 62%)}
+*{box-sizing:border-box}body{margin:0;background:radial-gradient(54rem 36rem at 88% -6%,hsl(248 70% 26% / .38),transparent 62%),var(--bg);
+background-attachment:fixed;color:var(--ink);font:15px/1.65 -apple-system,system-ui,sans-serif}
+.wrap{max-width:900px;margin-inline:auto;padding:48px 24px 80px}
+.eyebrow{display:inline-block;font-size:11.5px;font-weight:600;letter-spacing:.09em;text-transform:uppercase;
+color:var(--faint);border:1px solid var(--edge);border-radius:999px;background:var(--glass);padding:6px 12px}
+h1{font-size:clamp(24px,3.6vw,34px);font-weight:700;margin:14px 0 10px}h1 span{color:var(--accent)}
+.lede{color:var(--muted);max-width:66ch;margin:0 0 28px}.lede b{color:var(--ink)}
+h2{font-size:17px;margin:28px 0 8px}
+.card{border:1px solid var(--edge);border-radius:14px;background:var(--glass);padding:16px 18px;margin-top:12px}
+.card h3{margin:0 0 6px;font-size:14.5px}.card p{margin:0 0 8px;font-size:13.5px;color:var(--muted)}
+code{font-family:ui-monospace,Menlo,monospace;font-size:12px;background:hsl(0 0% 100% / .07);padding:1px 5px;border-radius:5px}
+pre{background:hsl(232 30% 4% / .6);border:1px solid var(--edge);border-radius:12px;padding:12px;overflow-x:auto;font-size:12px;color:var(--muted);font-family:ui-monospace,Menlo,monospace;line-height:1.55}
+.ok{color:var(--ok)}.bad{color:var(--bad)}.faint{color:var(--faint)}
+.foot{margin-top:32px;font-size:12px;color:var(--faint);line-height:1.9}
+</style></head><body><div class="wrap">
+<div class="eyebrow">follow-up to #3407 &middot; run 31400567250 &middot; 2026-08-10</div>
+<h1>A diagnostic <span>only a browser could read.</span></h1>
+<p class="lede">The contract probe shipped in #3407 and its first dispatch <b>failed exactly as
+designed</b> — a contract gate that cannot observe must never look green. Then I could not tell
+<i>which</i> failure it was, because every line it printed went somewhere a CLI cannot reach.</p>
+
+<h2>What happened</h2>
+<pre>run 31400567250 — dispatched on main immediately after merge
+
+  Install the newest published CLI ................ <span class="ok">success</span>
+  Report where the binary landed ................. <span class="ok">success</span>
+  Derive the contract ............................ <span class="bad">failure</span>
+
+$ gh run view 31400567250 --log     → only the ECHOED script lines
+$ gh api .../check-runs/…           → output.summary is EMPTY</pre>
+<p style="color:var(--muted);font-size:13.5px;margin-top:8px">Two candidate exits — <code>1</code>
+drift, <code>2</code> CANNOT-OBSERVE — and no way to distinguish them without opening a browser. The
+whole reason that layout step is unconditional was to answer this, and it answered it into a channel
+the asker cannot read.</p>
+
+<div class="card"><h3>The defect, stated plainly</h3>
+<p><code>$GITHUB_STEP_SUMMARY</code> renders in the web UI. It is <b>not</b> in
+<code>gh run view --log</code>, and it is <b>not</b> in the check-run API's
+<code>output.summary</code>. Writing diagnostics only there makes them invisible to every automated
+consumer — including the agent that dispatched the run.</p>
+<p>Same shape as the thirty-four defects this milestone exists to remove: the machinery ran, reported
+honestly, and reported into a void.</p></div>
+
+<h2>Fix</h2>
+<pre>-          } >> "$GITHUB_STEP_SUMMARY"
++          } | tee -a "$GITHUB_STEP_SUMMARY"</pre>
+<p style="color:var(--muted);font-size:13.5px;margin-top:8px">Both blocks now <code>tee</code>, so
+the layout listing and the verdict land in the log <i>and</i> the summary. The derive step also emits
+<code>derive-cc-output-keys exit code: N</code> explicitly, so exit 1 and exit 2 are distinguishable
+from the log alone rather than inferred from a red X.</p>
+
+<h2>A second mistake worth recording</h2>
+<pre>$ grep -c "tee -a \"$GITHUB_STEP_SUMMARY\"" file
+0        ← the shell expanded the variable to EMPTY inside double quotes,
+           so this searched for `tee -a ""` and I nearly "re-fixed" a
+           working edit
+$ grep -c 'tee -a' file
+2        ← correct</pre>
+<p style="color:var(--muted);font-size:13.5px;margin-top:8px">A verification step that cannot observe
+what it checks reports a false negative just as confidently as a false positive. Single-quote any
+grep pattern containing a <code>$</code>.</p>
+
+<p class="foot"><b>Still unanswered, deliberately.</b> Whether the runner populates
+<code>~/.local/share/claude/versions/</code> — the only path <code>findBinary()</code> searches — is
+what the next dispatch will show, now that the listing reaches the log. I am not guessing at it here:
+the install step succeeded and the derive step failed, which is consistent with both drift and
+cannot-observe, and the difference decides whether the follow-up fixes the lookup path or commits a
+regenerated snapshot.</p>
+</div></body></html>


### PR DESCRIPTION
## Summary

#3407's probe worked. Dispatched on `main`, run [31400567250](https://github.com/yonatangross/orchestkit/actions/runs/31400567250) **failed as designed** — a contract gate that cannot observe must never look green.

Then I could not tell **which** failure it was.

```
Install the newest published CLI ....... success
Report where the binary landed ........ success
Derive the contract ................... failure

gh run view 31400567250 --log    only the ECHOED script lines
gh api .../check-runs/...        output.summary is EMPTY
```

Two candidate exits — 1 drift, 2 CANNOT-OBSERVE — indistinguishable without opening a browser. That layout step is unconditional precisely to answer this, and it answered into a channel the asker cannot read.

## The defect

`GITHUB_STEP_SUMMARY` renders in the web UI only. It is **not** in `gh run view --log`, and **not** in the check-run API's `output.summary`. Diagnostics written only there are invisible to every automated consumer, including the agent that dispatched the run. Same shape as the defects this milestone exists to remove: the machinery ran, reported honestly, and reported into a void.

## Fix

Both summary blocks now `tee` instead of `>>`, so the binary-layout listing and the verdict reach the log as well as the summary. The derive step additionally prints `derive-cc-output-keys exit code: N`, so 1 and 2 are distinguishable from the log alone rather than inferred from a red X.

## A second mistake, recorded because it nearly cost a revert

My own verification of the fix reported 0 matches:

```
grep -c "tee -a \"...GITHUB_STEP_SUMMARY\"" file    ->  0     WRONG
grep -c 'tee -a' file                              ->  2     correct
```

The shell expanded the variable to empty inside double quotes, so it searched for `tee -a ""` and I nearly "re-fixed" a working edit. A verification step that cannot observe what it checks reports a false negative just as confidently as a false positive — single-quote any grep pattern containing a dollar sign.

## Still unanswered, deliberately

Whether the runner populates `~/.local/share/claude/versions/` — the only path `findBinary()` searches — is what the next dispatch will show now that the listing reaches the log. Install succeeded and derive failed, which is consistent with **both** drift and cannot-observe, and that difference decides whether the follow-up fixes the lookup path or commits a regenerated snapshot. Not guessing here.

`actionlint` exit 0; pre-commit workflow lint passed.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/fix/3308-probe-stdout-diagnostics/docs/fix--3308-probe-stdout-diagnostics/index.html)**

Refs #3308

🤖 Generated with [Claude Code](https://claude.com/claude-code)