### PR TITLE
fix(tests): give every mktemp a template so it honours TMPDIR

### DIFF
--- a/.github/workflows/ci-sentinel.yml
+++ b/.github/workflows/ci-sentinel.yml
@@ -240,7 +240,7 @@ jobs:
             # `--effort` removed alongside --bare — it's a session config that
             # needs the full CC load to take effect and is duplicated by
             # --max-turns 4 for our use case.
-            tmpdir="$(mktemp -d)"
+            tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
             # #1862 Bugs A+B: claude -p reports auth/permission errors as JSON on
             # STDOUT (verdict.json), not stderr — so log BOTH on failure. Each cat
             # is `|| true`-guarded: under errexit a cat of an empty/missing file

--- a/bin/git-hooks/pre-commit
+++ b/bin/git-hooks/pre-commit
@@ -143,9 +143,12 @@ if [[ -n "$WORKFLOW_FILES" ]]; then
   echo -n "  Linting GitHub Actions workflows... "
   if command -v actionlint >/dev/null 2>&1; then
     # shellcheck disable=SC2086
-    if ! actionlint -shellcheck= $WORKFLOW_FILES >/tmp/actionlint-precommit.log 2>&1; then
+    # Not a hardcoded /tmp path: that write is denied in a sandboxed shell, and
+    # the failure surfaces as "actionlint FAILED" on a workflow that is clean.
+    ACTIONLINT_LOG="${TMPDIR:-/tmp}/actionlint-precommit.log"
+    if ! actionlint -shellcheck= $WORKFLOW_FILES >"$ACTIONLINT_LOG" 2>&1; then
       echo "FAILED"
-      head -20 /tmp/actionlint-precommit.log
+      head -20 "$ACTIONLINT_LOG"
       echo "    Run 'actionlint -shellcheck= .github/workflows/*.yml' for full output"
       ERRORS=$((ERRORS + 1))
     else

--- a/bin/git-hooks/pre-push
+++ b/bin/git-hooks/pre-push
@@ -311,7 +311,7 @@ else
 fi
 [[ $CORES -lt $MAX_JOBS ]] && MAX_JOBS=$CORES
 
-export _PREPUSH_FAIL_DIR=$(mktemp -d)
+export _PREPUSH_FAIL_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -rf "$_PREPUSH_FAIL_DIR"' EXIT
 
 _run_test() {
@@ -453,7 +453,7 @@ echo "OK"
 # ===== Token overhead budget (blocking + warn tier) =====
 echo -n "  Checking token overhead budget... "
 
-TOKEN_LOG=$(mktemp)
+TOKEN_LOG=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -f "$TOKEN_LOG"' EXIT
 
 if ! run_with_timeout 30 bash tests/performance/test-token-overhead.sh >"$TOKEN_LOG" 2>&1; then
@@ -485,7 +485,7 @@ fi
 HOOK_CHANGES=$(echo "$CHANGED_FILES" | grep -E '^src/hooks/' || true)
 if [[ -n "$HOOK_CHANGES" ]]; then
   echo -n "  Running hook vitest suite... "
-  HOOK_LOG="$(mktemp)"
+  HOOK_LOG="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
   trap 'rm -f "$HOOK_LOG"' EXIT
   if ! (cd src/hooks && npx vitest run --reporter=dot >"$HOOK_LOG" 2>&1); then
     echo "FAILED"

--- a/docs/fix--mktemp-template-sweep/index.html
+++ b/docs/fix--mktemp-template-sweep/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The template is the fix, not the directory</title>
+<style>
+:root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--fg:#e6edf3;--dim:#8b949e;--ok:#3fb950;--bad:#f85149;--warn:#d29922;--accent:#58a6ff}
+*{box-sizing:border-box}
+body{margin:0;padding:2rem 1.25rem;background:var(--bg);color:var(--fg);font:15px/1.6 ui-monospace,Menlo,Consolas,monospace}
+main{max-width:60rem;margin:0 auto}h1{font-size:1.3rem;margin:0 0 .35rem}
+h2{font-size:1rem;margin:2rem 0 .7rem;color:var(--accent)}p.lede{color:var(--dim);margin:0 0 1.5rem}
+.panel{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:1.2rem;margin-bottom:1.2rem}
+fieldset{border:1px solid var(--line);border-radius:6px;padding:.7rem 1rem;margin:0 0 .6rem}
+legend{color:var(--dim);font-size:.82rem;padding:0 .4rem}
+fieldset label{display:inline-flex;align-items:center;gap:.4rem;margin:0 1.4rem .2rem 0}
+.v{margin-top:.9rem;padding:.8rem 1rem;border-radius:6px;background:#0b0f14;border:1px solid var(--line);border-left-width:4px}
+.v.ok{border-left-color:var(--ok)}.v.bad{border-left-color:var(--bad)}
+.v strong{display:block}.v.ok strong{color:var(--ok)}.v.bad strong{color:var(--bad)}
+.v p{margin:.3rem 0 0;font-size:.85rem;color:var(--dim)}
+pre{margin:0;background:#0b0f14;padding:.7rem;border-radius:6px;border:1px solid var(--line);font-size:.84rem;overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-size:.86rem}
+th,td{text-align:left;padding:.35rem .6rem;border-bottom:1px solid var(--line)}
+th{color:var(--dim);font-weight:400}td.n{text-align:right;font-variant-numeric:tabular-nums}
+.bar{display:inline-block;height:12px;background:var(--accent);border-radius:2px;vertical-align:middle}
+code{background:#21262d;padding:.1rem .35rem;border-radius:3px}
+.foot{color:var(--dim);font-size:.82rem;margin-top:2rem;border-top:1px solid var(--line);padding-top:1rem}
+</style></head><body><main>
+<h1>The template is the fix, not the directory</h1>
+<p class="lede">
+  A bare <code>mktemp</code> ignores <code>$TMPDIR</code> on macOS. Setting
+  TMPDIR therefore looks like a fix and changes nothing. Toggle both.
+</p>
+
+<div class="panel">
+  <fieldset>
+    <legend>conditions</legend>
+    <label><input type="checkbox" id="tmpdir" checked> TMPDIR points somewhere writable</label>
+    <label><input type="checkbox" id="tpl"> the call has an explicit template</label>
+    <label><input type="checkbox" id="deny" checked> system temp dir denies the write</label>
+  </fieldset>
+  <pre id="cmd"></pre>
+  <div class="v" id="v"><strong id="vt"></strong><p id="vp"></p></div>
+</div>
+
+<h2>Why two earlier sweeps of this class both "succeeded"</h2>
+<div class="panel">
+  <table>
+    <thead><tr><th>sweep</th><th>scoped by</th><th class="n">covered</th><th class="n">real</th></tr></thead>
+    <tbody>
+      <tr><td>#3550</td><td>directory (<code>.github/</code>)</td><td class="n">part</td><td class="n">bin/ too</td></tr>
+      <tr><td>this PR, 1st pass</td><td>regex dialect (<code>grep -E '\s'</code>)</td><td class="n">30</td><td class="n">76</td></tr>
+      <tr><td>this PR, shipped</td><td>whole tree, one dialect</td><td class="n">76</td><td class="n">76</td></tr>
+    </tbody>
+  </table>
+  <p style="margin:.8rem 0 0;font-size:.85rem;color:var(--dim)">
+    ERE has no <code>\s</code>, so the scan matched nothing useful and reported a
+    76-file surface as 30 — including the very file being fixed. Both sweeps
+    reported success. A gate that scans the whole tree in one dialect is the only
+    thing that can claim coverage.
+  </p>
+</div>
+
+<h2>Measured, on the test that was failing</h2>
+<div class="panel">
+  <table>
+    <tbody>
+      <tr><td>before</td><td class="n">9 pass / 5 fail</td><td><span class="bar" style="width:90px;background:var(--bad)"></span> 6 denials</td></tr>
+      <tr><td>after</td><td class="n">14 pass / 0 fail</td><td><span class="bar" style="width:140px"></span> 0 denials</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="foot">
+  Six sightings in one day: <code>count-hooks.sh</code>,
+  <code>run-all-tests.sh</code>, two <code>tests/ci/</code> scripts written to
+  catch this class, <code>test-dead-generation-guard.sh</code>, and
+  <code>pre-commit</code>'s hardcoded <code>/tmp</code> actionlint log.
+</div>
+</main>
+<script>
+(function(){
+  var t=document.getElementById('tmpdir'),p=document.getElementById('tpl'),d=document.getElementById('deny'),
+      cmd=document.getElementById('cmd'),v=document.getElementById('v'),vt=document.getElementById('vt'),vp=document.getElementById('vp');
+  function r(){
+    var T=t.checked,P=p.checked,D=d.checked;
+    cmd.textContent = (T?'TMPDIR=/writable ':'') + (P
+      ? 'f=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")'
+      : 'f=$(mktemp)');
+    var lands = P ? (T?'$TMPDIR':'/tmp') : 'the system temp dir';
+    var broken = !P && D;
+    v.className='v '+(broken?'bad':'ok');
+    if(broken){
+      vt.textContent='mkstemp failed: Operation not permitted';
+      vp.textContent='No template, so $TMPDIR is ignored and the call goes to '+lands+' regardless. Under set -e the whole script dies here — often before anything useful runs, which is why the failure gets misread as "your change broke the tests".';
+    } else if(!P && !D){
+      vt.textContent='works, by luck';
+      vp.textContent='No template, but the system temp dir happens to be writable. This is the state CI runs in, which is exactly why CI can never catch this class.';
+    } else {
+      vt.textContent='works, by construction';
+      vp.textContent='The template makes $TMPDIR effective, so the file lands in '+lands+'. Same code, same denial, different outcome.';
+    }
+  }
+  [t,p,d].forEach(function(e){e.addEventListener('change',r)}); r();
+})();
+</script></body></html>

--- a/scripts/cc-file-adoption-issues.sh
+++ b/scripts/cc-file-adoption-issues.sh
@@ -84,7 +84,7 @@ PROSE_EXT_RE='\.(md|mdx|markdown|html?|txt)$'
 # lanes and merged back into the ledger in a single jq pass at the end. The
 # filing loops run in a `jq | while` subshell, so a file (not a var) is how the
 # records survive back to the parent shell.
-DISPO_FILE="$(mktemp)"
+DISPO_FILE="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -f "$DISPO_FILE"' EXIT
 
 # Portable sha256 of stdin → bare hex (Linux sha256sum, macOS shasum). Used for
@@ -410,7 +410,7 @@ done < <(jq -r '.[] | "\(.version) \((.features // []) | length) \(.features_ext
 # version + space + slug (neither field contains a space, so the key is unique).
 if [ -s "$DISPO_FILE" ]; then
   DISPO_JSON="$(jq -s '.' "$DISPO_FILE")"
-  TMP_DISPO="$(mktemp)"
+  TMP_DISPO="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
   jq --argjson dispo "$DISPO_JSON" '
     ($dispo | map({key: (.version + " " + .feature_slug), value: .disposition}) | from_entries) as $m
     | map(
@@ -441,7 +441,7 @@ fi
 # proves it. A legacy entry gets cap_saturated with no cap_dropped, which is the
 # honest encoding of "at the cap, cause unknown".
 TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-TMP_GAPS="$(mktemp)"
+TMP_GAPS="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
 jq --arg ts "$TS" --argjson cap "$FEATURE_CAP" \
   'map(
      (if ((.features // []) | length) == $cap then . + {cap_saturated: true} else . end)

--- a/scripts/eval/aggregate-quality-index.sh
+++ b/scripts/eval/aggregate-quality-index.sh
@@ -71,7 +71,7 @@ read_metric() {
   jq -r "$filter // empty" "$file"
 }
 
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 # Union of skill ids seen across trigger + quality result files.

--- a/scripts/eval/eval-coverage.sh
+++ b/scripts/eval/eval-coverage.sh
@@ -72,7 +72,7 @@ list_agent_specs() {
   done | sort -u
 }
 
-TMP_WORK="$(mktemp -d)"
+TMP_WORK="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMP_WORK"' EXIT
 
 # nlines: line count of a file (empty file -> 0). No pipe-to-grep so an empty

--- a/scripts/eval/static-analysis.sh
+++ b/scripts/eval/static-analysis.sh
@@ -86,7 +86,7 @@ EXISTING_TESTS=(
   "Agent Frontmatter|$PROJECT_ROOT/tests/agents/test-agent-frontmatter.sh"
 )
 
-TMPDIR_A=$(mktemp -d)
+TMPDIR_A=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 for entry in "${EXISTING_TESTS[@]}"; do
   name="${entry%%|*}"
   script="${entry##*|}"

--- a/scripts/probe-command-discovery.sh
+++ b/scripts/probe-command-discovery.sh
@@ -69,7 +69,7 @@ if [[ ! -d "$PLUGIN_SRC/commands" ]]; then
 fi
 EXPECTED_COMMANDS=$(ls "$PLUGIN_SRC/commands"/*.md | awk 'END{print NR}')
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 cleanup() { rm -rf "$WORK"; }
 trap cleanup EXIT
 

--- a/scripts/prune-playgrounds.sh
+++ b/scripts/prune-playgrounds.sh
@@ -99,7 +99,7 @@ main() {
   # 1. append the dirs to the archive branch via an isolated worktree.
   git fetch origin "${ARCHIVE_BRANCH}" --quiet
   local wt name
-  wt="$(mktemp -d)"
+  wt="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
   git worktree add --quiet "${wt}" "origin/${ARCHIVE_BRANCH}"
   for name in ${list}; do
     mkdir -p "${wt}/docs"

--- a/scripts/stamp-counts.sh
+++ b/scripts/stamp-counts.sh
@@ -345,7 +345,7 @@ if [[ "${1:-}" == "--check" ]]; then
   STALE=0
   for file in "${MARKER_FILES[@]}"; do
     if [[ ! -f "$file" ]]; then continue; fi
-    TMP=$(mktemp)
+    TMP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     cp "$file" "$TMP"
     stamp_file "$TMP"
     if ! diff -q "$file" "$TMP" >/dev/null 2>&1; then
@@ -358,7 +358,7 @@ if [[ "${1:-}" == "--check" ]]; then
   # Check marketplace.json
   MKT="$PROJECT_ROOT/.claude-plugin/marketplace.json"
   if [[ -f "$MKT" ]]; then
-    TMP=$(mktemp)
+    TMP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     cp "$MKT" "$TMP"
     if [[ "$(uname)" == "Darwin" ]]; then
       sed -i '' -E "s/[0-9]+ skills, [0-9]+ agents, [0-9]+ hooks/${SKILLS} skills, ${AGENTS} agents, ${HOOKS} hooks/g" "$TMP"
@@ -375,7 +375,7 @@ if [[ "${1:-}" == "--check" ]]; then
   # Check pyproject.toml description count tuple
   PYPROJECT="$PROJECT_ROOT/pyproject.toml"
   if [[ -f "$PYPROJECT" ]]; then
-    TMP=$(mktemp)
+    TMP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     cp "$PYPROJECT" "$TMP"
     if [[ "$(uname)" == "Darwin" ]]; then
       sed -i '' -E "s/[0-9]+ skills, [0-9]+ agents, and [0-9]+ hooks/${SKILLS} skills, ${AGENTS} agents, and ${HOOKS} hooks/g" "$TMP"
@@ -403,7 +403,7 @@ if [[ "${1:-}" == "--check" ]]; then
   # Check CLAUDE.md plain directory-structure count comment
   CLAUDE_MD_F="$PROJECT_ROOT/CLAUDE.md"
   if [[ -f "$CLAUDE_MD_F" ]]; then
-    TMP=$(mktemp)
+    TMP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     cp "$CLAUDE_MD_F" "$TMP"
     if [[ "$(uname)" == "Darwin" ]]; then
       sed -i '' -E "s/# [0-9]+ skills \\(YAML/# ${SKILLS} skills (YAML/g" "$TMP"
@@ -421,7 +421,7 @@ if [[ "${1:-}" == "--check" ]]; then
   DOCS_DIR="$PROJECT_ROOT/docs/site/content"
   if [[ -d "$DOCS_DIR" ]]; then
     while IFS= read -r -d '' file; do
-      TMP=$(mktemp)
+      TMP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
       cp "$file" "$TMP"
       apply_docs_mdx_patterns "$TMP"
       if ! diff -q "$file" "$TMP" >/dev/null 2>&1; then

--- a/tests/agents/test-mcp-declared-vs-granted.sh
+++ b/tests/agents/test-mcp-declared-vs-granted.sh
@@ -224,7 +224,7 @@ for srv in $SERVERS_WITH_ROSTER; do
   fi
   [ "$rc" -eq 1 ] && continue  # no tokens for this server anywhere: nothing to check
 
-  hits_file="$(mktemp)"
+  hits_file="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
   printf '%s\n' "$hits" > "$hits_file"
   while IFS= read -r hit; do
     [ -z "$hit" ] && continue

--- a/tests/build/test-check-install.sh
+++ b/tests/build/test-check-install.sh
@@ -26,7 +26,7 @@ report_pass() { PASS=$((PASS+1)); echo "  PASS: $1"; }
 report_fail() { FAIL=$((FAIL+1)); echo "  FAIL: $1" >&2; }
 
 # ----- setup: copy the script into a temp project tree -----
-TMPDIR_FAKE="$(mktemp -d)"
+TMPDIR_FAKE="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMPDIR_FAKE"' EXIT
 mkdir -p "$TMPDIR_FAKE/scripts"
 cp "$SCRIPT_PATH" "$TMPDIR_FAKE/scripts/check-install.sh"

--- a/tests/ci/test-no-bare-mktemp.sh
+++ b/tests/ci/test-no-bare-mktemp.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Test: no bare `mktemp` survives on the CI-executed surface.
+#
+# Why (the #3564 class, fifth sighting):
+#
+# `mktemp` called with NO TEMPLATE writes to the system temp dir and — on macOS —
+# IGNORES $TMPDIR entirely. When that write is denied the call dies, and under
+# `set -e` it takes the whole script with it. Today that produced, in four
+# separate files: a silently zeroed hook subcount reported as false drift, a test
+# runner that killed every commit before running a test, and an eval suite
+# reporting 5 failures that were not failures.
+#
+# The repair is the TEMPLATE, not the directory: `mktemp "${TMPDIR:-/tmp}/x.XXXXXX"`
+# honours TMPDIR, a bare `mktemp` cannot. This is why `TMPDIR=/unwritable` looks
+# like it disproves the bug — it changes nothing for a bare call.
+#
+# This gate exists because the previous two sweeps of this class each MISSED
+# most of the surface and reported success:
+#   - #3550 swept `.github/` only, so bin/ci-setup.sh kept hanging jobs
+#   - a `git grep -E '\s'` scan silently matched nothing useful, because ERE has
+#     no \s, so a 76-file surface was measured as 30
+# A gate that scans the whole tree in one dialect is the only thing that can
+# claim coverage.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo "=== Bare mktemp Test ==="
+echo ""
+
+FAILED=0
+HITS=$(cd "$REPO_ROOT" && git ls-files tests bin scripts .github | python3 -c '
+import sys, re, pathlib
+# One dialect, one scan. $(mktemp) / `mktemp` / $(mktemp -d), comments excluded.
+BARE = re.compile(r"(\$\(|\`)\s*mktemp(\s+-d)?\s*(\)|\`)")
+for f in sys.stdin.read().split():
+    p = pathlib.Path(f)
+    if not p.is_file():
+        continue
+    try:
+        text = p.read_text()
+    except Exception:
+        continue
+    for i, line in enumerate(text.split("\n"), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        if BARE.search(line):
+            print(f"{f}:{i}:{line.strip()[:80]}")
+')
+
+if [ -z "$HITS" ]; then
+    echo "  PASS: no bare mktemp on the CI-executed surface"
+else
+    while IFS= read -r h; do
+        [ -n "$h" ] || continue
+        echo "  FAIL: $h"
+        FAILED=1
+    done <<< "$HITS"
+fi
+
+echo ""
+if [ "$FAILED" -ne 0 ]; then
+    echo "RESULT: FAIL"
+    echo ""
+    echo 'Give the call an explicit template so it honours TMPDIR:'
+    echo '    tmp=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")'
+    echo '    dir=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")'
+    exit 1
+fi
+
+echo "RESULT: PASS"
+exit 0

--- a/tests/config/test-config-system.sh
+++ b/tests/config/test-config-system.sh
@@ -220,7 +220,7 @@ echo ""
 echo "=== 7. Safety Hook Protection Tests ==="
 
 # Create a temp config with safety=false (should be ignored)
-TEMP_CONFIG=$(mktemp)
+TEMP_CONFIG=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 cat > "$TEMP_CONFIG" << 'EOF'
 {
   "version": "1.0.0",

--- a/tests/e2e/test-coordination-e2e.sh
+++ b/tests/e2e/test-coordination-e2e.sh
@@ -31,7 +31,7 @@ fail() { echo -e "  ${RED}✗${NC} $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
 info() { echo -e "  ${BLUE}ℹ${NC} $1"; }
 
 # Test-specific temp directory
-TEST_TEMP_DIR=$(mktemp -d)
+TEST_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -rf "$TEST_TEMP_DIR"' EXIT
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/tests/evals/README.md
+++ b/tests/evals/README.md
@@ -285,7 +285,7 @@ npm run eval:trigger -- --all
 |--------|------------|
 | Command Execution | Allowlist-based validation (no arbitrary `eval`) |
 | Binary Downloads | yq pinned to v4.40.5 with SHA256 checksum |
-| Workspace Isolation | Each test runs in `mktemp -d` with cleanup trap |
+| Workspace Isolation | Each test runs in `mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX"` with cleanup trap |
 | CI Isolation | Ephemeral GitHub Actions runners |
 | Timeouts | Configurable per-test (default 120s) |
 

--- a/tests/evals/scripts/lib/eval-common.sh
+++ b/tests/evals/scripts/lib/eval-common.sh
@@ -249,7 +249,7 @@ preflight_check_plugin_errors() {
     fi
 
     local tmp_out
-    tmp_out=$(mktemp)
+    tmp_out=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$tmp_out")
 
     # Minimal probe: ask Claude to emit its init event and stop immediately.

--- a/tests/evals/scripts/run-agent-eval.sh
+++ b/tests/evals/scripts/run-agent-eval.sh
@@ -201,7 +201,7 @@ extract_output_text() {
 grade_assertions_batch() {
     local assertions_json="$1"
     local output_text="$2"
-    local tmpfile; tmpfile=$(mktemp)
+    local tmpfile; tmpfile=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$tmpfile")
 
     local grading_prompt
@@ -244,7 +244,7 @@ $output_text"
 grade_assertion() {
     local assertion_check="$1"
     local output_text="$2"
-    local tmpfile; tmpfile=$(mktemp)
+    local tmpfile; tmpfile=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$tmpfile")
 
     local grading_prompt
@@ -287,7 +287,7 @@ prepare_scaffold() {
         return 0
     fi
 
-    local scaffold_dir; scaffold_dir=$(mktemp -d)
+    local scaffold_dir; scaffold_dir=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_DIRS+=("$scaffold_dir")
 
     case "$scaffold_type" in
@@ -421,8 +421,8 @@ eval_agent() {
             output_text=$(extract_output_text "$saved_file")
         else
             # Run agent
-            local out_file; out_file=$(mktemp)
-            local err_file; err_file=$(mktemp)
+            local out_file; out_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
+            local err_file; err_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
             CLEANUP_FILES+=("$out_file" "$err_file")
 
             echo -e "${BLUE}||${NC}  ${CYAN}Running agent ${agent_id}...${NC}"

--- a/tests/evals/scripts/run-evals.sh
+++ b/tests/evals/scripts/run-evals.sh
@@ -160,7 +160,7 @@ run_test() {
 
     # Create isolated workspace (tracked for cleanup)
     local workspace
-    workspace="$(mktemp -d)"
+    workspace="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
     TEMP_WORKSPACES+=("$workspace")
     local output_dir="$workspace/output"
     mkdir -p "$output_dir"

--- a/tests/evals/scripts/run-quality-eval.sh
+++ b/tests/evals/scripts/run-quality-eval.sh
@@ -582,7 +582,7 @@ classify_generation() {
 grade_assertions_batch() {
     local assertions_json="$1"  # JSON array of {name, check}
     local output_text="$2"
-    local tmpfile; tmpfile=$(mktemp)
+    local tmpfile; tmpfile=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$tmpfile")
 
     local grading_prompt
@@ -630,7 +630,7 @@ $output_text"
 grade_assertion() {
     local assertion_check="$1"
     local output_text="$2"
-    local tmpfile; tmpfile=$(mktemp)
+    local tmpfile; tmpfile=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$tmpfile")
 
     local grading_prompt
@@ -715,7 +715,7 @@ prepare_scaffold() {
         return 0
     fi
 
-    local scaffold_dir; scaffold_dir=$(mktemp -d)
+    local scaffold_dir; scaffold_dir=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_DIRS+=("$scaffold_dir")
 
     case "$scaffold_type" in
@@ -805,9 +805,9 @@ run_eval_entry() {
     local prompt="$1"
     local scaffold_cwd="$2"
 
-    local with_file; with_file=$(mktemp)
-    local base_file; base_file=$(mktemp)
-    local with_stderr; with_stderr=$(mktemp)
+    local with_file; with_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
+    local base_file; base_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
+    local with_stderr; with_stderr=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$with_file" "$base_file" "$with_stderr")
 
     # #3036: set when any generation this entry needs is unusable. The caller

--- a/tests/evals/scripts/run-skill-eval.sh
+++ b/tests/evals/scripts/run-skill-eval.sh
@@ -488,7 +488,7 @@ EOF
 
     # --- Step 6: RECORD — append one ledger line (BOTH outcomes), atomically --
     mkdir -p "$HP_EVALS_DIR"
-    HP_LEDGER_TMP="$(mktemp)"
+    HP_LEDGER_TMP="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
     CLEANUP_FILES+=("$HP_LEDGER_TMP")
     if [[ "$HP_HAVE_JQ" == "true" ]]; then
         jq -c -n \

--- a/tests/evals/scripts/run-trigger-eval.sh
+++ b/tests/evals/scripts/run-trigger-eval.sh
@@ -188,7 +188,7 @@ run_prompt() {
     local skill_name="$2"
     local reps="$3"
     local triggered=0
-    local tmpfile; tmpfile=$(mktemp)
+    local tmpfile; tmpfile=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_FILES+=("$tmpfile")
 
     local classification_prompt
@@ -328,7 +328,7 @@ eval_skill() {
 
     # --- Parallel prompt execution ---
     # Launch all prompts concurrently (up to MAX_PARALLEL), collect results via temp files.
-    local result_dir; result_dir=$(mktemp -d)
+    local result_dir; result_dir=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     CLEANUP_DIRS+=("$result_dir")
     local pids=()
     local running=0

--- a/tests/evals/test-budget-governor.sh
+++ b/tests/evals/test-budget-governor.sh
@@ -19,7 +19,7 @@ source "$REPO_ROOT/tests/evals/scripts/lib/budget-governor.sh"
 
 STATE="$REPO_ROOT/tests/evals/results/.budget-state.json"
 BACKUP=""
-[[ -f "$STATE" ]] && { BACKUP="$(mktemp)"; cp "$STATE" "$BACKUP"; }
+[[ -f "$STATE" ]] && { BACKUP="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"; cp "$STATE" "$BACKUP"; }
 restore() {
   if [[ -n "$BACKUP" ]]; then cp "$BACKUP" "$STATE"; rm -f "$BACKUP"; else rm -f "$STATE"; fi
 }

--- a/tests/evals/test-dead-generation-guard.sh
+++ b/tests/evals/test-dead-generation-guard.sh
@@ -36,7 +36,7 @@ log_pass() { echo "  ${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
 log_fail() { echo "  ${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
 section() { echo; echo "${YELLOW}$1${NC}"; }
 
-TMP=$(mktemp -d)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -rf "$TMP"' EXIT
 
 echo "=========================================="

--- a/tests/evals/test-quality-index-gate.sh
+++ b/tests/evals/test-quality-index-gate.sh
@@ -32,7 +32,7 @@ FAIL=0
 log_pass() { echo -e "  ${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
 log_fail() { echo -e "  ${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
 
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 echo "Quality Index Gate Self-Test (#2194)"

--- a/tests/external/test-installation.sh
+++ b/tests/external/test-installation.sh
@@ -30,7 +30,7 @@ TEST_TEMP_DIR=""
 # =============================================================================
 
 setup() {
-    TEST_TEMP_DIR=$(mktemp -d)
+    TEST_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     echo "Test temp directory: $TEST_TEMP_DIR"
 }
 

--- a/tests/feedback/test-feedback-system.sh
+++ b/tests/feedback/test-feedback-system.sh
@@ -34,7 +34,7 @@ TEST_TEMP_DIR=""
 # =============================================================================
 
 setup() {
-    TEST_TEMP_DIR=$(mktemp -d)
+    TEST_TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     export CLAUDE_PROJECT_DIR="$TEST_TEMP_DIR"
     mkdir -p "$TEST_TEMP_DIR/.claude/feedback"
     mkdir -p "$TEST_TEMP_DIR/.claude/scripts"

--- a/tests/hooks/test-context-injection-budget.sh
+++ b/tests/hooks/test-context-injection-budget.sh
@@ -39,7 +39,7 @@ if [ ! -f "$HOOKS_DIST/prompt.mjs" ]; then
 fi
 
 # Create temp dir for test session flags (so once-per-session hooks fire)
-TEST_SESSION_DIR=$(mktemp -d)
+TEST_SESSION_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 TEST_SESSION_ID="test-budget-$(date +%s)"
 trap "rm -rf $TEST_SESSION_DIR" EXIT
 

--- a/tests/hooks/test-run-hook-dispatcher.sh
+++ b/tests/hooks/test-run-hook-dispatcher.sh
@@ -32,8 +32,8 @@ run_hook() {
   local env_args=()
   for arg in "$@"; do env_args+=("$arg"); done
 
-  local tmpout; tmpout=$(mktemp)
-  local tmperr; tmperr=$(mktemp)
+  local tmpout; tmpout=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
+  local tmperr; tmperr=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 
   local exit_code=0
   env "${env_args[@]}" node "$RUN_HOOK" "$hook_name" \
@@ -160,8 +160,8 @@ fi
 # 2c. No hook name → SILENT_OK
 LAST_STDOUT=""
 LAST_EXIT=999
-local_tmpout=$(mktemp)
-local_tmperr=$(mktemp)
+local_tmpout=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
+local_tmperr=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 node "$RUN_HOOK" < /dev/null >"$local_tmpout" 2>"$local_tmperr" || true
 LAST_STDOUT=$(cat "$local_tmpout")
 LAST_EXIT=$?
@@ -178,7 +178,7 @@ echo "3. Security Hook Override Protection"
 echo "------------------------------------"
 
 # 3a. Security hooks cannot be disabled via hook-overrides.json
-TEMP_PROJECT=$(mktemp -d)
+TEMP_PROJECT=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 mkdir -p "$TEMP_PROJECT/.claude"
 cat > "$TEMP_PROJECT/.claude/hook-overrides.json" << 'OVERRIDE_EOF'
 {
@@ -253,10 +253,10 @@ fi
 # 4d. Oversized stdin (>512KB) — produces truncation warning
 # Use a temp file to avoid shell ARG_MAX limits on large payloads
 if command -v python3 &>/dev/null; then
-  LARGE_FILE=$(mktemp)
+  LARGE_FILE=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
   python3 -c "import json; open('$LARGE_FILE','w').write(json.dumps({'tool_input':{'command':'echo hi'},'hook_event':'PreToolUse','padding':'x'*600000}))"
-  local_tmpout=$(mktemp)
-  local_tmperr=$(mktemp)
+  local_tmpout=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
+  local_tmperr=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
   local_exit=0
   env "CLAUDE_PROJECT_DIR=$PROJECT_ROOT" node "$RUN_HOOK" "pretool/bash/dangerous-command-blocker" \
     < "$LARGE_FILE" >"$local_tmpout" 2>"$local_tmperr" || local_exit=$?
@@ -453,7 +453,7 @@ echo "--------------------------------------------"
 # level and asserts the record physically lands. It MUST fail if either default
 # regresses to the dropped side of the gate.
 
-SANDBOX=$(mktemp -d)
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 mkdir -p "$SANDBOX/home/.claude/teams/ghost-team-$$" "$SANDBOX/proj"
 echo '{}' > "$SANDBOX/home/.claude/teams/ghost-team-$$/config.json"
 # Backdate 48h so the 24h staleness window fires (BSD touch first, GNU fallback)

--- a/tests/hooks/test-stale-cache-cleanup.sh
+++ b/tests/hooks/test-stale-cache-cleanup.sh
@@ -53,7 +53,7 @@ LIVE_PID=$$
 # to /.claude/... and the hook silently no-ops, which reads exactly like the
 # bug under test. That mistake cost a debugging cycle here, so it is spelled out.
 make_fixture() {
-    FIX="$(mktemp -d)"
+    FIX="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
     local ch="$FIX/.claude/plugins/cache/orchestkit/$1"; shift
     mkdir -p "$ch"
     for spec in "$@"; do

--- a/tests/integration/hooks/test-continue-on-block-pattern.sh
+++ b/tests/integration/hooks/test-continue-on-block-pattern.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FIXTURE_DRIVER="$SCRIPT_DIR/lib/run-hook-fixture.mjs"
 
-TMP_DIR="$(mktemp -d)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
 PASS=0

--- a/tests/integration/test-cc-backfill-changelog-ref.sh
+++ b/tests/integration/test-cc-backfill-changelog-ref.sh
@@ -45,7 +45,7 @@ norm() { sed -E 's/^[[:space:]]*[-*+][[:space:]]+//; s/[[:space:]]+/ /g; s/^[[:s
 echo "CC Backfill Changelog-Ref — migration tests"
 echo "========================================================="
 
-MOCK_DIR=$(mktemp -d)
+MOCK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 MOCK_LOG="$MOCK_DIR/gh.log"
 export MOCK_LOG
 cat > "$MOCK_DIR/gh" <<'MOCK'

--- a/tests/integration/test-cc-consolidate-milestones.sh
+++ b/tests/integration/test-cc-consolidate-milestones.sh
@@ -43,7 +43,7 @@ echo "CC Consolidate Milestones — sweep tests"
 echo "========================================================="
 
 # ---- mock gh (PATH-shadow) ----------------------------------------------------
-MOCK_DIR=$(mktemp -d)
+MOCK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 MOCK_LOG="$MOCK_DIR/gh.log"
 export MOCK_LOG
 cat > "$MOCK_DIR/gh" <<'MOCK'

--- a/tests/integration/test-cc-release-watch-step3.sh
+++ b/tests/integration/test-cc-release-watch-step3.sh
@@ -42,7 +42,7 @@ echo "========================================================="
 cd "$PROJECT_ROOT"
 
 # ---- mock gh (PATH-shadow) ----------------------------------------------------
-MOCK_DIR=$(mktemp -d)
+MOCK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 MOCK_LOG="$MOCK_DIR/gh.log"
 export MOCK_LOG
 cat > "$MOCK_DIR/gh" <<'MOCK'
@@ -105,7 +105,7 @@ MOCK
 chmod +x "$MOCK_DIR/gh"
 export PATH="$MOCK_DIR:$PATH"
 
-WORK=$(mktemp -d)
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 cleanup() { rm -rf "$MOCK_DIR" "$WORK"; }
 trap cleanup EXIT
 
@@ -367,7 +367,7 @@ dispo_of() {
 }
 
 # ---- Case 12 (#2993): above-floor + ZERO evidence → NOT filed, noop stamped ---
-EVDIR=$(mktemp -d)   # empty dir = no evidence anywhere
+EVDIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")   # empty dir = no evidence anywhere
 F=$(feat "chrome_scroll_polish" 20)
 GAPS=$(jq -nc --argjson f "$F" '[{version: "2.1.999", features: [$f]}]')
 run_gate "case12-noop" "$GAPS" "$EVDIR"
@@ -383,7 +383,7 @@ rm -rf "$EVDIR"
 # ---- Case 13 (#2992): sub-floor + evidence → filed via recall lane -----------
 # The changelog line carries a mixedCase identifier (SessionStart) that appears
 # in the evidence file — the STRONG-token hit that drives the recall lane.
-EVDIR=$(mktemp -d)
+EVDIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 echo "handles SessionStart source and fork materialization" > "$EVDIR/dispatcher.ts"
 F=$(jq -nc '{feature_slug: "session_fork_source", gap_score: 5, description: "SessionStart reports source fork", category: "new_field", reference_changelog_line: "Changed SessionStart hooks to report source fork", affected_skills: []}')
 GAPS=$(jq -nc --argjson f "$F" '[{version: "2.1.999", features: [$f]}]')
@@ -404,7 +404,7 @@ fi
 rm -rf "$EVDIR"
 
 # ---- Case 14 (#2992): sub-floor + NO evidence → unfiled-subfloor -------------
-EVDIR=$(mktemp -d)   # empty
+EVDIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")   # empty
 F=$(feat "chrome_tab_group" 5)
 GAPS=$(jq -nc --argjson f "$F" '[{version: "2.1.999", features: [$f]}]')
 run_gate "case14-unfiled" "$GAPS" "$EVDIR"
@@ -445,7 +445,7 @@ fi
 # ---- Case 16 (#2993): above-floor WITH evidence → still files (gate-on happy) -
 # The changelog line names a mixedCase identifier (SubagentStop) present in the
 # evidence file — the STRONG-token hit that lets the precision lane file.
-EVDIR=$(mktemp -d)
+EVDIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 echo "the dispatcher handles the SubagentStop hook" > "$EVDIR/dispatcher.ts"
 F=$(jq -nc '{feature_slug: "subagentstop_hook", gap_score: 15, description: "Added the SubagentStop hook", category: "new_event", reference_changelog_line: "Added the SubagentStop hook event", affected_skills: []}')
 GAPS=$(jq -nc --argjson f "$F" '[{version: "2.1.999", features: [$f]}]')

--- a/tests/integration/test-cc-release-watch.sh
+++ b/tests/integration/test-cc-release-watch.sh
@@ -28,7 +28,7 @@ cd "$PROJECT_ROOT"
 
 # Save state we'll mutate during tests. Errors during backup are real (FS issue, perm denied)
 # and should fail the test rather than be hidden.
-SNAPSHOTS_BACKUP=$(mktemp -d)
+SNAPSHOTS_BACKUP=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 if [ -d shared/cc-snapshots ]; then
   # rsync rather than cp -r/. so we don't need shell-glob expansion of dotfiles.
   rsync -a shared/cc-snapshots/ "$SNAPSHOTS_BACKUP/"
@@ -452,7 +452,7 @@ mkdir -p shared/cc-snapshots
 LK=$(jq -r '.latest_known // .latest' shared/cc-support.json)
 STALE_FIXTURE=$(mktemp /tmp/cc-stale-fixture.XXXXXX)
 printf '# Changelog\n\n## 9.9.903\n\n- synthetic newest\n\n## 9.9.902\n\n- synthetic\n\n## 9.9.901\n\n- synthetic\n\n## %s\n\n- latest_known anchor\n' "$LK" > "$STALE_FIXTURE"
-GHOUT=$(mktemp)
+GHOUT=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 EXIT=0
 CC_RELEASE_WATCH_FIXTURE="$STALE_FIXTURE" GITHUB_OUTPUT="$GHOUT" \
   node scripts/cc-release-watch.mjs > /tmp/watch-stale.txt 2>&1 || EXIT=$?
@@ -478,7 +478,7 @@ mkdir -p shared/cc-snapshots
 LK=$(jq -r '.latest_known // .latest' shared/cc-support.json)
 STALE_FIXTURE=$(mktemp /tmp/cc-stale-fixture.XXXXXX)
 printf '# Changelog\n\n## 9.9.902\n\n- synthetic newest\n\n## 9.9.901\n\n- synthetic\n\n## %s\n\n- latest_known anchor\n' "$LK" > "$STALE_FIXTURE"
-GHOUT=$(mktemp)
+GHOUT=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 EXIT=0
 CC_RELEASE_WATCH_FIXTURE="$STALE_FIXTURE" GITHUB_OUTPUT="$GHOUT" \
   node scripts/cc-release-watch.mjs > /tmp/watch-stale2.txt 2>&1 || EXIT=$?
@@ -502,7 +502,7 @@ rm -rf shared/cc-snapshots/*.md shared/cc-adoption-gaps.json shared/gh-issue-arg
 mkdir -p shared/cc-snapshots
 STALE_FIXTURE=$(mktemp /tmp/cc-stale-fixture.XXXXXX)
 printf '# Changelog\n\n## 9.9.904\n\n- synthetic newest\n\n## 9.9.903\n\n- synthetic\n\n## 9.9.902\n\n- synthetic\n\n## 9.9.901\n\n- synthetic\n' > "$STALE_FIXTURE"
-GHOUT=$(mktemp)
+GHOUT=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 EXIT=0
 CC_RELEASE_WATCH_FIXTURE="$STALE_FIXTURE" GITHUB_OUTPUT="$GHOUT" \
   node scripts/cc-release-watch.mjs > /tmp/watch-stale3.txt 2>&1 || EXIT=$?
@@ -523,7 +523,7 @@ rm -rf shared/cc-snapshots/*.md shared/cc-adoption-gaps.json shared/gh-issue-arg
 mkdir -p shared/cc-snapshots
 GAP_FIXTURE=$(mktemp /tmp/cc-gap-fixture.XXXXXX)
 printf '# Changelog\n\n## 2.1.176\n\n- synthetic newest changelogged\n' > "$GAP_FIXTURE"
-GHOUT=$(mktemp)
+GHOUT=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 EXIT=0
 CC_RELEASE_WATCH_FIXTURE="$GAP_FIXTURE" CC_PUBLISHED_VERSION=2.1.177 GITHUB_OUTPUT="$GHOUT" \
   node scripts/cc-release-watch.mjs > /tmp/watch-gap.txt 2>&1 || EXIT=$?

--- a/tests/integration/test-cc-stale-belowfloor.sh
+++ b/tests/integration/test-cc-stale-belowfloor.sh
@@ -40,7 +40,7 @@ count_calls() {
 echo "CC Stale Below-Floor — labeling sweep tests"
 echo "========================================================="
 
-MOCK_DIR=$(mktemp -d)
+MOCK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 MOCK_LOG="$MOCK_DIR/gh.log"
 export MOCK_LOG
 cat > "$MOCK_DIR/gh" <<'MOCK'
@@ -77,7 +77,7 @@ MOCK
 chmod +x "$MOCK_DIR/gh"
 export PATH="$MOCK_DIR:$PATH"
 
-WORK=$(mktemp -d)
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 cleanup() { rm -rf "$MOCK_DIR" "$WORK"; }
 trap cleanup EXIT
 

--- a/tests/integration/test-cc-support-stamper.sh
+++ b/tests/integration/test-cc-support-stamper.sh
@@ -43,7 +43,7 @@ ORIG_TROUBLESHOOTING=$(cat docs/site/content/docs/troubleshooting/index.mdx)
 # as 7 spuriously dirty files, and trailing-newline state is load-bearing here —
 # see tests/skills/test-skill-length.sh, which documents that `wc -l` under-counts
 # a file missing its final newline.
-COMPAT_BACKUP_DIR=$(mktemp -d)
+COMPAT_BACKUP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 for skill_md in src/skills/*/SKILL.md; do
     [ -f "$skill_md" ] || continue
     mkdir -p "$COMPAT_BACKUP_DIR/$(dirname "$skill_md")"
@@ -75,7 +75,7 @@ fi
 # adds one.
 # ---------------------------------------------------------------------------
 STAMPER_SRC="scripts/stamp-cc-support.mjs"
-BACKUP_DIR=$(mktemp -d)
+BACKUP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 
 # `while read` rather than `mapfile`: this script's shebang is /bin/bash, which
 # on macOS is bash 3.2 where mapfile does not exist. A mapfile version passes

--- a/tests/integration/test-cc-triage.sh
+++ b/tests/integration/test-cc-triage.sh
@@ -34,7 +34,7 @@ GAPS_BACKUP=""
 SKILL_GAPS_BACKUP=""
 SKILL_GAPS_EXISTED=0
 [ -f shared/cc-skill-gaps.json ] && { SKILL_GAPS_BACKUP=$(cat shared/cc-skill-gaps.json); SKILL_GAPS_EXISTED=1; }
-SNAP_BACKUP_DIR=$(mktemp -d)
+SNAP_BACKUP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 [ -d shared/cc-snapshots ] && rsync -a shared/cc-snapshots/ "$SNAP_BACKUP_DIR/"
 
 restore() {

--- a/tests/integration/test-hook-chains.sh
+++ b/tests/integration/test-hook-chains.sh
@@ -29,7 +29,7 @@ export CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT/src"
 export CLAUDE_SESSION_ID="integration-test-$(date +%s)"
 
 # Temp directory
-TEST_TMP=$(mktemp -d)
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf $TEST_TMP" EXIT
 
 echo "=========================================="

--- a/tests/integration/test-multi-instance-gates.sh
+++ b/tests/integration/test-multi-instance-gates.sh
@@ -53,7 +53,7 @@ assert_output_contains() {
 }
 
 # Create temp directory for test files
-TEMP_DIR=$(mktemp -d)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf '$TEMP_DIR'" EXIT
 
 # NOTE: the skill duplication-detector and merge-conflict prediction hooks were

--- a/tests/integration/test-visual-style-validator.sh
+++ b/tests/integration/test-visual-style-validator.sh
@@ -29,7 +29,7 @@ VALIDATOR="bin/validate-visual-style.py"
 WRAPPER="bin/check-pr-visual-style.sh"
 WORKFLOW=".github/workflows/visual-style-lint.yml"
 
-WORK="$(mktemp -d)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
 # UTF-8 byte sequences (octal) so the test file itself stays low-emoji.

--- a/tests/manifests/test-manifest-dependencies.sh
+++ b/tests/manifests/test-manifest-dependencies.sh
@@ -60,7 +60,7 @@ if [[ ! -d "$MANIFESTS_DIR" ]]; then
 fi
 
 # Collect all known plugin names
-KNOWN_PLUGINS=$(mktemp)
+KNOWN_PLUGINS=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -f $KNOWN_PLUGINS" EXIT
 for manifest in "$MANIFESTS_DIR"/*.json; do
     jq -r '.name' "$manifest" >> "$KNOWN_PLUGINS"

--- a/tests/manifests/test-marketplace-ordering.sh
+++ b/tests/manifests/test-marketplace-ordering.sh
@@ -57,7 +57,7 @@ if [[ ! -f "$MARKETPLACE_JSON" ]]; then
 fi
 
 # Build position map: plugin_name -> index (0-based)
-POSITION_MAP=$(mktemp)
+POSITION_MAP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -f $POSITION_MAP" EXIT
 
 jq -r '.plugins[].name' "$MARKETPLACE_JSON" | nl -ba -v0 | while read -r idx name; do

--- a/tests/manifests/test-plugin-orphan-skills.sh
+++ b/tests/manifests/test-plugin-orphan-skills.sh
@@ -63,7 +63,7 @@ if [[ ! -d "$MANIFESTS_DIR" ]]; then
 fi
 
 # Collect all skills referenced in manifests (explicit arrays + "all")
-CLAIMED_SKILLS=$(mktemp)
+CLAIMED_SKILLS=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 HAS_ALL_PLUGIN=false
 ALL_PLUGIN_NAME=""
 trap "rm -f $CLAIMED_SKILLS" EXIT

--- a/tests/manifests/test-skill-uniqueness.sh
+++ b/tests/manifests/test-skill-uniqueness.sh
@@ -61,7 +61,7 @@ if [[ ! -d "$MANIFESTS_DIR" ]]; then
 fi
 
 # Temp file for skill->plugin mappings
-SKILL_MAP=$(mktemp)
+SKILL_MAP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -f $SKILL_MAP" EXIT
 
 # Collect all skill->plugin mappings from manifests

--- a/tests/orphans/test-unreachable-skills.sh
+++ b/tests/orphans/test-unreachable-skills.sh
@@ -67,7 +67,7 @@ ADVISORY="${ORK_UNREACHABLE_SKILLS_ADVISORY:-0}"
 VERBOSE=""
 for arg in "$@"; do [[ "$arg" == "--verbose" ]] && VERBOSE="1"; done
 
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 # Places an inbound reference can legitimately live. docs/ is deliberately out:

--- a/tests/schemas/test-alpha-channel.sh
+++ b/tests/schemas/test-alpha-channel.sh
@@ -179,7 +179,7 @@ if [[ ! -x "$BUMP_SCRIPT" ]]; then
 else
     ok "scripts/bump-stable-pin.sh is present and executable"
 
-    fixture_dir=$(mktemp -d)
+    fixture_dir=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     trap 'rm -rf "$fixture_dir"' EXIT
     fixture="$fixture_dir/marketplace.json"
 

--- a/tests/security/test-additional-security.sh
+++ b/tests/security/test-additional-security.sh
@@ -84,9 +84,9 @@ section()  { echo; echo "${YELLOW}$1${NC}"; }
 # comparing, so an unresolved sandbox root NEVER matches the resolved file path
 # and every containment assertion silently reads as "outside the project" —
 # a green run that graded nothing. Measured, not assumed.
-SANDBOX_PROJECT="$(cd "$(mktemp -d)" && pwd -P)"
-SANDBOX_OUTSIDE="$(cd "$(mktemp -d)" && pwd -P)"
-SANDBOX_TMP="$(cd "$(mktemp -d)" && pwd -P)"
+SANDBOX_PROJECT="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")" && pwd -P)"
+SANDBOX_OUTSIDE="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")" && pwd -P)"
+SANDBOX_TMP="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")" && pwd -P)"
 cleanup_all() {
   rm -rf "$SANDBOX_PROJECT" "$SANDBOX_OUTSIDE" "$SANDBOX_TMP"
   cleanup_test_env
@@ -256,7 +256,7 @@ run_instructions_loaded() { # run_instructions_loaded <tmpdir> <session_id>
 
 probe_session_id() { # probe_session_id <session_id> <expected-dirname> <label>
   local sid="$1" want="$2" label="$3" root got
-  root="$(cd "$(mktemp -d)" && pwd -P)"
+  root="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")" && pwd -P)"
   run_instructions_loaded "$root" "$sid"
 
   # Exactly one top-level entry, named as expected.
@@ -284,7 +284,7 @@ probe_session_id 'sess-abc123' \
 
 # The traversal payload is the one that could actually escape. Assert the
 # negative directly rather than inferring it from a directory listing.
-ESCAPE_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
+ESCAPE_ROOT="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")" && pwd -P)"
 mkdir -p "$ESCAPE_ROOT/inner"
 run_instructions_loaded "$ESCAPE_ROOT/inner" '../../../../pwned'
 if [[ -e "$ESCAPE_ROOT/pwned" ]] || [[ -e "$ESCAPE_ROOT/claude-session-..." ]]; then

--- a/tests/security/test-jq-injection.sh
+++ b/tests/security/test-jq-injection.sh
@@ -68,7 +68,7 @@ log_pass() { echo "  ${GREEN}✓${NC} $1"; }
 log_fail() { echo "  ${RED}✗${NC} $1"; }
 section()  { echo; echo "${YELLOW}$1${NC}"; }
 
-TMPD="$(mktemp -d)"
+TMPD="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMPD"' EXIT
 
 # ============================================================================

--- a/tests/security/test-npm-audit.sh
+++ b/tests/security/test-npm-audit.sh
@@ -119,7 +119,7 @@ audit_project() {
   echo "▶ $label ($dir)"
 
   local report errfile
-  errfile=$(mktemp)
+  errfile=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
   # npm audit exits 1 whenever findings exist, which is the normal case here, so
   # its exit code cannot distinguish "found CVEs" from "could not run". We decide
   # on the report instead. stderr is captured rather than discarded: an earlier

--- a/tests/security/test-path-traversal.sh
+++ b/tests/security/test-path-traversal.sh
@@ -92,7 +92,7 @@ section "4. Symlink bypass — the ME-001 defence (CWE-59)"
 # in the suite exercised that claim, so it was documentation rather than a
 # tested behaviour. A symlink pointing at a protected file must be denied on the
 # basis of its TARGET, not its innocuous-looking name.
-TMPD="$(mktemp -d)"
+TMPD="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 # Chain, do not replace: a bare `trap ... EXIT` OVERWRITES the helper's
 # `trap cleanup_test_env EXIT` (test-helpers.sh), so $TMPDIR/orchestkit-tests-$$
 # leaked on every run of this file.

--- a/tests/security/test-sqlite-injection.sh
+++ b/tests/security/test-sqlite-injection.sh
@@ -93,7 +93,7 @@ if [[ ! -x "$RUNNER" ]]; then
   echo "${RED}✗ hook runner missing: $RUNNER${NC}"
   exit 1
 fi
-TMPD="$(mktemp -d)"
+TMPD="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMPD"' EXIT
 
 # The DB is read back through node:sqlite rather than the sqlite3 CLI. That is

--- a/tests/security/test-symlink-attacks.sh
+++ b/tests/security/test-symlink-attacks.sh
@@ -75,7 +75,7 @@ if ! assert_hook_registered "$GUARD"; then
   exit 1
 fi
 
-TMPD="$(mktemp -d)"
+TMPD="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 # Chain, do not replace: a bare `trap ... EXIT` OVERWRITES the helper's
 # `trap cleanup_test_env EXIT` (test-helpers.sh), leaking the per-process
 # temp dir on every run.

--- a/tests/security/test-unicode-attacks.sh
+++ b/tests/security/test-unicode-attacks.sh
@@ -127,7 +127,7 @@ assert_absent() { # assert_absent <haystack> <needle> <label>
   fi
 }
 
-WORK_DIR="$(mktemp -d)"
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$WORK_DIR"' EXIT
 
 # ===========================================================================

--- a/tests/skills/run-skill-tests.sh
+++ b/tests/skills/run-skill-tests.sh
@@ -116,7 +116,7 @@ DIM='\033[2m'
 NC='\033[0m'
 
 # Results tracking
-RESULTS_FILE=$(mktemp)
+RESULTS_FILE=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 TOTAL_TESTS=0
 TOTAL_PASSED=0
 TOTAL_FAILED=0
@@ -297,7 +297,7 @@ run_test_file() {
     fi
 
     local output_file
-    output_file=$(mktemp)
+    output_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     local start
     start=$(get_ms)
     local exit_code=0

--- a/tests/skills/scripts/fixtures/script-test-helpers.sh
+++ b/tests/skills/scripts/fixtures/script-test-helpers.sh
@@ -138,7 +138,7 @@ check_arguments_in_markdown() {
     # Check for $ARGUMENTS outside of !command patterns
     # Remove !command patterns first, then check for $ARGUMENTS
     local temp_file
-    temp_file=$(mktemp)
+    temp_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     # Remove !`...` patterns
     sed 's/!`[^`]*`//g' "$file" > "$temp_file"
     # Check for $ARGUMENTS in remaining content
@@ -287,7 +287,7 @@ uses_arguments_in_task() {
     local file="$1"
     # Get content after removing !command patterns
     local temp_file
-    temp_file=$(mktemp)
+    temp_file=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     sed 's/!`[^`]*`//g' "$file" > "$temp_file"
     # Check for $ARGUMENTS in task section
     if awk '/Your Task|Task:|Instructions:/,/^##|^$/ {print}' "$temp_file" 2>/dev/null | grep -q '\$ARGUMENTS'; then

--- a/tests/skills/scripts/integration/test-script-execution.sh
+++ b/tests/skills/scripts/integration/test-script-execution.sh
@@ -217,7 +217,7 @@ for skill_path in "${SAMPLE_SKILLS[@]}"; do
     skill_name=$(echo "$skill_path" | cut -d'/' -f1)
     
     # Simulate full invocation: execute commands, substitute arguments
-    temp_content=$(mktemp)
+    temp_content=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     
     # Read file and process
     while IFS= read -r line; do

--- a/tests/skills/scripts/integration/test-script-invocation.sh
+++ b/tests/skills/scripts/integration/test-script-invocation.sh
@@ -84,7 +84,7 @@ simulate_skill_invocation() {
     local skill_file="$1"
     local arguments="${2:-}"
     local temp_output
-    temp_output=$(mktemp)
+    temp_output=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     
     # Step 1: Read skill file
     local skill_content

--- a/tests/skills/structure/test-cross-model-refuter-contract.sh
+++ b/tests/skills/structure/test-cross-model-refuter-contract.sh
@@ -24,7 +24,7 @@ SCHEMA="$REPO_ROOT/src/skills/review-pr/references/cross-model-output.schema.jso
 STUB="$REPO_ROOT/tests/fixtures/cross-model-refuter/stub-alt-model.sh"
 DOC="$REPO_ROOT/src/skills/review-pr/references/cross-model-refuter.md"
 ENGINE="$REPO_ROOT/src/shared/rules/adversarial-refutation.md"
-ERR="$(mktemp)"
+ERR="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -f "$ERR"' EXIT
 
 FAILED=0

--- a/tests/skills/structure/test-streak-gate-contract.sh
+++ b/tests/skills/structure/test-streak-gate-contract.sh
@@ -22,7 +22,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 GATE_DOC="$REPO_ROOT/src/skills/verify/references/streak-gate.md"
 SCHEMA="$REPO_ROOT/src/shared/rubric.schema.json"
 VERIFY_RUBRIC="$REPO_ROOT/src/skills/verify/rubric.json"
-ERR="$(mktemp)"
+ERR="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -f "$ERR"' EXIT
 
 FAILED=0

--- a/tests/skills/test-dashboard-specs.sh
+++ b/tests/skills/test-dashboard-specs.sh
@@ -55,7 +55,7 @@ done
 
 # Negative cases
 echo "[invalid specs]"
-TMP="$(mktemp)"
+TMP="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap "rm -f $TMP" EXIT
 SCRIPT="$PROJECT_ROOT/src/skills/explore/scripts/render-spec.mjs"
 
@@ -117,7 +117,7 @@ check "renders StatusBadge error glyph" bash -c "node '$SCRIPT' '$TMP' | grep -q
 echo "[main flag handling]"
 check_fails "no path arg fails cleanly"            node "$SCRIPT"
 check_fails "non-existent file fails cleanly"      node "$SCRIPT" "/tmp/does-not-exist-$$.json" --check
-TMPNOJSON=$(mktemp); echo 'not json content' > "$TMPNOJSON"
+TMPNOJSON=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX"); echo 'not json content' > "$TMPNOJSON"
 check_fails "invalid JSON content fails cleanly"   node "$SCRIPT" "$TMPNOJSON" --check
 rm -f "$TMPNOJSON"
 

--- a/tests/skills/test-mcp-pinning-check.sh
+++ b/tests/skills/test-mcp-pinning-check.sh
@@ -19,7 +19,7 @@ if [[ ! -x "$CHECK" ]]; then
     exit 1
 fi
 
-TMP="$(mktemp -d)"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "$TMP"' EXIT
 
 PASS=0

--- a/tests/skills/test-shared-scripts-drift.sh
+++ b/tests/skills/test-shared-scripts-drift.sh
@@ -34,7 +34,7 @@ fi
 # Negative case: introduce drift in a copy, --check must catch it; restore + verify
 CONSUMER="$PROJECT_ROOT/src/skills/explore/scripts/render-spec.mjs"
 if [[ -f "$CONSUMER" ]]; then
-  BACKUP="$(mktemp)"
+  BACKUP="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
   cp "$CONSUMER" "$BACKUP"
   trap 'cp "$BACKUP" "$CONSUMER"; rm -f "$BACKUP"' EXIT
   echo "// drift injected by test" >> "$CONSUMER"

--- a/tests/skills/test-storybook-catalog-import.sh
+++ b/tests/skills/test-storybook-catalog-import.sh
@@ -53,9 +53,9 @@ check "fixture passes --check" node "$SCRIPT" "$FIXTURE" --check
 echo
 
 # Generate and inspect output
-TMP=$(mktemp -d)
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf $TMP" EXIT
-PROJ=$(mktemp -d)
+PROJ=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf $TMP $PROJ" EXIT
 
 echo "[generation]"

--- a/tests/skills/triggering/test-trigger-keywords.sh
+++ b/tests/skills/triggering/test-trigger-keywords.sh
@@ -73,7 +73,7 @@ for eval_file in "$EVALS_DIR"/*.eval.yaml; do
     $VERBOSE && echo -e "  \033[1m$sid\033[0m"
 
     # Extract prompts with yq once into temp file
-    tmpf=$(mktemp)
+    tmpf=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
     yq -r '(.trigger_evals // [])[] | [.should_trigger, .prompt] | @tsv' "$eval_file" > "$tmpf" 2>/dev/null || true
 
     while IFS=$'\t' read -r should_trigger prompt; do

--- a/tests/unit/test-audit-activation.sh
+++ b/tests/unit/test-audit-activation.sh
@@ -24,7 +24,7 @@ echo "════════════════════════�
 # Sandbox tree: a fake src/agents + .claude/logs so the script's path-join
 # resolves to controlled fixtures (it derives REPO_ROOT from its own location,
 # so we copy the script into a temp tree four levels deep to match).
-SBX="$(mktemp -d)"
+SBX="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 mkdir -p "$SBX/src/skills/audit-activation/scripts" "$SBX/src/agents" "$SBX/.claude/logs" "$SBX/src/skills/demo"
 cp "$AUDIT" "$SBX/src/skills/audit-activation/scripts/run-activation-audit.sh"
 for a in alpha-agent beta-agent gamma-agent; do printf 'name: %s\n' "$a" > "$SBX/src/agents/$a.md"; done

--- a/tests/unit/test-changelog-parser.sh
+++ b/tests/unit/test-changelog-parser.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PARSER="$PROJECT_ROOT/scripts/changelog-to-props.mjs"
-FIXTURE_DIR=$(mktemp -d)
+FIXTURE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -rf "$FIXTURE_DIR"' EXIT
 
 RED=$'\033[0;31m'
@@ -56,7 +56,7 @@ EOF
 
 # Run parser against the fixture by temporarily overlaying CHANGELOG.md
 ORIG_CHANGELOG="$PROJECT_ROOT/CHANGELOG.md"
-BACKUP=$(mktemp)
+BACKUP=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
 cp "$ORIG_CHANGELOG" "$BACKUP"
 trap 'cp "$BACKUP" "$ORIG_CHANGELOG"; rm -f "$BACKUP"; rm -rf "$FIXTURE_DIR"' EXIT
 

--- a/tests/unit/test-consent-manager.sh
+++ b/tests/unit/test-consent-manager.sh
@@ -21,7 +21,7 @@ YELLOW=$'\033[33m'
 RESET=$'\033[0m'
 
 # Create temporary test directory
-TEST_DIR=$(mktemp -d)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf $TEST_DIR" EXIT
 
 # Export test environment

--- a/tests/unit/test-handoff-bundle-schema.sh
+++ b/tests/unit/test-handoff-bundle-schema.sh
@@ -29,7 +29,7 @@ pass() { echo "  ${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
 fail() { echo "  ${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
 
 # ─── sandbox for all fixtures ────────────────────────────────────────
-SANDBOX=$(mktemp -d)
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -rf "$SANDBOX"' EXIT
 
 # Helper: build a bundle from a directory, return path to .tar.gz

--- a/tests/unit/test-hooks-unit.sh
+++ b/tests/unit/test-hooks-unit.sh
@@ -35,7 +35,7 @@ export CLAUDE_SESSION_ID="test-session-$(date +%s)"
 export CLAUDE_PLUGIN_ROOT="$PROJECT_ROOT/plugins/ork"
 
 # Temp directory for test outputs
-TEST_TMP=$(mktemp -d)
+TEST_TMP=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf $TEST_TMP" EXIT
 
 echo "=========================================="

--- a/tests/unit/test-m127-boot-helpers.sh
+++ b/tests/unit/test-m127-boot-helpers.sh
@@ -37,7 +37,7 @@ fi
 source "${BOOT_SH}"
 
 # ── Fixture helpers ─────────────────────────────────────────────────────────
-TMP_BASE="$(mktemp -d)"
+TMP_BASE="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 trap 'rm -rf "${TMP_BASE}"' EXIT
 
 new_fixture() {

--- a/tests/unit/test-mdx-compile.sh
+++ b/tests/unit/test-mdx-compile.sh
@@ -57,7 +57,7 @@ fi
 #      so the guard works on every PR even without the private token.
 if [[ ! -d "$DOCS_SITE/node_modules/@mdx-js/mdx" ]]; then
   echo "  ${YELLOW}⚠${NC} @mdx-js/mdx not in docs/site/node_modules — installing"
-  INSTALL_LOG=$(mktemp)
+  INSTALL_LOG=$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")
   trap 'rm -f "$INSTALL_LOG"' EXIT
 
   set +e

--- a/tests/unit/test-memory-index-budget.sh
+++ b/tests/unit/test-memory-index-budget.sh
@@ -26,7 +26,7 @@ echo "  Auto-memory index budget check (ork:doctor Cat 4)"
 echo "════════════════════════════════════════════════════════════════"
 
 # ── Extract the verbatim snippet from the doc ───────────────────────────────
-SNIP="$(mktemp)"
+SNIP="$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")"
 awk '/## Auto-Memory Index Budget/{f=1} f&&/```bash/{c=1;next} f&&/```/{if(c)exit} c' "$DOC" > "$SNIP"
 if ! grep -q 'ORK_MEM_INDEX' "$SNIP"; then
   fail "snippet missing ORK_MEM_INDEX override — not testable"
@@ -41,7 +41,7 @@ assert() { # name, output, expected-substring
 assert_empty() { if [ -z "$2" ]; then pass "$1"; else fail "$1 — got: $2"; fi; }
 
 # ── Fixtures ────────────────────────────────────────────────────────────────
-T="$(mktemp -d)"
+T="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 printf -- '- [a](b.md) — short hook\n- [c](d.md) — another\n' > "$T/healthy.md"
 head -c 30000 /dev/zero | tr '\0' x > "$T/overbytes.md"                 # > 25 KB
 for _ in $(seq 1 250); do echo "- [a](b.md) — h"; done > "$T/overlines.md"  # > 200 lines, < 25 KB

--- a/tests/unit/test-pii-validation.sh
+++ b/tests/unit/test-pii-validation.sh
@@ -22,7 +22,7 @@ YELLOW=$'\033[33m'
 RESET=$'\033[0m'
 
 # Create temporary test directory
-TEST_DIR=$(mktemp -d)
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap "rm -rf $TEST_DIR" EXIT
 
 # Export test environment

--- a/tests/unit/test-stub-fallback.sh
+++ b/tests/unit/test-stub-fallback.sh
@@ -147,7 +147,7 @@ echo ""
 echo "▶ Test 4: simulate docs.yml's \`npm pkg set ... file:../stubs/analytics-stub\`"
 echo "────────────────────────────────────────────────────────────────"
 
-SANDBOX=$(mktemp -d)
+SANDBOX=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 trap 'rm -rf "$SANDBOX"' EXIT
 
 # Make a skeletal package.json that references @yonatan-hq/analytics like

--- a/tests/unit/test-sync-versions.sh
+++ b/tests/unit/test-sync-versions.sh
@@ -99,7 +99,7 @@ fi
 echo ""
 
 # ─── Sandbox: a throwaway copy of the tracked working tree ──────────
-SANDBOX="$(mktemp -d)"
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")"
 cleanup() { rm -rf "$SANDBOX"; }
 trap cleanup EXIT INT TERM
 # NOTE: this trap only removes a temp dir. Nothing in the repo needs restoring,

--- a/tests/unit/test-whats-new.sh
+++ b/tests/unit/test-whats-new.sh
@@ -31,7 +31,7 @@ hash_of() { cksum "$1" | awk '{print $1"-"$2}'; }
 # Returns the root dir on stdout.
 make_root() {
   local dir
-  dir=$(mktemp -d)
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
   printf '%s\n' "$1" > "$dir/CHANGELOG.md"
   cat > "$dir/README.md" <<'EOF'
 # Fixture
@@ -145,7 +145,7 @@ if run_gen "$ROOT" --check >/dev/null; then pass "--check passes on a fresh READ
 rm -rf "$ROOT"
 
 # ── 4. missing markers must ERROR, not silently pass ────────────────────────
-ROOT=$(mktemp -d)
+ROOT=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 printf '# Changelog\n\n## [8.84.7](https://x/c...d) (2026-07-23)\n\n* **x:** one ([#1](u))\n' > "$ROOT/CHANGELOG.md"
 printf '# No markers here\n' > "$ROOT/README.md"
 if run_gen "$ROOT" >/dev/null 2>&1; then

--- a/tests/worktree/test-worktree-symlink-config.sh
+++ b/tests/worktree/test-worktree-symlink-config.sh
@@ -131,7 +131,7 @@ fi
 echo ""
 echo "=== 5. --apply / --check round-trip ==="
 
-TMP_REPO=$(mktemp -d)
+TMP_REPO=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
 cleanup() { rm -rf "$TMP_REPO"; }
 trap cleanup EXIT
 
@@ -202,7 +202,7 @@ if [ -x "$RECLAIM" ]; then
     fi
 
     # Behavioural check: point it at an empty list and require a LOUD failure.
-    STUB_DIR=$(mktemp -d)
+    STUB_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ork.XXXXXX")
     cp "$RECLAIM" "$STUB_DIR/worktree-reclaim.sh"
     printf '#!/bin/bash\nexit 0\n' > "$STUB_DIR/worktree-config.sh"
     chmod +x "$STUB_DIR"/*.sh


### PR DESCRIPTION
## Problem

A bare `mktemp` writes to the system temp dir and, on macOS, **ignores `$TMPDIR`
entirely**. When that write is denied the call dies, and under `set -e` it takes
the whole script with it.

This is the fifth sighting of the class today, and the first sweep that covers
the surface rather than a directory. What it had already broken:

| file | symptom |
| --- | --- |
| `bin/count-hooks.sh` | silently zeroed a subcount → false `declared 171, actual 150`, blocking every commit (#3564) |
| `tests/run-all-tests.sh` | died before running a test, reporting `quick lint tests FAILED` with nothing run |
| `tests/ci/*.sh` | the two tests written to **catch** this class were themselves killed by it |
| `test-dead-generation-guard.sh` | 5 reported failures that were not failures |

## Fix

125 call sites in 76 files, `$(mktemp)` → `$(mktemp "${TMPDIR:-/tmp}/ork.XXXXXX")`.

**The template is the repair, not the directory.** With a template `TMPDIR` is
honoured; without one it is ignored. That is also why `TMPDIR=/unwritable`
appears to disprove the bug — it changes nothing for a bare call.

Also fixes the same class one layer up: `bin/git-hooks/pre-commit` wrote
actionlint output to a hardcoded `/tmp` path, so on a denied temp dir it
reported `actionlint FAILED` for a workflow that is clean. That was caught by
this very commit being refused.

## Proof, against the live denial rather than a simulation

```
before   9 passed / 5 failed   6 x "Operation not permitted"
after   14 passed / 0 failed   0 denials, exit 0
```

## The gate, and why it exists

`tests/ci/test-no-bare-mktemp.sh`. The two previous sweeps of this class each
missed most of the surface **and reported success**:

- #3550 scoped itself to `.github/`, leaving `bin/ci-setup.sh` hanging whole jobs
- my own first pass here used `git grep -E '\s'` — but ERE has no `\s`, so a
  76-file surface measured as **30**, and the file I was trying to fix was not
  in the list

One scan, one dialect, whole tree.

Mutation-verified, five ways:

- [x] bare `$(mktemp)` → gate fails
- [x] bare `$(mktemp -d)` → gate fails
- [x] backticked `` `mktemp` `` → gate fails
- [x] a comment mentioning mktemp → gate passes
- [x] a templated call → gate passes

## Test Plan

- [x] all 74 touched shell files pass `bash -n`
- [x] `ci-sentinel.yml` still parses; `actionlint` clean
- [x] `tests/ci`: 5 passed, 0 failed
- [x] `run-all-tests.sh --lint`: 3 categories, ALL TESTS PASSED
- [x] `validate-counts.sh`: PASSED

Refs #3190 — the deadlock that issue describes is already gone; what remains
under that number is this class. Worth retitling or closing and refiling.

## Interactive Playground

`docs/fix--mktemp-template-sweep/index.html`

Three toggles (TMPDIR writable, explicit template, temp dir denied) showing why
setting TMPDIR looks like a fix and changes nothing without a template, plus the
coverage table for why two earlier sweeps of this class both reported success.
