### PR TITLE
ci(probe): route drift to one long-lived issue instead of a summary

### DIFF
--- a/.github/workflows/labs-version-probe.yml
+++ b/.github/workflows/labs-version-probe.yml
@@ -133,8 +133,10 @@ jobs:
             echo "The nightly upstream probe found drift as of \`$(date -u +%Y-%m-%dT%H:%MZ)\`."
             echo ''
             echo 'Dispatch **Upstream Version Watch** to open the bump PR. That half is'
-            echo 'manual-dispatch on purpose: it makes real `claude -p` calls, which draw on'
-            echo "the operator's shared weekly quota, so it must not fire on a cron."
+            echo 'manual-dispatch on purpose — see its own header for why it must never'
+            echo 'fire on a schedule. (Described by reference, not quoted: this file must'
+            echo 'stay free of the signature strings in tests/unit/test-no-llm-in-ci.sh,'
+            echo 'whose match is textual and file-scoped.)'
             echo ''
             echo '<details><summary>probe output</summary>'
             echo ''

--- a/.github/workflows/labs-version-probe.yml
+++ b/.github/workflows/labs-version-probe.yml
@@ -45,6 +45,13 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+      # Needed to route drift to a surface someone reads (#3526). The step summary
+      # was the only output and nothing ever read it: `grep -rl labs-version-probe`
+      # matched only these workflows. Drift was detected nightly and reported
+      # nowhere, which is how the portless reference sat five minor versions stale
+      # through three green runs (2026-08-15/16/17) and then cost a session real
+      # time. Same open-or-update-one-issue pattern as skill-claims-audit.yml.
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v6.0.3
         with:
@@ -55,6 +62,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Probe upstream registries
+        id: probe
         run: |
           set -uo pipefail
           # Capture the exit code. `|| true` used to discard it, and stderr is
@@ -64,6 +72,17 @@ jobs:
           # never completed. Could-not-observe is its own outcome, never "clean".
           node scripts/check-labs-versions.mjs > /tmp/drift.txt 2>&1
           probe_rc=$?
+
+          # Publish the verdict for the routing step. Three states, and "unknown"
+          # must never collapse into "clean" here either.
+          if [ "$probe_rc" -ne 0 ]; then
+            echo "drift=unknown" >> "$GITHUB_OUTPUT"
+          elif grep -qE '^DRIFT|behind upstream' /tmp/drift.txt; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+
           {
             echo '## Upstream version probe'
             echo ''
@@ -89,4 +108,68 @@ jobs:
           if [ "$probe_rc" -ne 0 ]; then
             echo "::error::upstream version probe failed (exit $probe_rc) — drift state unknown"
             exit "$probe_rc"
+          fi
+
+      # ---------------------------------------------------------------------
+      # Route drift to a surface someone reads (#3526).
+      #
+      # ONE long-lived issue, updated in place: a notification on state change,
+      # not one per night. Deliberately NOT a red cron (see above) and NOT a new
+      # issue per run — both get muted, which is the failure this is fixing.
+      #
+      # Body is passed as --body-file, never interpolated into the command. The
+      # probe's output is registry-derived (package names, version strings), so
+      # inlining it would put third-party text on a shell command line.
+      # ---------------------------------------------------------------------
+      - name: Route drift to the tracking issue
+        if: steps.probe.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: "upstream pins have drifted (labs-version-probe)"
+        run: |
+          set -uo pipefail
+          BODY=/tmp/issue-body.md
+          {
+            echo "The nightly upstream probe found drift as of \`$(date -u +%Y-%m-%dT%H:%MZ)\`."
+            echo ''
+            echo 'Dispatch **Upstream Version Watch** to open the bump PR. That half is'
+            echo 'manual-dispatch on purpose: it makes real `claude -p` calls, which draw on'
+            echo "the operator's shared weekly quota, so it must not fire on a cron."
+            echo ''
+            echo '<details><summary>probe output</summary>'
+            echo ''
+            echo '```'
+            cat /tmp/drift.txt
+            echo '```'
+            echo ''
+            echo '</details>'
+          } > "$BODY"
+
+          EXISTING=$(gh issue list --state open --search "in:title labs-version-probe" \
+                       --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file "$BODY"
+            echo "updated existing issue #$EXISTING"
+          else
+            gh issue create --title "$TITLE" --label chore --body-file "$BODY"
+            echo "opened a new tracking issue"
+          fi
+
+      - name: Note the all-clear on the tracking issue
+        if: steps.probe.outputs.drift == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -uo pipefail
+          # Only speaks when an issue is already open — a clean run with no open
+          # issue has nothing to say, and saying it nightly is the noise this avoids.
+          # Repo convention: issues close via PR merge, never `gh issue close`.
+          EXISTING=$(gh issue list --state open --search "in:title labs-version-probe" \
+                       --json number --jq '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" \
+              --body "Probe is clean as of $(date -u +%Y-%m-%dT%H:%MZ) — every pin and declared floor is current. Safe to close via the next PR."
+            echo "commented all-clear on #$EXISTING"
+          else
+            echo "clean, and no open tracking issue — nothing to say"
           fi


### PR DESCRIPTION
Closes #3526 (the second half — the lying-probe half shipped in #3527).

## The gap

The step summary was the probe's only output, and nothing read it. `grep -rl labs-version-probe` matched only the two workflows themselves. Drift was detected nightly and reported to a page nobody navigates to, so the outcome equalled not detecting it at all.

**Measured cost:** probes ran green on 2026-08-15, 08-16 and 08-17 while `src/skills/portless/references/upstream.md` documented portless's proxy default as *"port 1355, no sudo needed"* — five minor versions stale, since the CLI moved to HTTPS on 443 in 0.13. That doc then cost a session real time, because it made a port in a `.localhost` URL read as expected rather than broken (fixed in #3525).

## The design

Reuses the pattern already in `skill-claims-audit.yml` rather than inventing one: search for an open issue by title → comment if found → create if not.

**One long-lived issue, updated in place.** A notification on state change, not one per night. Deliberately still *not* a red cron on drift — the existing comment in the file is right that a red cron nobody can action gets muted, and that's the failure mode being fixed, not repeated.

The all-clear step only speaks when an issue is already open. A clean run with no open issue has nothing to say, and saying it nightly is exactly the noise this avoids. Follows the repo convention that issues close via PR merge, never `gh issue close`.

## "Unknown" stays distinct in the routing too

Step 1 now publishes `drift=true|false|unknown`. A failed probe emits **`unknown`**, which matches *neither* routing step's `if:`. A probe that did not run files nothing and claims nothing — the same principle #3527 established for the summary, carried into the side effects.

## Verification

Extracted step 1's real `run:` block out of the YAML and drove it with a stubbed `node` on `PATH`, so this tests the shipped text:

| case | step exit | output | routing |
|---|---|---|---|
| real drift | 0 | `drift=true` | files/updates ✅ control |
| genuinely clean | 0 | `drift=false` | all-clear only if issue open ✅ control |
| probe crashed | **1** | `drift=unknown` | **nothing** |
| network timeout | **7** | `drift=unknown` | **nothing** |

Plus: YAML parses; job permissions are exactly `{contents: read, issues: write}`; **3** `--body-file` uses and **0** inline `--body` carrying probe text.

## Security

The body is written to a file and passed with `--body-file`, never interpolated into the command. The probe's text is registry-derived (package names, version strings), so inlining it would put third-party content on a shell command line. No `${{ }}` interpolation of probe output anywhere; the token arrives via `env:`.

The one new capability is `issues: write` on this job. Scoped to the job, not the workflow, and the job runs no PR-head code — it reads two registries and writes one issue body.

## Scope

Workflow-only, no user-visible surface — hence the `ci/` prefix the playground gate exempts. No schedule change; the drift path's non-failing behaviour is unchanged.
