### PR TITLE
fix(tests): give the runner a scratch file it can actually create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,6 @@ docs/site/.claude/memory/sessions/
 # (__guards_main_tmp.ts, __probe_main_tmp.ts) — one of them would have poisoned
 # any `grep permission_mode src/`.
 **/__*_tmp.ts
+
+# scratch fallback when the system temp dir is unwritable (see tests/run-all-tests.sh)
+tests/.tmp/

--- a/docs/fix--runner-mktemp/scratch-fallback.html
+++ b/docs/fix--runner-mktemp/scratch-fallback.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>A test runner that could not create a scratch file</title>
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--fg:#e6edf3;--dim:#8b949e;
+        --ok:#3fb950;--bad:#f85149;--warn:#d29922;--accent:#58a6ff}
+  *{box-sizing:border-box}
+  body{margin:0;padding:2rem 1.25rem;background:var(--bg);color:var(--fg);
+       font:15px/1.6 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+  main{max-width:58rem;margin:0 auto}
+  h1{font-size:1.3rem;margin:0 0 .35rem}
+  h2{font-size:1rem;margin:2rem 0 .75rem;color:var(--accent)}
+  p.lede{color:var(--dim);margin:0 0 1.5rem}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:8px;
+         padding:1.25rem;margin-bottom:1.25rem}
+  fieldset{border:1px solid var(--line);border-radius:6px;padding:.7rem 1rem;margin:0 0 .5rem}
+  legend{color:var(--dim);font-size:.82rem;padding:0 .4rem}
+  fieldset label{display:inline-flex;align-items:center;gap:.4rem;margin:0 1.25rem .2rem 0}
+  .steps{list-style:none;margin:.5rem 0 0;padding:0}
+  .steps li{padding:.45rem .7rem;border-left:3px solid var(--line);margin-bottom:.35rem;background:#0b0f14}
+  .steps li.hot{border-left-color:var(--bad)}
+  .steps li.good{border-left-color:var(--ok)}
+  .steps li.dim{color:var(--dim)}
+  .v{margin-top:.9rem;padding:.75rem 1rem;border-radius:6px;background:#0b0f14;
+     border:1px solid var(--line);border-left-width:4px}
+  .v.ok{border-left-color:var(--ok)} .v.bad{border-left-color:var(--bad)}
+  .v strong{display:block} .v.ok strong{color:var(--ok)} .v.bad strong{color:var(--bad)}
+  .v p{margin:.3rem 0 0;font-size:.85rem;color:var(--dim)}
+  code{background:#21262d;padding:.1rem .35rem;border-radius:3px}
+  pre{margin:0;background:#0b0f14;padding:.7rem;border-radius:6px;border:1px solid var(--line);font-size:.84rem;overflow-x:auto}
+  .foot{color:var(--dim);font-size:.82rem;margin-top:2rem;border-top:1px solid var(--line);padding-top:1rem}
+</style>
+</head>
+<body>
+<main>
+  <h1>A test runner that could not create a scratch file</h1>
+  <p class="lede">
+    One denied <code>mktemp</code> stopped every commit. Toggle the two
+    conditions to see where the failure lands.
+  </p>
+
+  <div class="panel">
+    <fieldset>
+      <legend>conditions</legend>
+      <label><input type="checkbox" id="deny" checked> system temp dir denies the write</label>
+      <label><input type="checkbox" id="fixed"> apply the fallback</label>
+    </fieldset>
+    <ul class="steps" id="steps"></ul>
+    <div class="v" id="verdict"><strong id="vT"></strong><p id="vP"></p></div>
+  </div>
+
+  <h2>Why TMPDIR is not the workaround</h2>
+  <div class="panel">
+<pre><code>$ TMPDIR=/unwritable mktemp
+/var/folders/7v/.../T/tmp.iGOVlVqii5   &lt;-- TMPDIR ignored
+
+$ TMPDIR=/unwritable mktemp "$TMPDIR/x.XXXXXX"
+mktemp: mkstemp failed: Operation not permitted   &lt;-- honoured</code></pre>
+    <p style="margin:.7rem 0 0;font-size:.85rem;color:var(--dim)">
+      macOS <code>mktemp</code> with no TEMPLATE ignores <code>TMPDIR</code>
+      entirely. That is why setting it looks like a fix and proves nothing, and
+      why the template is the actual repair rather than a style preference.
+    </p>
+  </div>
+
+  <h2>The part that is almost funny</h2>
+  <div class="panel">
+    <p style="margin:0;font-size:.88rem;color:var(--dim)">
+      Two of the tests this runner executes were written to catch a denied
+      <code>mktemp</code> silently zeroing a count. Both used a bare
+      <code>mktemp -d</code> themselves, so both died of the condition they
+      exist to detect. They pass in CI, whose temp dir works, and fail in
+      exactly the environment the bug lives in.
+    </p>
+  </div>
+
+  <div class="foot">
+    Order of preference: <code>TMPDIR</code>, then <code>/tmp</code>, then a
+    gitignored <code>tests/.tmp/</code> beside the runner. A named failure if all
+    three are unusable, never a silent one.
+  </div>
+</main>
+<script>
+(function(){
+  var deny=document.getElementById('deny'), fixed=document.getElementById('fixed'),
+      steps=document.getElementById('steps'), verdict=document.getElementById('verdict'),
+      vT=document.getElementById('vT'), vP=document.getElementById('vP');
+  function render(){
+    var d=deny.checked, f=fixed.checked, broken=(d&&!f), s=[];
+    s.push([f?'mktemp with an explicit template, TMPDIR honoured':'RESULTS_FILE=$(mktemp)  — bare, system temp only', d?(f?'good':'hot'):'dim']);
+    if(d&&f){
+      s.push(['TMPDIR denied, falls back to /tmp, then tests/.tmp/','good']);
+      s.push(['scratch file created, suite runs','good']);
+    } else if(d){
+      s.push(['mkstemp fails: Operation not permitted','hot']);
+      s.push(['set -e aborts the runner before any test','hot']);
+      s.push(['pre-commit reports "quick lint tests FAILED", zero output','hot']);
+    } else {
+      s.push(['scratch file created, suite runs','dim']);
+    }
+    steps.innerHTML='';
+    s.forEach(function(x){var li=document.createElement('li');li.textContent=x[0];li.className=x[1];steps.appendChild(li);});
+    verdict.className='v '+(broken?'bad':'ok');
+    vT.textContent = broken ? 'every commit blocked' : 'suite runs, 3 categories';
+    vP.textContent = broken
+      ? 'No test executed, so the failure says nothing about the code being committed. The obvious reading is "my change broke the tests", which is false.'
+      : 'The runner reaches the tests. A genuine failure now means what it says.';
+  }
+  deny.addEventListener('change',render); fixed.addEventListener('change',render); render();
+})();
+</script>
+</body>
+</html>

--- a/tests/ci/test-count-hooks-temp-failure.sh
+++ b/tests/ci/test-count-hooks-temp-failure.sh
@@ -41,7 +41,25 @@ if [ ! -x "$COUNTER" ] && [ ! -f "$COUNTER" ]; then
     exit 1
 fi
 
-SHIM_DIR="$(mktemp -d)"
+# A test about a denied mktemp must not itself die on a denied mktemp. Bare
+# `mktemp` writes to the system temp dir; an explicit TEMPLATE is what makes
+# TMPDIR effective, because macOS mktemp with no template ignores TMPDIR and
+# goes to /var/folders regardless. Falls back beside this script so the suite
+# still runs in a sandboxed shell.
+scratch_dir() {
+    local d
+    for base in "${TMPDIR:-/tmp}" /tmp "$SCRIPT_DIR/.tmp"; do
+        [ -n "$base" ] || continue
+        mkdir -p "$base" 2>/dev/null || continue
+        if d=$(mktemp -d "${base%/}/ork-test.XXXXXX" 2>/dev/null) && [ -w "$d" ]; then
+            printf '%s' "$d"; return 0
+        fi
+    done
+    echo "FAIL: no writable scratch dir (TMPDIR, /tmp, $SCRIPT_DIR/.tmp)" >&2
+    return 1
+}
+
+SHIM_DIR="$(scratch_dir)"
 trap 'rm -rf "$SHIM_DIR"' EXIT
 
 # --- 1. healthy baseline ----------------------------------------------------

--- a/tests/ci/test-no-unbounded-package-manager.sh
+++ b/tests/ci/test-no-unbounded-package-manager.sh
@@ -75,7 +75,25 @@ fi
 # cannot fail is worth less than no gate, so this path stays dumb and explicit.
 echo ""
 echo "--- 3: no raw package-manager call outside the helper ---"
-HITS_FILE="$(mktemp)"
+# A test about a denied mktemp must not itself die on a denied mktemp. Bare
+# `mktemp` writes to the system temp dir; an explicit TEMPLATE is what makes
+# TMPDIR effective, because macOS mktemp with no template ignores TMPDIR and
+# goes to /var/folders regardless. Falls back beside this script so the suite
+# still runs in a sandboxed shell.
+scratch_file() {
+    local f
+    for base in "${TMPDIR:-/tmp}" /tmp "$SCRIPT_DIR/.tmp"; do
+        [ -n "$base" ] || continue
+        mkdir -p "$base" 2>/dev/null || continue
+        if f=$(mktemp "${base%/}/ork-hits.XXXXXX" 2>/dev/null) && [ -w "$f" ]; then
+            printf '%s' "$f"; return 0
+        fi
+    done
+    echo "FAIL: no writable scratch dir (TMPDIR, /tmp, $SCRIPT_DIR/.tmp)" >&2
+    return 1
+}
+
+HITS_FILE="$(scratch_file)"
 trap 'rm -f "$HITS_FILE"' EXIT
 
 {

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -86,7 +86,36 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-RESULTS_FILE=$(mktemp)
+# ---------------------------------------------------------------------------
+# Scratch files, without depending on a writable system temp dir.
+#
+# A bare `mktemp` writes to the system temp dir and dies when that write is
+# denied. Under `set -e` that killed this runner on its first scratch file, so
+# nothing ran and the pre-commit hook reported "quick lint tests FAILED" with no
+# test having executed. Same class as #3564 (a denied mktemp silently zeroed a
+# subcount in count-hooks.sh); the blast radius here is larger, because this
+# script sits on the commit path and its failure blocks every commit.
+#
+# An explicit TEMPLATE is what makes TMPDIR effective: macOS `mktemp` called
+# with no template ignores TMPDIR entirely and goes to /var/folders regardless,
+# which is also why `TMPDIR=/somewhere bash run-all-tests.sh` looks like it
+# works and proves nothing.
+# ---------------------------------------------------------------------------
+scratch_file() {
+    local f
+    for dir in "${TMPDIR:-/tmp}" /tmp "$SCRIPT_DIR/.tmp"; do
+        [ -n "$dir" ] || continue
+        mkdir -p "$dir" 2>/dev/null || continue
+        if f=$(mktemp "${dir%/}/ork-tests.XXXXXX" 2>/dev/null) && [ -w "$f" ]; then
+            printf '%s' "$f"
+            return 0
+        fi
+    done
+    echo "run-all-tests: FAILED to create a scratch file in TMPDIR, /tmp or $SCRIPT_DIR/.tmp" >&2
+    return 1
+}
+
+RESULTS_FILE=$(scratch_file)
 TOTAL_PASSED=0
 TOTAL_FAILED=0
 # Advisory-warning ratchet (2026-08-01): sections print "Warnings: N" lines.
@@ -138,7 +167,7 @@ run_dir() {
 
     local exit_code=0
     local section_out
-    section_out=$(mktemp)
+    section_out=$(scratch_file)
     # tee so the operator sees everything AND the ratchet can count warnings.
     # `|| exit_code=$?` captures the engine's real exit (pipefail) without
     # tripping set -e; the code is recorded below, never swallowed.
@@ -180,7 +209,7 @@ run_script() {
 
     local exit_code=0
     local section_out
-    section_out=$(mktemp)
+    section_out=$(scratch_file)
     # Same capture contract as run_dir: recorded, never swallowed.
     bash "$script" 2>&1 | tee "$section_out" || exit_code=$?
     local section_warnings


### PR DESCRIPTION
## Problem

`tests/run-all-tests.sh` died on its first scratch file and took the pre-commit
hook with it, so **no commit could be made at all** where the system temp dir is
not writable:

```
$ bash ./tests/run-all-tests.sh --lint
mktemp: mkstemp failed on /var/folders/.../T/tmp.0VHibpIGlz: Operation not permitted
```

Nothing else printed. The runner never reached a test, and pre-commit reported
`quick lint tests FAILED`, which reads as *your change broke the tests* when no
test had run.

Three bare `mktemp` calls under `set -e`: lines 89, 141, 183.

## Relationship to #3564

Same class, **not covered by it**. #3567 was scoped to `bin/count-hooks.sh`,
where the denial produced a silently wrong number. Here it produces total failure
to run, which is louder but worse, because this script sits on the commit path.

## Fix

`scratch_file()` tries `TMPDIR`, then `/tmp`, then a gitignored `tests/.tmp/`
beside the runner, and fails with a named cause if all three are unusable.

An explicit **template** is the actual repair, not a style preference: macOS
`mktemp` with no template ignores `TMPDIR` entirely and goes to `/var/folders`,
so `TMPDIR=/somewhere bash run-all-tests.sh` appears to work while proving
nothing.

Also fixes the two tests this runner executes that had the same defect:

| file | call |
| --- | --- |
| `tests/ci/test-count-hooks-temp-failure.sh:44` | `SHIM_DIR="$(mktemp -d)"` |
| `tests/ci/test-no-unbounded-package-manager.sh:78` | `HITS_FILE="$(mktemp)"` |

Both were written to catch a denied `mktemp` silently zeroing a count, and both
died of the condition they exist to detect. They pass in CI, whose temp dir
works, and fail in exactly the environment the bug lives in.

## Test Plan

Verified against the live denial rather than a simulation.

- [x] before: one error line, zero categories run
- [x] after: **3 categories, ALL TESTS PASSED**
- [x] both repaired tests report `RESULT: PASS` individually
- [x] `bash -n` clean on all three scripts

## Interactive Playground

`docs/fix--runner-mktemp/scratch-fallback.html`

Toggle the denial and the fallback to see where the failure lands.
