### PR TITLE
ci(playground): exempt fork PRs from the playground gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.head_ref }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          # Expression, not string interpolation of attacker-controlled text:
+          # this evaluates to the literal true/false before the shell sees it.
+          IS_FORK: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
         run: |
           set -uo pipefail
 
@@ -220,6 +223,28 @@ jobs:
           # Automated branches, kept as a cheap fast path.
           if [[ "$HEAD_REF" =~ ^(dependabot/|release-please|renovate/|chore/cc-snapshot-|ci/) ]]; then
             skip "Skipping playground check for automated branch ($HEAD_REF)"
+          fi
+
+          # Fork PRs. This gate exists to keep OUR feature work documented in
+          # the Lab, which presumes knowledge an outside contributor does not
+          # have and cannot get from CONTRIBUTING: the docs/<branch-slug>/
+          # naming rule, the no-third-party-render-proxy rule, and the
+          # lab-manifest publishing step. Being REQUIRED, it hard-blocked such
+          # PRs with no path forward.
+          #
+          # Hit twice for real. #3193 was a one-line docs diff, and the fix then
+          # was to widen INERT by path; that does not generalise, because the
+          # next case (#3495) was a two-line change to a Python example under
+          # src/skills/, a path that legitimately IS user-facing. The problem is
+          # not which files were touched, it is that we are taxing a stranger
+          # for an artifact only a maintainer knows how to produce.
+          #
+          # So: exempt cross-repository PRs and let the maintainer add the
+          # playground when landing the change. This cannot be used to dodge the
+          # gate on our own work, because a branch pushed to this repo is never
+          # cross-repository.
+          if [[ "$IS_FORK" == "true" ]]; then
+            skip "Skipping playground check for fork PR ($PR_AUTHOR); maintainer adds the playground at merge time"
           fi
 
           # Path-based inertness.


### PR DESCRIPTION
## Summary

Exempts cross-repository (fork) PRs from the required `PR Playground` check.

Closes #3502.

## Why

The gate exists to keep our own feature work documented in the Lab. Producing a
conforming playground requires knowledge an outside contributor has no way to
acquire from `CONTRIBUTING.md`:

- the directory must be `docs/<branch-name-with-slashes-as-dashes>/`
- the PR body must reference it, and must not use a third-party render proxy
- publishing for real means editing `docs/site/lab-manifest.json` and running
  the lab codegen

Because the check is required, an outside contributor hits a red gate with no
path forward.

## Why widening INERT again was not the answer

This has fired twice:

- #3193, a one-line docs diff. Fixed then by adding paths to the INERT
  allowlist.
- #3495, a two-line change to a Python example under `src/skills/`.

The second case is the reason the first fix did not generalise. `src/skills/**`
legitimately IS user-facing, so it cannot go on an inert-path allowlist. The
real signal is not which files were touched, it is that we were taxing a
stranger for an artifact only a maintainer knows how to produce.

## What changed

One skip clause in the `Decide whether a playground is required` step, placed
after the existing bot and automated-branch skips:

```bash
if [[ "$IS_FORK" == "true" ]]; then
  skip "Skipping playground check for fork PR ($PR_AUTHOR); maintainer adds the playground at merge time"
fi
```

`IS_FORK` is passed via `env` as an expression that evaluates to a literal
`true`/`false` before the shell sees it, so no attacker-controlled string is
interpolated into `run:`.

## This cannot be used to dodge the gate on our own work

`IS_FORK` is `head.repo.full_name != repository`. A branch pushed to this
repository is never cross-repository, so our own PRs always fall through to the
existing path check.

## Test plan

Replayed the extracted skip chain against the real conditions:

| case | result |
| --- | --- |
| fork, `src/skills` change (the #3495 case) | SKIP |
| our own branch, `src/skills` change | REQUIRED |
| bot author | SKIP |
| automated branch | SKIP |
| fork on a `ci/`-looking branch | SKIP |

- [x] `ci.yml` still parses as YAML, `playground-check` intact
- [x] Behaviour verified per the table above
- [ ] CI green

Touches only `.github/`, which is on the INERT list, so this PR does not
require a playground itself.
