### PR TITLE
fix(build): stop a denied scratch file from zeroing the hook subcount

### DIFF
--- a/bin/count-hooks.sh
+++ b/bin/count-hooks.sh
@@ -39,20 +39,56 @@ GLOBAL=$(( GLOBAL_CMD + GLOBAL_HTTP ))
 # A blanket `|| true` would also swallow rc>=2, turning a broken grep into a
 # silent zero and quietly shrinking the advertised hook count. So rc is inspected:
 # 1 yields 0, anything higher fails loudly with grep's own stderr.
+#
+# The scratch file that carries that stderr is a REPORTING convenience and must
+# never gate the count (#3564). It used to be a bare `mktemp`. When the system
+# temp dir denied the write (EPERM, e.g. under a sandbox), `errfile` came back
+# empty, `2>""` failed as a redirect, grep never ran, and rc came back 1, which
+# this function is required to read as "no match" -> 0. A real SKILL count of 21
+# silently became 0 and validate-counts reported "declared 171, actual 150"
+# against a tree with no drift at all. Editing the manifest to match that 150
+# would have introduced the very drift the check exists to catch.
+#
+# So: ask for the temp file, verify we can actually write it, and when we cannot,
+# drop the stderr capture and keep counting. Losing a quoted error message is a
+# cosmetic loss. Losing the count is a correctness one.
 count_run_hook_lines() {
   local dir="$1"; shift
   local out rc errfile
-  errfile="$(mktemp)"
+
+  errfile="$(mktemp "${TMPDIR:-/tmp}/count-hooks.XXXXXX" 2>/dev/null || true)"
+  if [ -n "$errfile" ] && [ ! -w "$errfile" ]; then
+    errfile=""
+  fi
+
   set +e
-  out="$(grep -rch 'command:.*run-hook' "$dir" "$@" 2>"$errfile")"
-  rc=$?
+  if [ -n "$errfile" ]; then
+    out="$(grep -rch 'command:.*run-hook' "$dir" "$@" 2>"$errfile")"
+    rc=$?
+  else
+    # No writable scratch file: let grep's stderr reach the terminal rather than
+    # redirecting it into a path that does not exist.
+    out="$(grep -rch 'command:.*run-hook' "$dir" "$@")"
+    rc=$?
+  fi
   set -e
+
   if [ "$rc" -ge 2 ]; then
-    echo "count-hooks: grep failed on $dir (exit $rc): $(cat "$errfile")" >&2
-    rm -f "$errfile"
+    local detail="(stderr not captured: no writable temp dir)"
+    if [ -n "$errfile" ]; then
+      detail="$(cat "$errfile")"
+    fi
+    echo "count-hooks: grep failed on $dir (exit $rc): $detail" >&2
+    if [ -n "$errfile" ]; then
+      rm -f "$errfile"
+    fi
     return 1
   fi
-  rm -f "$errfile"
+
+  if [ -n "$errfile" ]; then
+    rm -f "$errfile"
+  fi
+
   printf '%s\n' "$out" | awk '{s+=$1} END{print s+0}'
 }
 

--- a/docs/fix--3564-count-hooks-mktemp/silent-zero.html
+++ b/docs/fix--3564-count-hooks-mktemp/silent-zero.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>#3564 — how a scratch file turned 171 hooks into 150</title>
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--fg:#e6edf3;--dim:#8b949e;
+        --ok:#3fb950;--bad:#f85149;--warn:#d29922;--accent:#58a6ff}
+  *{box-sizing:border-box}
+  body{margin:0;padding:2rem 1.25rem;background:var(--bg);color:var(--fg);
+       font:15px/1.6 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  main{max-width:58rem;margin:0 auto}
+  h1{font-size:1.3rem;margin:0 0 .35rem}
+  h2{font-size:1rem;margin:2rem 0 .75rem;color:var(--accent)}
+  p.lede{color:var(--dim);margin:0 0 1.75rem}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:8px;
+         padding:1.25rem;margin-bottom:1.25rem}
+  fieldset{border:1px solid var(--line);border-radius:6px;padding:.75rem 1rem;margin:0 0 1rem}
+  legend{color:var(--dim);font-size:.82rem;padding:0 .4rem}
+  fieldset label{display:inline-flex;align-items:center;gap:.4rem;margin:0 1.5rem .25rem 0}
+  .steps{list-style:none;margin:0;padding:0}
+  .steps li{padding:.5rem .75rem;border-left:3px solid var(--line);margin-bottom:.4rem;
+            background:#0b0f14;transition:border-color .15s,color .15s}
+  .steps li.hot{border-left-color:var(--bad)}
+  .steps li.good{border-left-color:var(--ok)}
+  .steps li.dim{color:var(--dim)}
+  .out{font-size:1.05rem;padding:.85rem 1rem;border-radius:6px;background:#0b0f14;
+       border:1px solid var(--line);margin-top:1rem}
+  .out .num{font-weight:700}
+  .bad .num{color:var(--bad)} .ok .num{color:var(--ok)}
+  .note{margin-top:.75rem;font-size:.88rem;color:var(--dim)}
+  table{border-collapse:collapse;width:100%;font-size:.88rem}
+  th,td{text-align:left;padding:.4rem .6rem;border-bottom:1px solid var(--line)}
+  th{color:var(--dim);font-weight:400}
+  code{background:#21262d;padding:.1rem .35rem;border-radius:3px}
+  pre{margin:0;overflow-x:auto;background:#0b0f14;padding:.75rem;border-radius:6px;
+      border:1px solid var(--line);font-size:.85rem}
+  .foot{color:var(--dim);font-size:.82rem;margin-top:2rem;border-top:1px solid var(--line);padding-top:1rem}
+</style>
+</head>
+<body>
+<main>
+  <h1>How a scratch file turned 171 hooks into 150</h1>
+  <p class="lede">
+    <code>count-hooks.sh</code> redirected grep's stderr into a file from a bare
+    <code>mktemp</code>. Deny that one write and the count silently shrinks. Toggle
+    the two conditions to walk the chain.
+  </p>
+
+  <div class="panel">
+    <fieldset>
+      <legend>conditions</legend>
+      <label><input type="checkbox" id="deny"> temp dir denies the write (EPERM)</label>
+      <label><input type="checkbox" id="fixed"> apply the #3564 fix</label>
+    </fieldset>
+
+    <ul class="steps" id="steps"></ul>
+
+    <div class="out" id="out"></div>
+    <p class="note" id="note"></p>
+  </div>
+
+  <h2>Why rc=1 is the trap</h2>
+  <div class="panel">
+    <p style="margin:0 0 .6rem">
+      The function must treat "no match" as zero, because zero agent-scoped hooks
+      is a legitimate state since #3461 removed all 45 of them:
+    </p>
+<pre><code>if [ "$rc" -ge 2 ]; then   # real error, fail loudly
+    ...
+fi
+# rc of 0 or 1 falls through and counts</code></pre>
+    <p class="note" style="margin-top:.75rem">
+      A failed redirect also produces rc=1. So the one code path deliberately kept
+      quiet is the exact path a broken scratch file lands on. The guard was
+      correct; the thing it depended on was not guarded.
+    </p>
+  </div>
+
+  <h2>Verification note</h2>
+  <div class="panel">
+    <p style="margin:0 0 .6rem">The obvious repro reports success and hides the bug:</p>
+<pre><code>$ TMPDIR=/unwritable mktemp
+/var/folders/7v/.../T/tmp.iGOVlVqii5   <-- TMPDIR ignored</code></pre>
+    <p class="note" style="margin-top:.75rem">
+      macOS <code>mktemp</code> with no template ignores <code>TMPDIR</code>. Driving
+      this needs a real denial of <code>/var/folders</code> or a PATH shim, which is
+      what the regression test uses.
+    </p>
+  </div>
+
+  <h2>Measured</h2>
+  <div class="panel">
+    <table>
+      <thead><tr><th>script</th><th>mktemp</th><th>output</th></tr></thead>
+      <tbody>
+        <tr><td>origin/main</td><td>healthy</td><td>GLOBAL=150 AGENT=0 SKILL=21 TOTAL=171</td></tr>
+        <tr><td>origin/main</td><td>denied</td><td style="color:var(--bad)">GLOBAL=150 AGENT=0 SKILL=0 TOTAL=150</td></tr>
+        <tr><td>fixed</td><td>denied</td><td style="color:var(--ok)">GLOBAL=150 AGENT=0 SKILL=21 TOTAL=171</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="foot">
+    The scratch file only ever carried an error message. It now degrades to
+    "stderr not captured" instead of taking the count with it, and
+    <code>tests/ci/test-count-hooks-temp-failure.sh</code> asserts the counts are
+    identical with and without a writable temp dir. Issue #3564.
+  </div>
+</main>
+
+<script>
+(function(){
+  var deny=document.getElementById('deny'), fixed=document.getElementById('fixed'),
+      steps=document.getElementById('steps'), out=document.getElementById('out'),
+      note=document.getElementById('note');
+
+  function render(){
+    var d=deny.checked, f=fixed.checked, s=[], broken=(d && !f);
+
+    s.push([f?'mktemp with an explicit template, result checked for writability'
+             :'errfile="$(mktemp)"', d?(f?'good':'hot'):'dim']);
+
+    if(d && f){
+      s.push(['not writable, so the stderr capture is dropped and grep runs bare','good']);
+    } else if(d){
+      s.push(['EPERM: errfile is empty','hot']);
+      s.push(['grep ... 2>"" fails as a redirect, grep never runs','hot']);
+      s.push(['rc=1, which this function must read as "no match"','hot']);
+    } else {
+      s.push(['scratch file created, grep runs normally','dim']);
+    }
+    s.push([broken?'SKILL subcount returns 0':'SKILL subcount returns 21', broken?'hot':'good']);
+
+    steps.innerHTML='';
+    s.forEach(function(x){
+      var li=document.createElement('li'); li.textContent=x[0]; li.className=x[1];
+      steps.appendChild(li);
+    });
+
+    var total=broken?150:171;
+    out.className='out '+(broken?'bad':'ok');
+    out.innerHTML='GLOBAL=150 AGENT=0 SKILL=<span class="num">'+(broken?0:21)+
+                  '</span> TOTAL=<span class="num">'+total+'</span>';
+    note.textContent = broken
+      ? 'validate-counts reports "declared 171, actual 150" and pre-commit blocks every commit. '+
+        'The tempting repair is to edit the manifest down to 150, which would introduce the very '+
+        'drift the check exists to catch.'
+      : 'Matches the manifest. Commits proceed.';
+  }
+  deny.addEventListener('change',render);
+  fixed.addEventListener('change',render);
+  render();
+})();
+</script>
+</body>
+</html>

--- a/tests/ci/test-count-hooks-temp-failure.sh
+++ b/tests/ci/test-count-hooks-temp-failure.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Test: bin/count-hooks.sh must report the same counts whether or not it can
+# create a scratch file, and must still fail loudly on a genuinely broken grep.
+#
+# Why this exists (#3564):
+#
+# count_run_hook_lines() redirected grep's stderr into a file from a bare
+# `mktemp`. When the system temp dir denied the write, `errfile` came back empty,
+# `2>""` failed as a redirect, grep never ran, and rc came back 1 -- which this
+# function is REQUIRED to read as "no match" -> 0, because zero agent-scoped
+# hooks is a legitimate state. So a real SKILL count of 21 became a silent 0:
+#
+#     healthy            GLOBAL=150 AGENT=0 SKILL=21 TOTAL=171
+#     mktemp denied      GLOBAL=150 AGENT=0 SKILL=0  TOTAL=150
+#
+# validate-counts.sh then reported "declared 171, actual 150" against a tree with
+# no drift, and pre-commit blocked every commit. The dangerous repair is the
+# obvious one: edit the manifest down to 150 and introduce real drift.
+#
+# CI cannot catch this on its own -- its temp dir works. The trigger is a
+# sandboxed or hardened environment, so the failure has to be injected. Note that
+# `TMPDIR=/unwritable` does NOT work as an injection: macOS `mktemp` called with
+# no template ignores TMPDIR entirely and goes to /var/folders. A PATH shim is
+# the only portable way to drive it.
+#
+# The assertion is equality against the healthy run, not a hardcoded 171, so this
+# test keeps working as the real hook count changes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COUNTER="$REPO_ROOT/bin/count-hooks.sh"
+
+FAILED=0
+echo "=== count-hooks.sh Temp-Failure Test ==="
+echo ""
+
+if [ ! -x "$COUNTER" ] && [ ! -f "$COUNTER" ]; then
+    echo "FAIL: missing $COUNTER"
+    exit 1
+fi
+
+SHIM_DIR="$(mktemp -d)"
+trap 'rm -rf "$SHIM_DIR"' EXIT
+
+# --- 1. healthy baseline ----------------------------------------------------
+echo "--- 1: healthy run produces a non-zero total ---"
+HEALTHY="$(bash "$COUNTER")"
+echo "  $HEALTHY"
+
+HEALTHY_TOTAL="$(printf '%s' "$HEALTHY" | sed -n 's/.*TOTAL=\([0-9]*\).*/\1/p')"
+if [ -n "$HEALTHY_TOTAL" ] && [ "$HEALTHY_TOTAL" -gt 0 ]; then
+    echo "  PASS: TOTAL=$HEALTHY_TOTAL"
+else
+    echo "  FAIL: could not read a positive TOTAL from the healthy run"
+    FAILED=1
+fi
+
+# --- 2. identical output when mktemp is denied ------------------------------
+echo ""
+echo "--- 2: a denied mktemp must not change any subcount ---"
+cat > "$SHIM_DIR/mktemp" <<'SHIM'
+#!/bin/sh
+echo "mktemp: mkstemp failed on /var/folders/x/T/tmp.XXXX: Operation not permitted" >&2
+exit 1
+SHIM
+chmod +x "$SHIM_DIR/mktemp"
+
+DENIED="$(PATH="$SHIM_DIR:$PATH" bash "$COUNTER" 2>/dev/null || true)"
+echo "  $DENIED"
+
+if [ "$DENIED" = "$HEALTHY" ]; then
+    echo "  PASS: identical to the healthy run"
+else
+    echo "  FAIL: counts changed when the temp dir was unwritable"
+    echo "        healthy: $HEALTHY"
+    echo "        denied : $DENIED"
+    echo "        This is #3564: a scratch-file failure silently zeroed a subcount."
+    FAILED=1
+fi
+
+rm -f "$SHIM_DIR/mktemp"
+
+# --- 3. a genuinely broken grep must still fail loudly ----------------------
+# The counterpart risk: making the function tolerant of temp failure must not
+# make it tolerant of grep itself dying. rc>=2 is a real error and has to
+# propagate, or a broken grep becomes the same silent zero by another route.
+echo ""
+echo "--- 3: grep exiting >=2 still fails loudly ---"
+cat > "$SHIM_DIR/grep" <<'SHIM'
+#!/bin/sh
+echo "grep: simulated catastrophic failure" >&2
+exit 2
+SHIM
+chmod +x "$SHIM_DIR/grep"
+
+set +e
+BROKEN_OUT="$(PATH="$SHIM_DIR:$PATH" bash "$COUNTER" 2>&1)"
+BROKEN_RC=$?
+set -e
+
+if [ "$BROKEN_RC" -ne 0 ]; then
+    echo "  PASS: exited $BROKEN_RC instead of reporting a count"
+else
+    echo "  FAIL: exited 0 with '$BROKEN_OUT' despite grep failing hard"
+    FAILED=1
+fi
+
+echo ""
+echo "=== Summary ==="
+echo "  healthy TOTAL : ${HEALTHY_TOTAL:-unknown}"
+echo ""
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAIL"
+    exit 1
+fi
+
+echo "RESULT: PASS"
+exit 0


### PR DESCRIPTION
## Problem

`count_run_hook_lines()` in `bin/count-hooks.sh` redirected grep's stderr into a
file from a bare `mktemp`. When the system temp dir denies that write, the
failure does not surface as an error. It surfaces as a wrong number:

1. `errfile` comes back empty
2. `grep ... 2>""` fails as a redirect, so grep never runs
3. rc comes back `1`
4. and `1` is the one code this function **must** read as "no match" and count as
   zero, because zero agent-scoped hooks is legitimate since #3461 removed all 45

A real SKILL count of 21 becomes a silent 0:

```
healthy        GLOBAL=150 AGENT=0 SKILL=21 TOTAL=171
mktemp denied  GLOBAL=150 AGENT=0 SKILL=0  TOTAL=150
```

`validate-counts.sh` then reports `declared 171, actual 150` against a tree with
no drift in it, and pre-commit blocks **every** commit.

The dangerous repair is the obvious one. Editing the manifest down to 150 would
introduce exactly the drift the check exists to catch. The header comment two
lines above the bug already warned about turning a broken grep into a silent
zero; the `mktemp` that guard depends on was itself unguarded.

## Fix

The scratch file only ever carried an error message for the `rc>=2` branch, so it
must never gate the count. Ask for it with an explicit template, verify it is
writable, and when it is not, drop the stderr capture and keep counting. Losing a
quoted error message is cosmetic. Losing the count is not.

`tests/ci/test-count-hooks-temp-failure.sh` asserts the output is **identical**
with and without a writable temp dir, and that a grep exiting `>=2` still fails
loudly rather than trading one silent zero for another. The equality is against
the healthy run rather than a hardcoded 171, so it survives the real count
changing.

## A trap for anyone verifying this

The obvious repro reports success and hides the bug:

```
$ TMPDIR=/unwritable mktemp
/var/folders/7v/.../T/tmp.iGOVlVqii5      <- TMPDIR ignored entirely
$ TMPDIR=/unwritable bash bin/count-hooks.sh
GLOBAL=150 AGENT=0 SKILL=21 TOTAL=171     <- green, looks fine
```

macOS `mktemp` called with **no template** ignores `TMPDIR` and goes straight to
`/var/folders`. Driving this needs a genuine denial of that path (the sandbox
case in #3322) or a PATH shim, which is what the test uses. CI's temp dir works,
so CI could never have caught this on its own.

## Test Plan

- [x] mutation: against `origin/main`'s `count-hooks.sh` the new test fails with
      the exact reported delta (`denied: TOTAL=150` vs `healthy: TOTAL=171`)
- [x] fixed script under a failing-mktemp shim: `TOTAL=171`
- [x] fixed script with a healthy mktemp: `TOTAL=171`
- [x] grep forced to exit 2: `count-hooks.sh` exits non-zero, no count printed
- [x] `bash bin/validate-counts.sh` Validation PASSED
- [x] `bash scripts/ci/run-tests.sh tests/ci` 4 passed, 0 failed
- [x] `shellcheck` clean on both files

## Interactive Playground

`docs/fix--3564-count-hooks-mktemp/silent-zero.html`

Two checkboxes (deny the temp write, apply the fix) walk the four-step cascade
and show the resulting count. Open the file from a local checkout.

Closes #3564
