### PR TITLE
ci(probe): a failed probe is UNKNOWN, not "every pin is current"

### DIFF
--- a/.github/workflows/labs-version-probe.yml
+++ b/.github/workflows/labs-version-probe.yml
@@ -57,11 +57,22 @@ jobs:
       - name: Probe upstream registries
         run: |
           set -uo pipefail
-          node scripts/check-labs-versions.mjs > /tmp/drift.txt 2>&1 || true
+          # Capture the exit code. `|| true` used to discard it, and stderr is
+          # redirected INTO the file the grep reads, so a stack trace or a fetch
+          # timeout matched neither pattern and fell through to the else branch —
+          # printing "Every pin and declared floor is current" for a probe that
+          # never completed. Could-not-observe is its own outcome, never "clean".
+          node scripts/check-labs-versions.mjs > /tmp/drift.txt 2>&1
+          probe_rc=$?
           {
             echo '## Upstream version probe'
             echo ''
-            if grep -qE '^DRIFT|behind upstream' /tmp/drift.txt; then
+            if [ "$probe_rc" -ne 0 ]; then
+              echo "**Probe FAILED (exit $probe_rc). Drift state is UNKNOWN, not clean.**"
+              echo ''
+              echo 'Nothing was verified this run. Do not read this as "pins are current" —'
+              echo 'read the output below, fix the probe, and re-dispatch.'
+            elif grep -qE '^DRIFT|behind upstream' /tmp/drift.txt; then
               echo 'Drift detected. Dispatch **Upstream Version Watch** to open the bump PR.'
             else
               echo 'No drift. Every pin and declared floor is current.'
@@ -71,5 +82,11 @@ jobs:
             cat /tmp/drift.txt
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          # Never fail the nightly run on drift: a red cron nobody can action is a red
+          # Never fail the nightly run on DRIFT: a red cron nobody can action is a red
           # cron people mute. The step summary is the deliverable.
+          # A FAILED PROBE is different — it means the check did not run, so it goes
+          # red. That is actionable (fix the probe) and cannot be confused with clean.
+          if [ "$probe_rc" -ne 0 ]; then
+            echo "::error::upstream version probe failed (exit $probe_rc) — drift state unknown"
+            exit "$probe_rc"
+          fi


### PR DESCRIPTION
Closes #3526 (defect 1 of 2 — the reporting-surface half stays open there for a design call).

## The bug

`labs-version-probe.yml` discarded the probe's exit code with `|| true`, while redirecting stderr **into the file the grep reads**:

```bash
node scripts/check-labs-versions.mjs > /tmp/drift.txt 2>&1 || true
...
if grep -qE '^DRIFT|behind upstream' /tmp/drift.txt; then ... else
  echo 'No drift. Every pin and declared floor is current.'
```

So a stack trace or a fetch timeout matched neither pattern, fell through to `else`, and asserted every pin was current. **A probe that never completed was byte-identical in outcome to a clean one.**

The network case needs no code change to trigger — it's the ordinary failure path for a job that hits npm and GitHub every night.

## The fix

Three outcomes instead of two, with could-not-observe never folded into clean. A failed probe also exits non-zero: unlike drift — where the existing comment is right that a red cron nobody can action gets muted — a *broken probe* is actionable, and red is the only state that can't be mistaken for a pass.

## Verification

The harness extracts the shipped `run:` block out of the YAML and drives it with a stubbed `node` on `PATH`, so it tests the real text rather than a hand-copy of it. Both controls, plus both formerly-lying cases:

| case | step exit | summary line |
|---|---|---|
| real drift (rc 0) | 0 | `Drift detected. Dispatch Upstream Version Watch…` ✅ control |
| genuinely clean (rc 0) | 0 | `No drift. Every pin and declared floor is current.` ✅ control |
| probe crashed (rc 1) | **1** | `Probe FAILED (exit 1). Drift state is UNKNOWN, not clean.` |
| network timeout (rc 7) | **7** | `Probe FAILED (exit 7). Drift state is UNKNOWN, not clean.` |

The two controls matter as much as the two fixes: they show detection and the genuine-clean path are unchanged, so this isn't a gate that now shouts at everything.

## Why it was worth finding

Probes ran **green on 2026-08-15, 08-16, and 08-17** while `src/skills/portless/references/upstream.md` documented portless's proxy default as *"port 1355, no sudo needed"* — five minor versions stale, since the CLI moved to HTTPS on 443 in 0.13. That stale doc then cost a session real time: it made a port in a `.localhost` URL read as expected rather than broken (fixed in #3525).

## Scope

Workflow-only, no user-visible surface — hence the `ci/` prefix the playground gate exempts. No change to the drift path's behaviour, no schedule change, no new permissions.
