### PR TITLE
fix(ci): bound the second apt-get, the one outside .github/

### DIFF
--- a/bin/ci-setup.sh
+++ b/bin/ci-setup.sh
@@ -25,6 +25,43 @@ log_info() { echo -e "${GREEN}[CI-SETUP]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[CI-SETUP]${NC} $1"; }
 log_error() { echo -e "${RED}[CI-SETUP]${NC} $1"; }
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ============================================================================
+# SYSTEM DEPENDENCIES
+# ============================================================================
+# Every package install routes through .github/scripts/ensure-system-deps.sh.
+# Never call a package manager directly from here.
+#
+# Why (#3557): this script's own `sudo apt-get update -qq` hung for a full job
+# cap on fork PR #3555 -- 15m16s on two jobs, 30m15s on a third, each equal to
+# that job's `timeout-minutes` to the second. The guard that used to sit around
+# it (`if ! sudo apt-get update -qq; then log_warn "continuing anyway"`) could
+# not help: it catches a non-zero EXIT, and a hang never exits.
+#
+# #3550 fixed this exact class, but scoped the sweep to `.github/` -- its commit
+# message states "no raw apt-get call remains in .github/" (4c4c25cb1), which
+# was true. bin/ sits outside that path, so this call site was never in scope
+# and kept the hang alive after the fix shipped. The helper skips the package
+# manager entirely when the tools are already present (jq ships on the hosted
+# runner image) and bounds the call with `timeout` when an install is genuinely
+# needed. tests/ci/test-no-unbounded-package-manager.sh gates the whole surface
+# so the next sweep cannot miss a directory again.
+# ============================================================================
+
+ensure_system_deps() {
+    local helper="$REPO_ROOT/.github/scripts/ensure-system-deps.sh"
+
+    if [[ ! -f "$helper" ]]; then
+        log_error "missing $helper"
+        log_error "refusing to fall back to an unbounded package-manager call (#3557)"
+        exit 1
+    fi
+
+    bash "$helper" "$@"
+}
+
 # ============================================================================
 # MAIN SETUP
 # ============================================================================
@@ -133,13 +170,8 @@ setup_linux() {
         fi
     done
 
-    # Update package lists (Ubuntu official repos only now)
-    log_info "Updating package lists..."
-    if ! sudo apt-get update -qq; then
-        log_warn "apt-get update had issues, continuing anyway..."
-    fi
-
-    # Install required dependencies
+    # Install required dependencies. ensure_system_deps skips apt entirely when
+    # the tools are already present, and bounds the call when they are not.
     log_info "Installing dependencies..."
     local packages=("jq")
 
@@ -147,7 +179,7 @@ setup_linux() {
         packages+=("shellcheck")
     fi
 
-    sudo apt-get install -y -qq "${packages[@]}"
+    ensure_system_deps "${packages[@]}"
 
     log_info "Linux setup complete"
 }
@@ -169,11 +201,13 @@ setup_macos() {
 
     # Install dependencies
     log_info "Installing dependencies via Homebrew..."
-    brew install jq
+    local packages=("jq")
 
     if [[ "$with_shellcheck" == "true" ]]; then
-        brew install shellcheck
+        packages+=("shellcheck")
     fi
+
+    ensure_system_deps "${packages[@]}"
 
     log_info "macOS setup complete"
 }

--- a/docs/fix--3557-ci-setup-apt-bound/timeout-budget.html
+++ b/docs/fix--3557-ci-setup-apt-bound/timeout-budget.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>#3557 — where a hung package mirror spends your CI budget</title>
+<style>
+  :root{
+    --bg:#0d1117; --panel:#161b22; --line:#30363d; --fg:#e6edf3; --dim:#8b949e;
+    --ok:#3fb950; --bad:#f85149; --warn:#d29922; --accent:#58a6ff;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;padding:2rem 1.25rem;background:var(--bg);color:var(--fg);
+       font:15px/1.6 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  main{max-width:60rem;margin:0 auto}
+  h1{font-size:1.35rem;margin:0 0 .35rem}
+  h2{font-size:1rem;margin:2rem 0 .75rem;color:var(--accent)}
+  p.lede{color:var(--dim);margin:0 0 1.75rem}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:8px;
+         padding:1.25rem;margin-bottom:1.25rem}
+  label{display:block;margin:.85rem 0 .3rem;color:var(--dim);font-size:.85rem}
+  input[type=range]{width:100%;accent-color:var(--accent)}
+  .val{color:var(--fg);font-weight:700}
+  .row{display:flex;gap:1.5rem;flex-wrap:wrap}
+  .row>div{flex:1 1 14rem}
+  .bar{height:26px;border-radius:4px;background:#21262d;position:relative;
+       overflow:hidden;margin:.4rem 0 .2rem;border:1px solid var(--line)}
+  .fill{height:100%;transition:width .18s ease,background .18s ease}
+  .caption{font-size:.82rem;color:var(--dim)}
+  .verdict{margin-top:1rem;padding:.85rem 1rem;border-radius:6px;
+           border-left:4px solid var(--line);background:#0b0f14}
+  .verdict.bad{border-left-color:var(--bad)}
+  .verdict.ok{border-left-color:var(--ok)}
+  .verdict strong{display:block;margin-bottom:.25rem}
+  fieldset{border:1px solid var(--line);border-radius:6px;padding:.75rem 1rem;margin:1rem 0 0}
+  legend{color:var(--dim);font-size:.82rem;padding:0 .4rem}
+  fieldset label{display:inline-flex;align-items:center;gap:.4rem;margin:0 1.25rem 0 0;color:var(--fg)}
+  table{border-collapse:collapse;width:100%;font-size:.88rem;margin-top:.5rem}
+  th,td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid var(--line)}
+  th{color:var(--dim);font-weight:400}
+  td.n{text-align:right;font-variant-numeric:tabular-nums}
+  code{background:#21262d;padding:.1rem .35rem;border-radius:3px;font-size:.88em}
+  .foot{color:var(--dim);font-size:.82rem;margin-top:2rem;border-top:1px solid var(--line);padding-top:1rem}
+</style>
+</head>
+<body>
+<main>
+  <h1>Where a hung package mirror spends your CI budget</h1>
+  <p class="lede">
+    On fork PR #3555, three jobs died inside <code>Setup environment</code> without
+    running a single test. Drag the controls to see why the failure time tracked the
+    job's own cap instead of the hang.
+  </p>
+
+  <div class="panel">
+    <div class="row">
+      <div>
+        <label for="cap">Job <code>timeout-minutes</code>: <span class="val" id="capV">15</span> min</label>
+        <input id="cap" type="range" min="5" max="60" step="5" value="15">
+      </div>
+      <div>
+        <label for="hang">Mirror stops responding for: <span class="val" id="hangV">unreachable</span></label>
+        <input id="hang" type="range" min="0" max="61" step="1" value="61">
+      </div>
+    </div>
+
+    <fieldset>
+      <legend>install path</legend>
+      <label><input type="radio" name="mode" value="raw" checked> raw <code>sudo apt-get update</code></label>
+      <label><input type="radio" name="mode" value="bounded"> <code>ensure-system-deps.sh</code></label>
+    </fieldset>
+
+    <div class="bar"><div class="fill" id="fill" style="width:100%;background:var(--bad)"></div></div>
+    <div class="caption" id="caption"></div>
+
+    <div class="verdict bad" id="verdict"><strong id="vTitle"></strong><span id="vBody"></span></div>
+  </div>
+
+  <h2>What actually happened, 2026-08-19</h2>
+  <div class="panel">
+    <table>
+      <thead><tr><th>job</th><th class="n">cap</th><th class="n">died after</th><th>step</th></tr></thead>
+      <tbody>
+        <tr><td>Security Tests</td><td class="n">15 min</td><td class="n">15m 16s</td><td>Setup environment</td></tr>
+        <tr><td>Compliance Tests</td><td class="n">15 min</td><td class="n">15m 16s</td><td>Setup environment</td></tr>
+        <tr><td>Unit Tests (node 20)</td><td class="n">30 min</td><td class="n">30m 15s</td><td>Setup environment</td></tr>
+      </tbody>
+    </table>
+    <p class="caption" style="margin-top:.9rem">
+      Each job died at its own cap, to the second. That is <code>timeout-minutes</code>
+      firing, not a test failing and not concurrency cancelling. GitHub reports a
+      cap-killed job as <em>cancelled</em>, which is what made it read like an infra flake.
+    </p>
+  </div>
+
+  <h2>Why the existing guard could not help</h2>
+  <div class="panel">
+    <p style="margin:0 0 .6rem">The call site carried what looks like a safety net:</p>
+    <pre style="margin:0;overflow-x:auto"><code>if ! sudo apt-get update -qq; then
+    log_warn "apt-get update had issues, continuing anyway..."
+fi</code></pre>
+    <p class="caption" style="margin-top:.75rem">
+      That catches a non-zero <strong>exit</strong>. A hang never exits, so the guard
+      never runs. Only an external watchdog (<code>timeout</code>) converts a hang into
+      an exit the guard can see.
+    </p>
+  </div>
+
+  <div class="foot">
+    Fix: every package install routes through <code>.github/scripts/ensure-system-deps.sh</code>,
+    which skips the package manager when the tools are already present and bounds the call at
+    <code>SYSTEM_DEPS_TIMEOUT</code> (90s default) otherwise.
+    <code>tests/ci/test-no-unbounded-package-manager.sh</code> greps the whole CI-executed
+    surface so the next call site cannot reintroduce this. Issue #3557.
+  </div>
+</main>
+
+<script>
+(function(){
+  var cap=document.getElementById('cap'), hang=document.getElementById('hang'),
+      capV=document.getElementById('capV'), hangV=document.getElementById('hangV'),
+      fill=document.getElementById('fill'), caption=document.getElementById('caption'),
+      verdict=document.getElementById('verdict'), vTitle=document.getElementById('vTitle'),
+      vBody=document.getElementById('vBody'),
+      BOUND=1.5; // ensure-system-deps.sh: 90s per package-manager call
+
+  function mode(){
+    var r=document.querySelectorAll('input[name=mode]');
+    for(var i=0;i<r.length;i++) if(r[i].checked) return r[i].value;
+    return 'raw';
+  }
+  function fmt(m){
+    if(m<1) return Math.round(m*60)+'s';
+    var whole=Math.floor(m), s=Math.round((m-whole)*60);
+    return whole+'m'+(s?' '+s+'s':'');
+  }
+
+  function render(){
+    var c=+cap.value, h=+hang.value, m=mode(), unreachable=(h>60);
+    capV.textContent=c;
+    hangV.textContent = unreachable ? 'unreachable' : fmt(h);
+
+    var cost, outcome, why, colour;
+
+    if(m==='bounded'){
+      // The common path never touches the package manager at all: jq ships on the image.
+      if(unreachable || h>BOUND){
+        cost=BOUND; outcome='fails fast, named cause'; colour='var(--warn)';
+        why='The watchdog cuts the call at 90s and prints "the package mirror is '+
+            'unreachable or throttled. This is an infrastructure failure in setup, not a '+
+            'test failure." You lose 90 seconds and you know exactly why.';
+      } else {
+        cost=h; outcome='installs and continues'; colour='var(--ok)';
+        why='The mirror answered inside the bound, so the install completes normally. '+
+            'On a hosted runner jq is already present, so the usual cost here is ~0s: '+
+            'the helper skips the package manager entirely.';
+      }
+    } else {
+      if(unreachable || h>c){
+        cost=c; outcome='job cancelled at its cap'; colour='var(--bad)';
+        why='Nothing bounds the call, so it runs until the job cap kills it. Zero tests '+
+            'ran, the whole cap is burnt, and the job reports "cancelled" — which reads '+
+            'as an infra flake rather than a hang with an address.';
+      } else {
+        cost=h; outcome='recovers, silently slow'; colour='var(--warn)';
+        why='The mirror answered before the cap, so this run passes. The cost is invisible '+
+            'and paid on every single job, which is why the defect survived unnoticed.';
+      }
+    }
+
+    var pct=Math.max(2,Math.min(100,(cost/c)*100));
+    fill.style.width=pct+'%';
+    fill.style.background=colour;
+    caption.textContent='Setup environment burns '+fmt(cost)+' of the '+c+
+      '-minute cap ('+Math.round((cost/c)*100)+'%) before the job resolves.';
+
+    verdict.className='verdict '+(colour==='var(--bad)'?'bad':'ok');
+    vTitle.textContent=outcome;
+    vBody.textContent=why;
+  }
+
+  cap.addEventListener('input',render);
+  hang.addEventListener('input',render);
+  var radios=document.querySelectorAll('input[name=mode]');
+  for(var i=0;i<radios.length;i++) radios[i].addEventListener('change',render);
+  render();
+})();
+</script>
+</body>
+</html>

--- a/tests/ci/test-no-unbounded-package-manager.sh
+++ b/tests/ci/test-no-unbounded-package-manager.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Test: no raw package-manager call survives on the CI-executed surface.
+#
+# Why this gate exists (#3557):
+#
+# #3550 removed every unbounded `apt-get update` it could find and its commit
+# message recorded the result as "no raw apt-get call remains in .github/"
+# (4c4c25cb1). That statement was true and the fix worked -- the job log for the
+# fork PR that then hung shows the new helper doing its job in under a second:
+#
+#     ensure-system-deps: all requested tools present, skipping package manager
+#
+# Six seconds later the same job stalled for its entire cap inside a SECOND,
+# unbounded `sudo apt-get update -qq` living in bin/ci-setup.sh. bin/ is outside
+# `.github/`, so the sweep never looked there. Three jobs died at exactly their
+# own `timeout-minutes` (15m16s, 15m16s, 30m15s) and an external contributor's
+# first pull request could not merge.
+#
+# The lesson is not "we missed a file". It is that a sweep scoped by DIRECTORY
+# cannot prove it covered the surface, and nothing failed when it hadn't. This
+# test is the coverage proof: it greps the whole CI-executed surface, so the
+# next call site added anywhere in it fails here instead of at a job cap.
+#
+# The allowlist is exactly one file: the helper that owns the bounded call.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Directories whose contents CI actually executes.
+SEARCH_DIRS=(".github" "bin" "scripts")
+
+# The one file allowed to call a package manager, because it bounds the call.
+HELPER_REL=".github/scripts/ensure-system-deps.sh"
+
+# Package-manager invocations that can block on a network mirror.
+PATTERN='(apt-get|apt|yum|dnf|apk|brew|choco|pacman)[[:space:]]+(update|upgrade|install|add)'
+
+FAILED=0
+echo "=== Unbounded Package-Manager Call Test ==="
+echo ""
+echo "  surface   : ${SEARCH_DIRS[*]}"
+echo "  allowlist : $HELPER_REL"
+echo ""
+
+# --- 1. the helper must exist ----------------------------------------------
+echo "--- 1: the bounded helper is present ---"
+if [ -f "$REPO_ROOT/$HELPER_REL" ]; then
+    echo "  PASS: $HELPER_REL"
+else
+    echo "  FAIL: $HELPER_REL is missing — nothing bounds package installs"
+    echo "RESULT: FAIL"
+    exit 1
+fi
+
+# --- 2. that helper actually bounds its calls -------------------------------
+# A helper that stopped using `timeout` would pass a naive grep gate while
+# reintroducing the exact hang, so assert the watchdog rather than the filename.
+echo ""
+echo "--- 2: the helper bounds its package-manager calls ---"
+if grep -qE '\b(timeout|gtimeout)\b' "$REPO_ROOT/$HELPER_REL"; then
+    echo "  PASS: helper resolves a timeout watchdog"
+else
+    echo "  FAIL: helper no longer uses timeout/gtimeout — the bound is gone"
+    FAILED=1
+fi
+
+# --- 3. no raw call anywhere else on the surface ----------------------------
+# Collected into a file rather than piped into `while`: with `set -e` +
+# `pipefail`, a `grep -v` that filters out every line of a directory exits 1 and
+# kills the whole collection subshell. That is not hypothetical -- the first cut
+# of this gate did exactly that, .github was the first directory searched, and
+# the gate reported "0 raw call sites" against a tree that had one. A gate that
+# cannot fail is worth less than no gate, so this path stays dumb and explicit.
+echo ""
+echo "--- 3: no raw package-manager call outside the helper ---"
+HITS_FILE="$(mktemp)"
+trap 'rm -f "$HITS_FILE"' EXIT
+
+{
+    cd "$REPO_ROOT" || exit 1
+    for d in "${SEARCH_DIRS[@]}"; do
+        [ -d "$d" ] || continue
+        # -I skips binaries. Failure here means "no match", never "broken".
+        grep -rInE "$PATTERN" "$d" 2>/dev/null || true
+    done
+} | grep -vE "^${HELPER_REL}:" \
+  | awk -F: '{
+        line = $0
+        sub(/^[^:]*:[^:]*:/, "", line)          # drop path:lineno prefix
+        if (line ~ /^[[:space:]]*#/) next        # a comment about apt is not a call
+        if (line ~ /(echo|printf)[[:space:]]/) next  # help text naming a command is not a call
+        print
+    }' > "$HITS_FILE" || true
+
+HITS="$(wc -l < "$HITS_FILE" | tr -d " ")"
+if [ "$HITS" -eq 0 ]; then
+    echo "  PASS: no raw package-manager call found"
+else
+    while IFS= read -r hit; do
+        [ -n "$hit" ] || continue
+        echo "  FAIL: $hit"
+    done < "$HITS_FILE"
+    FAILED=1
+fi
+
+echo ""
+echo "=== Summary ==="
+echo "  raw call sites found : $HITS"
+echo ""
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAIL"
+    echo ""
+    echo "Route the install through the bounded helper instead:"
+    echo "    bash $HELPER_REL <command> [<command>...]"
+    echo ""
+    echo "It skips the package manager when the tools are already installed and"
+    echo "bounds the call with \`timeout\` when they are not, so a dead mirror"
+    echo "fails in ~90s with a named cause instead of at the job's timeout cap."
+    exit 1
+fi
+
+echo "RESULT: PASS"
+exit 0


### PR DESCRIPTION
## Problem

Three jobs on fork PR #3555 died inside `Setup environment` without running a
single test. Each died at its own `timeout-minutes`, to the second:

| job | cap | died after |
| --- | --- | --- |
| Security Tests | 15 min | 15m 16s |
| Compliance Tests | 15 min | 15m 16s |
| Unit Tests (node 20) | 30 min | 30m 15s |

That is the cap firing, not a test failing and not concurrency cancelling.
GitHub reports a cap-killed job as `cancelled`, which is what made it read as an
infra flake. An external contributor's first pull request cannot merge in this
state, and re-running does not help: two re-runs on head `bfe10fe4` cancelled
the same way.

## Root cause

The job log locates it exactly. The helper added by #3550 worked as designed:

```
06:25:29  ensure-system-deps: all requested tools present, skipping package manager
06:25:35  [CI-SETUP] Updating package lists...
06:40:35  ##[error]The operation was canceled.  duration_ms=900108
06:40:35  Terminate orphan process: pid (2313) (ci-setup.sh)
```

Six seconds after the bounded helper returned, a second and unbounded
`sudo apt-get update -qq` in `bin/ci-setup.sh` hung for the full cap.

#3550 swept this class and recorded the result as "no raw apt-get call remains
in `.github/`" (4c4c25cb1). That was true. `bin/` is outside that path, so this
call site was never in scope, and it kept the hang alive after the fix shipped.

The guard already wrapped around the call could not help:

```bash
if ! sudo apt-get update -qq; then
    log_warn "apt-get update had issues, continuing anyway..."
fi
```

It catches a non-zero **exit**. A hang never exits.

## Fix

1. `bin/ci-setup.sh` routes both the Linux and macOS installs through
   `.github/scripts/ensure-system-deps.sh`, which skips the package manager when
   the tools are already present (jq ships on the hosted runner image) and bounds
   the call with `timeout` when they are not. A dead mirror now costs ~90s with a
   named cause instead of a whole job cap.
2. `tests/ci/test-no-unbounded-package-manager.sh` greps the entire CI-executed
   surface (`.github`, `bin`, `scripts`) instead of one directory, and asserts the
   helper still resolves a watchdog. A sweep scoped by directory cannot prove it
   covered the surface. This gate can.

## Test Plan

The gate's first cut could not fail. Collecting hits through a `while` loop fed
by a pipeline meant a `grep -v` that filtered out every line of the first
directory exited 1, and under `set -e` with `pipefail` that killed the collection
before `bin/` was ever searched. It reported zero hits against a tree that had
one. Rewritten, then verified by mutation rather than by reading:

- [x] reintroduce the exact #3557 line in `bin/` gate exits 1
- [x] raw `brew install` in `scripts/` gate exits 1
- [x] unbind the helper (drop `timeout`) gate exits 1
- [x] a comment naming apt-get gate stays green
- [x] clean tree gate exits 0
- [x] `bash scripts/ci/run-tests.sh tests/ci` 3 passed, 0 failed
- [x] `bash tests/ci/lint.sh` 6 passed, 0 failed (shellcheck clean)
- [x] helper exercised on macOS: skips the package manager, exit 0

## Interactive Playground

`docs/fix--3557-ci-setup-apt-bound/timeout-budget.html`

Drag the job cap and the mirror hang duration to see why the failure time
tracked the cap rather than the hang, and what the bounded path does instead.
Open the file from a local checkout.

Closes #3557
