### PR TITLE
fix(ci): bound and skip system dep installs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -30,23 +30,14 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Install system dependencies (Linux)
-      if: runner.os == 'Linux'
+    # jq and rsync are preinstalled on the hosted runner images, so the normal
+    # path here does not touch a package manager at all. When an install is
+    # genuinely needed the helper bounds it with `timeout` and names the cause
+    # on failure. `timeout-minutes:` cannot be used on a composite-action step,
+    # it is silently ignored (actions/runner#1979). See issue #3545.
+    - name: Install system dependencies
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y jq rsync
-
-    - name: Install system dependencies (macOS)
-      if: runner.os == 'macOS'
-      shell: bash
-      run: brew install jq rsync
-
-    - name: Install system dependencies (Windows)
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        choco install jq rsync -y
-        # Verify tools are available
-        rsync --version || echo "WARNING: rsync not found, some operations may fail"
+      run: bash .github/scripts/ensure-system-deps.sh jq rsync
 
     - name: Setup Node.js
       uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6

--- a/.github/scripts/ensure-system-deps.sh
+++ b/.github/scripts/ensure-system-deps.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Ensure system CLI tools are available, without paying for a package-manager
+# round trip when they are already installed.
+#
+# Why this exists (issue #3545): six CI jobs on 2026-08-17/18 burned their
+# entire timeout-minutes cap inside "Setup environment" and never reached a
+# test. The cause was `apt-get update` hanging on an unreachable mirror. jq and
+# rsync ship preinstalled on the ubuntu-latest runner image, so that apt call
+# was pure overhead on every run that did not hang, and a full-cap job loss on
+# the ones that did.
+#
+# Two properties matter here:
+#   1. Skip the package manager entirely when every requested tool is present.
+#   2. When an install is genuinely needed, bound it with `timeout` so a mirror
+#      hang fails in minutes with a named cause instead of at the job cap.
+#
+# `timeout-minutes:` is silently ignored on steps inside a composite action
+# (actions/runner#1979), so the bound has to be the `timeout` command.
+#
+# Usage:
+#   .github/scripts/ensure-system-deps.sh jq rsync
+#
+# Arguments are command names. The command name is assumed to double as the
+# package name, which holds for jq, rsync and ffmpeg.
+#
+# Environment:
+#   SYSTEM_DEPS_TIMEOUT  seconds allowed per package-manager call (default 90).
+#     apt takes two calls (update, then install), so the worst case is roughly
+#     three minutes instead of the 20 to 30 minute job cap. Raise it for a
+#     genuinely heavy package if one ever needs longer.
+
+set -euo pipefail
+
+TIMEOUT_SECS="${SYSTEM_DEPS_TIMEOUT:-90}"
+LOG_PREFIX="ensure-system-deps:"
+
+if [ "$#" -eq 0 ]; then
+    echo "${LOG_PREFIX} no commands requested, nothing to do"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Presence check. The common path exits here without touching apt/brew/choco.
+# ---------------------------------------------------------------------------
+missing=()
+for cmd in "$@"; do
+    if command -v "${cmd}" >/dev/null 2>&1; then
+        echo "${LOG_PREFIX} ${cmd} already present at $(command -v "${cmd}")"
+    else
+        missing+=("${cmd}")
+    fi
+done
+
+if [ "${#missing[@]}" -eq 0 ]; then
+    echo "${LOG_PREFIX} all requested tools present, skipping package manager"
+    exit 0
+fi
+
+echo "${LOG_PREFIX} missing tools: ${missing[*]}"
+
+# ---------------------------------------------------------------------------
+# 2. Resolve a watchdog. GNU coreutils `timeout` is present on Linux runners.
+#    Bare macOS ships neither timeout nor gtimeout, so there the install runs
+#    unbounded, which is exactly the status quo rather than a regression.
+# ---------------------------------------------------------------------------
+bound=()
+if command -v timeout >/dev/null 2>&1; then
+    bound=(timeout "${TIMEOUT_SECS}")
+elif command -v gtimeout >/dev/null 2>&1; then
+    bound=(gtimeout "${TIMEOUT_SECS}")
+else
+    echo "${LOG_PREFIX} WARNING no timeout command found, running install unbounded"
+fi
+
+run_bounded() {
+    local label="$1"
+    shift
+    local status=0
+    "${bound[@]+"${bound[@]}"}" "$@" || status=$?
+
+    if [ "${status}" -eq 124 ]; then
+        echo "${LOG_PREFIX} FAILED: ${label} exceeded ${TIMEOUT_SECS}s" >&2
+        echo "${LOG_PREFIX} the package mirror is unreachable or throttled." >&2
+        echo "${LOG_PREFIX} This is an infrastructure failure in setup, not a test failure. Re-run the job." >&2
+        return 1
+    fi
+
+    if [ "${status}" -ne 0 ]; then
+        echo "${LOG_PREFIX} FAILED: ${label} exited ${status}" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# 3. Install only what is missing, through whichever manager this runner has.
+# ---------------------------------------------------------------------------
+if command -v apt-get >/dev/null 2>&1; then
+    run_bounded "apt-get update" sudo apt-get update -qq
+    run_bounded "apt-get install" sudo apt-get install -y "${missing[@]}"
+elif command -v brew >/dev/null 2>&1; then
+    run_bounded "brew install" brew install "${missing[@]}"
+elif command -v choco >/dev/null 2>&1; then
+    run_bounded "choco install" choco install "${missing[@]}" -y
+else
+    echo "${LOG_PREFIX} FAILED: no supported package manager found (apt-get, brew, choco)" >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Never let a silent no-op install pass. A later step dying with
+#    "jq: command not found" is worse than failing here with the reason.
+# ---------------------------------------------------------------------------
+still_missing=()
+for cmd in "${missing[@]}"; do
+    command -v "${cmd}" >/dev/null 2>&1 || still_missing+=("${cmd}")
+done
+
+if [ "${#still_missing[@]}" -ne 0 ]; then
+    echo "${LOG_PREFIX} FAILED: still missing after install: ${still_missing[*]}" >&2
+    exit 1
+fi
+
+echo "${LOG_PREFIX} installed ${missing[*]}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,7 @@ jobs:
           persist-credentials: false
 
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y jq rsync
+        run: bash .github/scripts/ensure-system-deps.sh jq rsync
 
       - name: Build plugins
         run: bash scripts/build-plugins.sh
@@ -75,7 +73,7 @@ jobs:
           persist-credentials: false
 
       - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
+        run: bash .github/scripts/ensure-system-deps.sh jq
 
       - name: Build plugins (for validation)
         run: bash scripts/build-plugins.sh

--- a/.github/workflows/release-video.yml
+++ b/.github/workflows/release-video.yml
@@ -125,7 +125,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        run: bash .github/scripts/ensure-system-deps.sh ffmpeg
 
       - name: Install demo dependencies
         working-directory: orchestkit-demos


### PR DESCRIPTION
Closes #3545.

## The defect

Six CI job timeouts on 2026-08-17/18 all died inside **Setup environment**, before a single test ran, and only at the job's 20/30-minute cap. Two external causes: `sudo apt-get update && sudo apt-get install -y jq rsync` hanging on a slow mirror, and `codeload.github.com` 429s. Each occurrence cost the full cap plus a rerun, and it renders in the checks list as though a test failed, which sends people diagnosing code that never executed.

## The trap this could have shipped as a no-op

The obvious fix is `timeout-minutes:` on the step. **That key is silently ignored on steps inside a composite action** (actions/runner#1979). It would have looked like a fix and changed nothing. The fix therefore uses the `timeout` command inside the run block.

## What changed

New `.github/scripts/ensure-system-deps.sh`, called from `.github/actions/setup/action.yml` (replacing three OS-specific install steps) and from the duplicated apt lines in `build.yml` and `release-video.yml`. Behavior:

1. **Skip entirely when the tools exist.** jq and rsync are preinstalled on hosted runner images, so the normal path never touches a package manager.
2. **Bound each call** (default 90s, `SYSTEM_DEPS_TIMEOUT` overrides) and name the cause on timeout, explicitly saying it is an infrastructure failure in setup rather than a test failure.
3. **Never pass silently.** If an install returns 0 but the tool is still missing, the script fails there rather than letting a later step die with `jq: command not found`.

After this change there is no raw `apt-get` left anywhere in `.github/`.

## Evidence, re-derived independently of the authoring run

Skip path, on this machine:

```
ensure-system-deps: jq already present at /usr/local/bin/jq
ensure-system-deps: rsync already present at /usr/bin/rsync
ensure-system-deps: all requested tools present, skipping package manager
rc=0
```

Bounded-failure path, in a real `ubuntu:24.04` container with a fake `apt-get` that sleeps 600s:

```
== timeout available: /usr/bin/timeout
ensure-system-deps: missing tools: definitelymissingtool
ensure-system-deps: FAILED: apt-get update exceeded 4s
ensure-system-deps: the package mirror is unreachable or throttled.
ensure-system-deps: This is an infrastructure failure in setup, not a test failure. Re-run the job.
EXIT=1 WALL=4s (unbounded would be 600s)
```

Silent-no-op path (install exits 0, installs nothing): fails at the guard with `still missing after install: jq rsync`, exit 1.

Suites: `tests/ci` 2/2 passed, `bin/validate-counts.sh` PASSED (105 skills / 36 agents / 171 hooks). shellcheck clean on the new script; `actionlint` with the flags CI uses exits 0 on both edited workflows.

## Honest limitations

- **macOS runs unbounded.** Bare macOS ships neither `timeout` nor `gtimeout`, so on macOS the install runs unbounded with a printed warning. That is the status quo there, not a new weakness. Verified: my own macOS run of the bounded test did not terminate, which is exactly this.
- **The macOS and Windows branches are currently unreachable in CI.** Every `runs-on` is `ubuntu-latest` except one `windows-latest` in `windows-smoke.yml`, which wires `actions/setup-node` directly and never touches the composite. So those branches cannot be validated by a CI run here.
- **Blast radius correction:** the composite action is used by **3 workflow files across 24 job call sites**, not the "32 workflows" first claimed. That number came from a grep that also matched `actions/setup-node`. Re-verified: `grep -rln "uses: ./.github/actions/setup"` returns 3 files, 24 call sites.
- **`.github/scripts/` is not shellchecked in CI** (the lint glob only scans `src/hooks`), so the new script is covered by local shellcheck only. Widening that glob would likely surface pre-existing findings across `scripts/` and `bin/`, which belongs in its own change.

## Deliberately not done

`build.yml` still does its own narrower setup rather than calling the composite action: the composite also does node setup, plugin build and `ci-setup.sh`, so swapping it in would be a behavior change rather than a dedupe. Routing both through the shared script gets the dedupe without that risk.

No playground: this PR touches only `.github/**`, which the PR Playground gate treats as inert.
