### PR TITLE
fix(release): real component counts, and a named announce identity

### DIFF
--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -113,6 +113,10 @@ jobs:
           # Growth channels only — LinkedIn is curated/hand-written (never auto).
           # Instagram joins once Meta Business Verification clears.
           ANNOUNCE_CHANNELS: twitter,devto,hashnode,substack,threads
+          # Draft under the project's automation account, never a maintainer's
+          # personal one. Inert until the platform adapter honours it — see
+          # announce-release.mjs.
+          ANNOUNCE_ACCOUNT: yonyon2ai
           HQ_API_URL: ${{ secrets.HQ_API_URL }}
           HQ_API_TOKEN: ${{ secrets.HQ_API_TOKEN }}
           DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}

--- a/docs/fix--release-rail-counts-and-account/release-rail.html
+++ b/docs/fix--release-rail-counts-and-account/release-rail.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Release rail — component counts and the announce account</title>
+<style>
+:root{--bg:#fbfaf9;--panel:#fff;--ink:#1c1917;--mute:#78716c;--line:#e7e5e4;
+ --ok:#047857;--bad:#b91c1c;--warn:#b45309;--accent:#c2410c}
+@media(prefers-color-scheme:dark){:root{--bg:#0c0a09;--panel:#1c1917;--ink:#f5f5f4;--mute:#a8a29e;--line:#292524}}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+ font:14px/1.6 ui-sans-serif,-apple-system,"SF Pro Text",Inter,system-ui,sans-serif}
+header{max-width:1000px;margin:0 auto;padding:28px 32px 0}
+h1{font-size:20px;margin:0 0 4px;letter-spacing:-.01em}
+.sub{color:var(--mute);font-size:13px;margin:0 0 20px}
+.tabs{display:flex;gap:2px;border-bottom:1px solid var(--line);max-width:1000px;margin:0 auto;padding:0 32px;flex-wrap:wrap}
+.tab{padding:9px 15px;border:0;background:none;color:var(--mute);cursor:pointer;font:inherit;
+ font-weight:500;border-bottom:2px solid transparent;margin-bottom:-1px}
+.tab[aria-selected=true]{color:var(--ink);border-bottom-color:var(--accent)}
+main{max-width:1000px;margin:0 auto;padding:24px 32px 64px}
+.panel[hidden]{display:none}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px;margin-bottom:18px}
+.card h2{font-size:15px;margin:0 0 4px;font-weight:600}
+.lede{color:var(--mute);font-size:12.5px;margin:0 0 16px}
+pre{font:12px/1.5 ui-monospace,SFMono-Regular,monospace;background:var(--bg);
+ border:1px solid var(--line);border-radius:8px;padding:14px;overflow-x:auto;margin:0}
+code{font:12px ui-monospace,monospace;background:var(--line);padding:1px 5px;border-radius:4px}
+table{width:100%;border-collapse:collapse;font-size:13px}
+th{text-align:left;color:var(--mute);font-weight:500;font-size:11.5px;text-transform:uppercase;
+ letter-spacing:.04em;padding:0 10px 8px 0;border-bottom:1px solid var(--line)}
+td{padding:9px 10px 9px 0;border-bottom:1px solid var(--line);vertical-align:top}
+tr:last-child td{border-bottom:0}
+.pill{display:inline-block;border-radius:99px;padding:1px 8px;font-size:11px;font-weight:600;color:#fff}
+.pill.ok{background:var(--ok)}.pill.no{background:var(--mute)}.pill.bad{background:var(--bad)}
+.tiles{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:14px}
+.tile{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
+.tile .v{font-size:24px;font-weight:600;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+.tile .v.bad{color:var(--bad)}.tile .v.ok{color:var(--ok)}
+.tile .k{color:var(--mute);font-size:12px;margin-top:2px}
+.ctl{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:14px}
+button.t{border:1px solid var(--line);background:var(--panel);color:var(--ink);
+ border-radius:7px;padding:6px 12px;font:inherit;font-size:12.5px;cursor:pointer}
+button.t[aria-pressed=true]{background:var(--accent);color:#fff;border-color:var(--accent)}
+.warn{border:1px solid var(--warn);border-radius:9px;padding:12px 15px;margin-bottom:16px;font-size:12.5px}
+.warn b{color:var(--warn)}
+.good{border:1px solid var(--ok);border-radius:9px;padding:12px 15px;margin-bottom:16px;font-size:12.5px}
+.good b{color:var(--ok)}
+[hidden]{display:none !important}
+</style></head><body>
+<header>
+  <h1>Release rail: component counts, and which identity announces</h1>
+  <p class="sub">Playground for PR "fix(release): real component counts, and a machine account on announce" · 2026-08-14</p>
+</header>
+<div class="tabs" role="tablist">
+  <button class="tab" role="tab" aria-selected="true"  data-p="p1">The stats bug</button>
+  <button class="tab" role="tab" aria-selected="false" data-p="p2">The account field</button>
+  <button class="tab" role="tab" aria-selected="false" data-p="p3">Why the gate stays</button>
+</div>
+<main>
+
+<section class="panel" id="p1">
+  <div class="warn"><b>The defect.</b> <code>changelog-to-props.mjs</code> defaulted
+  <code>statsBefore</code>/<code>statsAfter</code> to <code>{0,0,0}</code> and only filled them from a
+  <code>Skill count: 197 → 199</code> regex that release-please changelogs never emit. That script also
+  feeds <code>release-video.yml</code>, so the zeros reached the rendered release videos, not just the
+  announce payload.</div>
+
+  <div class="card">
+    <h2>Toggle the fix</h2>
+    <p class="lede">Same input changelog, both code paths. These are the real values produced locally.</p>
+    <div class="ctl">
+      <button class="t" id="bBefore" aria-pressed="true">before (regex only)</button>
+      <button class="t" id="bAfter"  aria-pressed="false">after (manifest-derived)</button>
+    </div>
+
+    <div id="sBefore">
+      <div class="tiles">
+        <div class="tile"><div class="v bad">0</div><div class="k">skills — wrong</div></div>
+        <div class="tile"><div class="v ok">36</div><div class="k">agents — right by luck</div></div>
+        <div class="tile"><div class="v bad">0</div><div class="k">hooks — wrong</div></div>
+      </div>
+      <pre>statsBefore: {"skills":0,"agents":36,"hooks":0}
+statsAfter : {"skills":0,"agents":36,"hooks":0}</pre>
+    </div>
+
+    <div id="sAfter" hidden>
+      <div class="tiles">
+        <div class="tile"><div class="v ok">105</div><div class="k">skills</div></div>
+        <div class="tile"><div class="v ok">36</div><div class="k">agents</div></div>
+        <div class="tile"><div class="v ok">216</div><div class="k">hooks</div></div>
+      </div>
+      <pre>statsBefore: {"skills":105,"agents":36,"hooks":216}
+statsAfter : {"skills":105,"agents":36,"hooks":216}</pre>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Why the manifest, and not a filesystem walk</h2>
+    <p class="lede">Several sources were plausible. Only one is already CI-gated.</p>
+    <table>
+      <thead><tr><th style="width:210px">Source</th><th style="width:80px">Verdict</th><th>Reason</th></tr></thead>
+      <tbody>
+        <tr><td><code>manifests/ork.json</code> description</td>
+            <td><span class="pill ok">chosen</span></td>
+            <td class="lede" style="margin:0">Already asserted against the filesystem by
+                <code>bin/validate-counts.sh</code>, so a green CI makes it correct by construction.
+                One JSON read, no shell-out.</td></tr>
+        <tr><td>filesystem walk</td><td><span class="pill no">no</span></td>
+            <td class="lede" style="margin:0">Correct, but duplicates the counting rules (skip
+                <code>shared/</code>, exclude README/INDEX/CONTRIBUTING, hooks need
+                <code>bin/count-hooks.sh</code>). Two implementations drift.</td></tr>
+        <tr><td><code>shared-data.ts</code> TOTALS</td><td><span class="pill no">no</span></td>
+            <td class="lede" style="margin:0">Right numbers, but it is TypeScript and this is a plain
+                <code>.mjs</code> script. Reading it means regexing a generated TS file.</td></tr>
+        <tr><td>the changelog</td><td><span class="pill bad">no</span></td>
+            <td class="lede" style="margin:0">The original approach. Release-please never writes a
+                count delta, which is the entire bug.</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>The fallback that was deleted, not ported</h2>
+    <p class="lede"><code>agents</code> looked correct the whole time. It was luck.</p>
+    <pre>// removed in this PR
+const allAgentMentions = [...fullText.matchAll(/(\d+)\s+agents/g)];
+// ...count frequency, take the most frequent value >= 20
+landscape.statsBefore.agents = count;   // guessed a CURRENT total
+landscape.statsAfter.agents  = count;   // from HISTORICAL prose</pre>
+    <p class="lede" style="margin:12px 0 0">It scanned the whole changelog and picked the most common
+    "N agents" mention. It returned 36, which is right, but only because the agent count has been
+    stable for months. One release that changed the count would have produced a stale number with no
+    signal that anything was wrong.</p>
+  </div>
+</section>
+
+<section class="panel" id="p2" hidden>
+  <div class="warn"><b>The risk.</b> The announce payload carried no account selector, so the
+  receiving platform fell back to its own default posting identity. An automated release rail must
+  publish under a dedicated bot account, never a maintainer's personal one.</div>
+
+  <div class="card">
+    <h2>Payload diff</h2>
+    <div class="ctl">
+      <button class="t" id="aBefore" aria-pressed="true">before</button>
+      <button class="t" id="aAfter"  aria-pressed="false">after</button>
+    </div>
+    <pre id="pBefore">{
+  "repo": "yonatangross/orchestkit",
+  "version": "10.0.0",
+  "release_url": "https://github.com/…",
+  "notes_markdown": "…",
+  "highlights": [],
+  "channels": ["twitter", "devto", "hashnode", "substack", "threads"],
+  "dry_run": false
+}</pre>
+    <pre id="pAfter" hidden>{
+  "repo": "yonatangross/orchestkit",
+  "version": "10.0.0",
+  "release_url": "https://github.com/…",
+  "notes_markdown": "…",
+  "highlights": [],
+  "channels": ["twitter", "devto", "hashnode", "substack", "threads"],
+  "account": "yonyon2ai",
+  "dry_run": false
+}</pre>
+    <p class="lede" style="margin:12px 0 0">The field is <b>inert</b> until the platform reads it — an
+    unknown key is ignored server-side. Shipping this half first records the intent and makes the
+    platform change a one-sided edit.</p>
+  </div>
+
+  <div class="card">
+    <h2>Why state it rather than inherit it</h2>
+    <table>
+      <thead><tr><th style="width:190px">Property</th><th>Rationale</th></tr></thead>
+      <tbody>
+        <tr><td>explicit, not inherited</td>
+            <td class="lede" style="margin:0">A default that lives in the receiver's credential
+                configuration is invisible from this repo. Naming the identity in the payload makes the
+                intent reviewable in the diff.</td></tr>
+        <tr><td>fail loud, not soft</td>
+            <td class="lede" style="margin:0">An unknown account value should be rejected rather than
+                silently falling back. A silent fallback on this particular field publishes under the
+                wrong identity.</td></tr>
+        <tr><td>overridable</td>
+            <td class="lede" style="margin:0"><code>ANNOUNCE_ACCOUNT</code> is an env var, so a
+                different caller can select a different identity without a code change.</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="panel" id="p3" hidden>
+  <div class="good"><b>This PR changes nothing about the cadence gate.</b> The instinct on "why has
+  this never fired in 33 releases" is to open it. The evidence says do not.</div>
+
+  <div class="card">
+    <h2>What the latest prerelease would actually have announced</h2>
+    <p class="lede">Composed locally from the real release. This is the complete announceable content.</p>
+    <pre>highlights: 1
+  [changed] "mcp: drop the last ork-elicit leftover
+             from the esbuild header"
+
+notes_markdown: 381 chars of release-please output
+  compare links, commit SHAs, issue refs</pre>
+    <table style="margin-top:16px">
+      <thead><tr><th style="width:260px">Against the observed formula</th><th></th></tr></thead>
+      <tbody>
+        <tr><td>one capability, pain-first</td><td><span class="pill bad">no</span>
+            <span class="lede" style="margin:0">a leftover removal, phrased as internal jargon</span></td></tr>
+        <tr><td>a number that reframes</td><td><span class="pill bad">no</span>
+            <span class="lede" style="margin:0">no number at all</span></td></tr>
+        <tr><td>means something to a reader</td><td><span class="pill bad">no</span>
+            <span class="lede" style="margin:0">"ork-elicit leftover" is meaningless outside this repo</span></td></tr>
+        <tr><td>worth 1 of 33 posts</td><td><span class="pill bad">no</span>
+            <span class="lede" style="margin:0">33 of these would train followers to ignore the feed</span></td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2>The gate, verbatim</h2>
+    <pre>if [ "$EVENT_NAME" = "release" ] &amp;&amp; semver_is_prerelease "$VERSION"; then
+  skip=true
+  echo "::notice::$VERSION is a prerelease — not announcing."</pre>
+    <p class="lede" style="margin:12px 0 0">33 alphas, 33 green runs, 0 drafts. The workflow reports
+    success because skipping <em>is</em> the correct outcome. <code>workflow_dispatch</code> bypasses
+    it, so a manual dry run still exercises the whole path. The first real announce is the v10.0.0
+    GA cut.</p>
+  </div>
+</section>
+
+</main>
+<script>
+// No innerHTML anywhere in this file. Every element above is static markup;
+// this script only flips `hidden` and aria state. That keeps the page free of
+// dynamic-HTML sinks entirely rather than sanitising them one by one.
+(function () {
+  var tabs = document.querySelectorAll('.tab');
+  var panels = document.querySelectorAll('.panel');
+  for (var i = 0; i < tabs.length; i++) {
+    tabs[i].addEventListener('click', function (ev) {
+      var target = ev.currentTarget.getAttribute('data-p');
+      for (var a = 0; a < tabs.length; a++) {
+        tabs[a].setAttribute('aria-selected', String(tabs[a] === ev.currentTarget));
+      }
+      for (var b = 0; b < panels.length; b++) {
+        panels[b].hidden = panels[b].id !== target;
+      }
+    });
+  }
+
+  function pair(btnA, btnB, viewA, viewB) {
+    function show(first) {
+      document.getElementById(viewA).hidden = !first;
+      document.getElementById(viewB).hidden = first;
+      document.getElementById(btnA).setAttribute('aria-pressed', String(first));
+      document.getElementById(btnB).setAttribute('aria-pressed', String(!first));
+    }
+    document.getElementById(btnA).addEventListener('click', function () { show(true); });
+    document.getElementById(btnB).addEventListener('click', function () { show(false); });
+  }
+
+  pair('bBefore', 'bAfter', 'sBefore', 'sAfter');
+  pair('aBefore', 'aAfter', 'pBefore', 'pAfter');
+})();
+</script></body></html>

--- a/scripts/announce-release.mjs
+++ b/scripts/announce-release.mjs
@@ -16,6 +16,9 @@
  *                     — LinkedIn is intentionally excluded: it is a curated,
  *                     hand-written channel, never auto-drafted. Instagram joins
  *                     once Meta Business Verification clears.
+ *   ANNOUNCE_ACCOUNT  which social identity should own these drafts
+ *                     (default "yonyon2ai" — the project's automation account).
+ *                     See the note below on why this field exists.
  *   HQ_API_URL        platform API base                       [enables live POST]
  *   HQ_API_TOKEN      platform API_STATIC_TOKEN               [enables live POST]
  *   DRY_RUN           "true" to compose without posting
@@ -38,6 +41,7 @@ const {
   RELEASE_NOTES = "",
   REPO = "yonatangross/orchestkit",
   ANNOUNCE_CHANNELS = "twitter,devto,hashnode,substack,threads",
+  ANNOUNCE_ACCOUNT = "yonyon2ai",
   HQ_API_URL,
   HQ_API_TOKEN,
   DRY_RUN = "false",
@@ -80,6 +84,17 @@ try {
   console.error(`[announce-release] changelog parse skipped: ${e.message}`);
 }
 
+// `account` names the social identity that should own these drafts.
+//
+// Without it, the receiving platform selects a posting identity from its own
+// default credentials, which is not necessarily the automation account. An
+// automated release rail must publish under a dedicated bot identity, never a
+// maintainer's personal one, so the choice is stated explicitly here rather
+// than inherited.
+//
+// This field is INERT until the platform adapter reads it; an unknown key is
+// ignored server-side. Shipping our half first means the contract is in place
+// and the intent is recorded, so the platform change is a one-sided edit.
 const payload = {
   repo: REPO,
   version: RELEASE_VERSION,
@@ -87,6 +102,7 @@ const payload = {
   notes_markdown: RELEASE_NOTES.slice(0, 20000),
   highlights,
   channels: ANNOUNCE_CHANNELS.split(",").map((s) => s.trim()).filter(Boolean),
+  account: ANNOUNCE_ACCOUNT,
   dry_run: dryRun,
 };
 
@@ -100,7 +116,7 @@ if (dryRun || !haveCreds) {
     );
   }
   console.log(JSON.stringify({ mode: "dry-run", payload }, null, 2));
-  summary(`### 📣 Release announce (dry-run)\nChannels: \`${payload.channels.join(", ")}\` · highlights: ${highlights.length}`);
+  summary(`### 📣 Release announce (dry-run)\nAccount: \`@${payload.account}\` · channels: \`${payload.channels.join(", ")}\` · highlights: ${highlights.length}`);
   summary(haveCreds ? "" : "> Set `HQ_API_URL` + `HQ_API_TOKEN` repo secrets to post for real.");
   process.exit(0);
 }

--- a/scripts/changelog-to-props.mjs
+++ b/scripts/changelog-to-props.mjs
@@ -18,6 +18,42 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CHANGELOG_PATH = resolve(__dirname, "..", "CHANGELOG.md");
+const MANIFEST_PATH = resolve(__dirname, "..", "manifests", "ork.json");
+
+// ---------- Component counts ----------
+
+/**
+ * Current component counts, read from the ork manifest description — the same
+ * string `bin/validate-counts.sh` asserts against the filesystem, so if CI is
+ * green these numbers are correct by construction.
+ *
+ * Why not the changelog: statsBefore/statsAfter used to default to {0,0,0} and
+ * were only ever populated by a `Skill count: 197 → 199` regex that
+ * release-please changelogs never emit. Every release since has rendered
+ * "0 skills, 0 hooks" into the announce payload AND the release videos
+ * (release-video.yml feeds on this script). `agents` looked right only by
+ * accident, via a "most frequent N agents" scan of the whole changelog.
+ *
+ * Returns nulls (never zeros) if the manifest can't be read, so a caller can
+ * tell "unknown" from "genuinely zero".
+ */
+function readDeclaredCounts() {
+  try {
+    const { description = "" } = JSON.parse(readFileSync(MANIFEST_PATH, "utf8"));
+    const grab = (re) => {
+      const m = description.match(re);
+      return m ? parseInt(m[1], 10) : null;
+    };
+    return {
+      skills: grab(/(\d+)\s+skills/i),
+      agents: grab(/(\d+)\s+agents/i),
+      hooks: grab(/(\d+)\s+(?:TypeScript\s+)?hooks/i),
+    };
+  } catch (e) {
+    console.error(`[changelog-to-props] manifest counts unavailable: ${e.message}`);
+    return { skills: null, agents: null, hooks: null };
+  }
+}
 
 // ---------- Parse ----------
 
@@ -190,12 +226,18 @@ function buildProps(parsed) {
   const landscapeHighlights = parsed.highlights.slice(0, 5);
   const squareHighlights = parsed.highlights.slice(0, 3);
 
+  // Baseline is the CURRENT declared count, not zero. A release rarely states a
+  // delta, so before == after by default and the composition renders a true
+  // total instead of "0 skills". An explicit `skills: 105 → 107` in the
+  // changelog still wins below.
+  const counts = readDeclaredCounts();
+
   const landscape = {
     version: parsed.version,
     date: formatDate(parsed.date),
     highlights: landscapeHighlights,
-    statsBefore: { skills: 0, agents: 0, hooks: 0 },
-    statsAfter: { skills: 0, agents: 0, hooks: 0 },
+    statsBefore: { ...counts },
+    statsAfter: { ...counts },
     ctaCommand: "/plugin install ork@latest",
     accentColor: "#2A9D8F",
   };
@@ -230,25 +272,10 @@ function buildProps(parsed) {
   if (agentMatch) {
     landscape.statsBefore.agents = parseInt(agentMatch[1]);
     landscape.statsAfter.agents = parseInt(agentMatch[2]);
-  } else {
-    // Scan full changelog for "N agents" and take the most common large value
-    const fullText = parsed.fullContent;
-    const allAgentMentions = [...fullText.matchAll(/(\d+)\s+agents/g)];
-    if (allAgentMentions.length > 0) {
-      // Count frequency of each value, pick the most frequent (likely the total)
-      const freq = {};
-      for (const m of allAgentMentions) {
-        const n = parseInt(m[1]);
-        if (n >= 20) freq[n] = (freq[n] || 0) + 1; // Filter out small subsets
-      }
-      const entries = Object.entries(freq);
-      if (entries.length > 0) {
-        entries.sort((a, b) => b[1] - a[1]); // Most frequent first
-        const count = parseInt(entries[0][0]);
-        landscape.statsBefore.agents = count;
-        landscape.statsAfter.agents = count;
-      }
-    }
+    // The old `else` branch here scanned the WHOLE changelog for "N agents" and
+    // took the most frequent value >= 20. It is deleted, not ported: it guessed
+    // a current total from historical prose, and only looked right because the
+    // agent count has been stable. readDeclaredCounts() is the real source.
   }
 
   // Copy parsed stats to square

--- a/tests/unit/test-changelog-parser.sh
+++ b/tests/unit/test-changelog-parser.sh
@@ -124,6 +124,81 @@ else
   pass "missing version produces non-zero exit"
 fi
 
+# ─── Test 4: component stats are real, never zero ─────────────────
+# Regression guard. statsBefore/statsAfter used to default to {0,0,0} and were
+# only filled by a "Skill count: 197 → 199" regex that release-please never
+# emits, so every release rendered "0 skills, 0 hooks" into both the announce
+# payload and the release videos (release-video.yml feeds on this script).
+# Counts now come from the ork manifest description, which bin/validate-counts.sh
+# already asserts against the filesystem.
+#
+# Process substitution, not here-strings: bash 5.3 deadlocks on here-strings
+# that pipe back a payload over PIPE_BUF (ork#3348). stderr is NOT swallowed —
+# a parser crash must fail loudly, not read as "counts are zero".
+#
+# `printf '%s\n'`, never `printf '%s'`: without the newline `read` hits EOF and
+# returns 1, which under `set -e` kills the suite mid-run and prints no summary.
+#
+# NOTE: this block runs while the fixture CHANGELOG is swapped in, so $LATEST is
+# a fixture version. That is deliberate — the counts must come from the manifest
+# regardless of what the changelog says, which is exactly the regression.
+LATEST=$(node -e '
+const fs=require("fs");
+const m=fs.readFileSync(process.argv[1],"utf8").match(/^## \[([0-9][^\]]*)\]/m);
+process.stdout.write(m?m[1]:"");
+' "$PROJECT_ROOT/CHANGELOG.md")
+
+DECLARED=$(node -e '
+const d=require(process.argv[1]).description||"";
+const g=(re)=>{const m=d.match(re);return m?m[1]:"0"};
+process.stdout.write([
+  g(/(\d+)\s+skills/i), g(/(\d+)\s+agents/i), g(/(\d+)\s+(?:TypeScript\s+)?hooks/i),
+].join(" "));
+' "$PROJECT_ROOT/manifests/ork.json")
+read -r DECL_SKILLS DECL_AGENTS DECL_HOOKS < <(printf '%s\n' "$DECLARED")
+
+for fmt in --landscape --square; do
+  props=$(node "$PARSER" "$LATEST" "$fmt")
+  stats=$(printf '%s' "$props" | node -e '
+let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+  const a=JSON.parse(s).statsAfter||{};
+  process.stdout.write([a.skills,a.agents,a.hooks].join(" "));
+});')
+  read -r GOT_SKILLS GOT_AGENTS GOT_HOOKS < <(printf '%s\n' "$stats")
+
+  if [[ -z "$GOT_SKILLS" || "$GOT_SKILLS" == "0" || "$GOT_HOOKS" == "0" ]]; then
+    fail "$fmt statsAfter zeroed: skills=$GOT_SKILLS hooks=$GOT_HOOKS"
+  else
+    pass "$fmt statsAfter counts are non-zero"
+  fi
+
+  if [[ "$GOT_SKILLS" == "$DECL_SKILLS" && "$GOT_AGENTS" == "$DECL_AGENTS" && "$GOT_HOOKS" == "$DECL_HOOKS" ]]; then
+    pass "$fmt statsAfter matches manifest ($DECL_SKILLS/$DECL_AGENTS/$DECL_HOOKS)"
+  else
+    fail "$fmt statsAfter $GOT_SKILLS/$GOT_AGENTS/$GOT_HOOKS != manifest $DECL_SKILLS/$DECL_AGENTS/$DECL_HOOKS"
+  fi
+done
+
+# ─── Test 5: announce payload carries the machine account ─────────
+# The payload had no account field, so the receiving platform fell back to its
+# own default posting identity. An automated release rail must publish under a
+# dedicated bot account, never a maintainer's personal one.
+ANNOUNCE="$PROJECT_ROOT/scripts/announce-release.mjs"
+# stderr is CAPTURED to a file, not discarded: the script legitimately warns
+# "creds unset" there in dry-run, but a real crash must stay readable.
+ANNOUNCE_ERR="$FIXTURE_DIR/announce.err"
+acct=$(RELEASE_VERSION="$LATEST" RELEASE_URL="https://example.invalid/r" \
+  DRY_RUN=true node "$ANNOUNCE" 2>"$ANNOUNCE_ERR" | node -e '
+let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{
+  process.stdout.write(String((JSON.parse(s).payload||{}).account||""));
+});')
+
+if [[ "$acct" == "yonyon2ai" ]]; then
+  pass "announce payload defaults to the automation account"
+else
+  fail "announce payload account is '$acct', expected 'yonyon2ai' (stderr: $(cat "$ANNOUNCE_ERR"))"
+fi
+
 echo ""
 echo "════════════════════════════════════════════════════════════════"
 echo "  Total: $((PASS + FAIL))  |  Passed: ${GREEN}${PASS}${NC}  |  Failed: ${RED}${FAIL}${NC}"


### PR DESCRIPTION
## What

Two defects in the release rail, found by composing the announce payload locally rather than reading the code.

### 1. Component counts rendered as zero

`changelog-to-props.mjs` defaulted `statsBefore`/`statsAfter` to `{0,0,0}` and only populated them from a `Skill count: 197 -> 199` regex that release-please changelogs never emit.

Blast radius is wider than the announce payload: `release-video.yml:83,89` feeds on this same script, so every rendered release video has likely been displaying "0 skills, 0 hooks", including the assets attached to `v10.0.0-alpha.33`.

`agents` looked correct only by accident. A fallback scanned the entire changelog for `N agents` and took the most frequent value over 20, guessing a current total from historical prose. It happened to be right because the agent count has been stable. That fallback is deleted, not ported.

Counts now come from the ork manifest description, which is the same string `bin/validate-counts.sh` already asserts against the filesystem. A green CI makes them correct by construction.

```
before:  {"skills":0,   "agents":36, "hooks":0}
after:   {"skills":105, "agents":36, "hooks":216}
```

An explicit `skills: 105 -> 107` delta in a changelog still wins over the baseline.

### 2. The announce payload named no posting identity

`announce-release.mjs` sent no account selector, so the receiving platform fell back to its own default posting identity. An automated release rail must publish under a dedicated bot account, never a maintainer's personal one.

The payload now carries `account`, defaulted via `ANNOUNCE_ACCOUNT` to the project's automation account. The field is inert until the platform honours it, since an unknown key is ignored server-side. The platform half is tracked separately.

## What this deliberately does NOT change

The prerelease cadence gate stays exactly as it is. The instinct on "why has this never fired in 33 releases" is to open the gate, and the evidence says do not: alpha.33's entire announceable content was *"drop the last ork-elicit leftover from the esbuild header"*. Thirty-three of those would be worse than silence. The gate is the only thing that has kept them off the feed. The first real announce is the v10.0.0 GA cut.

## Verification

| Gate | Result |
|---|---|
| `tests/unit/test-changelog-parser.sh` | 13/13 pass |
| Mutation check | reintroducing the zeroed stats turns 4 assertions red |
| `shellcheck -S warning` | clean |
| `actionlint` | clean |
| `tests/security/run-security-tests.sh` | 19/19 pass |

The regression tests use process substitution with a trailing newline rather than here-strings. Here-strings deadlock on bash 5.3 past PIPE_BUF (#3348), and without the trailing newline `read` returns 1 at EOF, which under `set -e` kills the suite mid-run and prints no summary. That second failure mode bit this PR during authoring and is why the tests are commented the way they are.

Full `npm test --quick` was started but its background task wrote 0 bytes, which is the symptom described in #3263. The gates above were run directly in the foreground instead.

## Interactive Playground

**[Open Playground](https://github.com/yonatangross/orchestkit/blob/fix/release-rail-counts-and-account/docs/fix--release-rail-counts-and-account/release-rail.html)** — `docs/fix--release-rail-counts-and-account/release-rail.html`

Three tabs, every number produced locally rather than retyped:

- **The stats bug** — toggle between the regex-only path and the manifest-derived path, plus why the manifest beat a filesystem walk, and the deleted "most frequent N agents" fallback.
- **The account field** — the payload diff, and why the identity is stated rather than inherited.
- **Why the gate stays** — what the latest prerelease would actually have announced, scored against the observed formula.

The playground is static markup; its script only toggles `hidden` and aria state, so the page contains no dynamic-HTML sinks.
