### PR TITLE
fix(cli): npm strips a bin value starting with ./

### DIFF
--- a/docs/fix--cli-bin-stripped-on-publish/index.html
+++ b/docs/fix--cli-bin-stripped-on-publish/index.html
@@ -1,0 +1,112 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The bin field npm deletes on publish</title>
+<style>
+  :root{--bg:#0b0d10;--panel:#14181d;--line:#242b33;--fg:#e6edf3;--dim:#8b98a5;
+        --ok:#3fb950;--bad:#f85149;--mono:ui-monospace,SFMono-Regular,Menlo,monospace}
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
+  main{max-width:820px;margin:0 auto;padding:32px 20px 80px}
+  h1{font-size:24px;margin:0 0 6px} h2{font-size:17px;margin:30px 0 10px;padding-top:18px;border-top:1px solid var(--line)}
+  p.lead{color:var(--dim);margin:0 0 22px}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px}
+  .row{display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:10px}
+  button{background:#0b0d10;color:var(--fg);border:1px solid var(--line);border-radius:7px;
+         padding:8px 12px;font:12.5px var(--mono);cursor:pointer}
+  button.sel{border-color:var(--ok);color:var(--ok)}
+  pre{margin:8px 0 0;font:12.5px/1.55 var(--mono);white-space:pre-wrap;background:#0b0d10;
+      border:1px solid var(--line);border-radius:8px;padding:12px}
+  .verdict{margin-top:10px;font:13px var(--mono);font-weight:700}
+  .ok{color:var(--ok)} .bad{color:var(--bad)}
+  table{border-collapse:collapse;width:100%;margin-top:8px;font-size:13.5px}
+  th,td{text-align:left;padding:7px 9px;border-bottom:1px solid var(--line)}
+  th{color:var(--dim);font-size:12px;text-transform:uppercase;letter-spacing:.05em}
+  td.m{font:12.5px var(--mono)}
+  code{font:12.5px var(--mono);background:#0b0d10;padding:1px 5px;border-radius:4px}
+  footer{margin-top:38px;color:var(--dim);font-size:13px;border-top:1px solid var(--line);padding-top:16px}
+</style>
+</head>
+<body>
+<main>
+  <h1>The <code>bin</code> field npm deletes on publish</h1>
+  <p class="lead">
+    npm 11 silently removes any <code>bin</code> entry whose value starts with
+    <code>./</code>. The package still builds, tests, packs and installs. It just has no
+    executables. Pick a manifest below to see what the registry would have stored.
+  </p>
+
+  <div class="panel">
+    <div class="row" id="tabs"></div>
+    <pre id="src"></pre>
+    <div class="verdict" id="verdict"></div>
+    <pre id="stored"></pre>
+  </div>
+
+  <h2>Measured, not assumed</h2>
+  <p>Five manifests, published with <code>--dry-run</code> on npm 11.19.0:</p>
+  <table>
+    <tr><th>bin value</th><th>entries stripped</th></tr>
+    <tr><td class="m">"./dist/cli.js" (one key)</td><td class="m bad">1</td></tr>
+    <tr><td class="m">"./dist/cli.js" (two keys)</td><td class="m bad">2</td></tr>
+    <tr><td class="m">"./dist/cli.js" (string form)</td><td class="m bad">1</td></tr>
+    <tr><td class="m">"dist/cli.js" (one key)</td><td class="m ok">0</td></tr>
+    <tr><td class="m">"dist/cli.js" (two keys)</td><td class="m ok">0</td></tr>
+  </table>
+  <p>The key count and the string-vs-object form are irrelevant. Only the leading
+     <code>./</code> matters.</p>
+
+  <h2>Why nothing local caught it</h2>
+  <table>
+    <tr><th>Check</th><th>Verdict</th><th>Why it missed</th></tr>
+    <tr><td class="m">npm run build</td><td class="ok">pass</td><td>tsc never reads bin</td></tr>
+    <tr><td class="m">npm test (34)</td><td class="ok">pass</td><td>spawns dist/cli.js by path, not by bin name</td></tr>
+    <tr><td class="m">npm pack</td><td class="ok">pass</td><td>keeps the field intact in the tarball</td></tr>
+    <tr><td class="m">CI (41 checks)</td><td class="ok">pass</td><td>never publishes</td></tr>
+    <tr><td class="m">npm publish</td><td class="bad">warn</td><td>the only place it shows, and only as a warning</td></tr>
+  </table>
+  <p>
+    A successful publish would have exited <code>0</code>. The failure would first have
+    appeared to a stranger running <code>npx orchestkit</code> against a package that
+    installs cleanly and has no command.
+  </p>
+
+  <footer>
+    Fix: drop the <code>./</code>. Guarded by <code>tests/package-publish.test.ts</code>,
+    which asserts on the manifest rather than on the build, since the build was never
+    the thing that was wrong.
+  </footer>
+</main>
+<script>
+const CASES = [
+  {id:'broken', label:'./dist/cli.js', bin:{orchestkit:'./dist/cli.js', ork:'./dist/cli.js'}, stripped:true},
+  {id:'fixed',  label:'dist/cli.js',   bin:{orchestkit:'dist/cli.js',   ork:'dist/cli.js'},   stripped:false},
+];
+const tabs = document.getElementById('tabs');
+let active = 'broken';
+
+function render() {
+  const c = CASES.find(x => x.id === active);
+  tabs.innerHTML = CASES.map(x =>
+    `<button data-id="${x.id}" class="${x.id===active?'sel':''}">bin: "${x.label}"</button>`).join('');
+  tabs.querySelectorAll('button').forEach(b =>
+    b.onclick = () => { active = b.dataset.id; render(); });
+
+  document.getElementById('src').textContent =
+    'package.json as authored\n\n"bin": ' + JSON.stringify(c.bin, null, 2);
+
+  const v = document.getElementById('verdict');
+  v.textContent = c.stripped
+    ? 'npm warn publish: 2 entries "invalid and removed"  ->  publish still exits 0'
+    : 'no manifest warnings  ->  both commands ship';
+  v.className = 'verdict ' + (c.stripped ? 'bad' : 'ok');
+
+  document.getElementById('stored').textContent =
+    'what the registry stores\n\n"bin": ' +
+    (c.stripped ? '{}   // npx orchestkit -> command not found' : JSON.stringify(c.bin, null, 2));
+}
+render();
+</script>
+</body>
+</html>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://orchestkit.yonyon.ai/developers",
   "type": "module",
   "bin": {
-    "orchestkit": "./dist/cli.js",
-    "ork": "./dist/cli.js"
+    "orchestkit": "dist/cli.js",
+    "ork": "dist/cli.js"
   },
   "exports": {
     ".": {

--- a/packages/cli/tests/package-publish.test.ts
+++ b/packages/cli/tests/package-publish.test.ts
@@ -1,0 +1,77 @@
+// Guards the package manifest against the publish-time normalizer.
+//
+// npm 11 silently DELETES any `bin` entry whose value starts with "./". The
+// package still packs, installs and tests fine; it just ships with no binaries,
+// so `npx orchestkit` resolves to nothing. Measured on npm 11.19.0:
+//
+//   {"x":"./dist/cli.js"}                    -> 1 entry stripped
+//   {"x":"./dist/cli.js","ork":"./dist/..."} -> 2 entries stripped
+//   {"x":"dist/cli.js"}                      -> 0 stripped
+//   {"x":"dist/cli.js","ork":"dist/cli.js"}  -> 0 stripped
+//   "./dist/cli.js" (string form)            -> 1 stripped
+//
+// The trap is that NOTHING local catches it. `npm pack` keeps the field intact
+// in the tarball, our spawn tests run ./dist/cli.js directly, and CI never
+// publishes. Only `npm publish` (even --dry-run) prints the warning, and only as
+// a `npm warn`, so a successful publish would have exited 0 with no binaries.
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const pkg = JSON.parse(
+	readFileSync(resolve(__dirname, "../package.json"), "utf8"),
+) as {
+	name: string;
+	bin?: Record<string, string>;
+	files?: string[];
+	engines?: { node?: string };
+};
+
+describe("bin entries survive npm's publish-time normalizer", () => {
+	it("declares both binaries", () => {
+		expect(Object.keys(pkg.bin ?? {}).sort()).toEqual(["orchestkit", "ork"]);
+	});
+
+	it("no bin value starts with ./ (npm 11 deletes those on publish)", () => {
+		for (const [name, target] of Object.entries(pkg.bin ?? {})) {
+			expect(
+				target.startsWith("./"),
+				`bin["${name}"] = "${target}" would be stripped at publish; drop the leading "./"`,
+			).toBe(false);
+		}
+	});
+
+	it("no bin value is absolute or escapes the package", () => {
+		for (const [name, target] of Object.entries(pkg.bin ?? {})) {
+			expect(target.startsWith("/"), `bin["${name}"] is absolute`).toBe(false);
+			expect(target.includes(".."), `bin["${name}"] escapes the package`).toBe(false);
+		}
+	});
+
+	it("every bin target is inside a published directory", () => {
+		// A bin pointing outside `files` publishes a manifest whose binary is
+		// absent from the tarball: install succeeds, the command does not exist.
+		for (const [name, target] of Object.entries(pkg.bin ?? {})) {
+			const top = target.split("/")[0] as string;
+			expect(pkg.files ?? [], `bin["${name}"] target not in files[]`).toContain(top);
+		}
+	});
+
+	it("every bin target exists once the package is built", () => {
+		const dist = resolve(__dirname, "../dist");
+		if (!existsSync(dist)) return; // unbuilt tree; the build test covers this
+		for (const [name, target] of Object.entries(pkg.bin ?? {})) {
+			expect(
+				existsSync(resolve(__dirname, "..", target)),
+				`bin["${name}"] -> ${target} missing from a built tree`,
+			).toBe(true);
+		}
+	});
+
+	it("the built binary keeps its shebang", () => {
+		const cli = resolve(__dirname, "../dist/cli.js");
+		if (!existsSync(cli)) return;
+		expect(readFileSync(cli, "utf8").startsWith("#!/usr/bin/env node")).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

`npm publish` reported that both binaries were removed from the manifest:

```
npm warn publish "bin[orchestkit]" script name dist/cli.js was invalid and removed
npm warn publish "bin[ork]"        script name dist/cli.js was invalid and removed
```

That would have shipped a package that installs cleanly and has no commands.
`npx orchestkit` would resolve to nothing. Publish exits `0` either way.

## Cause, measured not guessed

Five manifests through `npm publish --dry-run` on npm 11.19.0:

| bin value | entries stripped |
|---|---|
| `{"x":"./dist/cli.js"}` | 1 |
| `{"x":"./dist/cli.js","ork":"./dist/cli.js"}` | 2 |
| `"./dist/cli.js"` (string form) | 1 |
| `{"x":"dist/cli.js"}` | **0** |
| `{"x":"dist/cli.js","ork":"dist/cli.js"}` | **0** |

Key count and object-vs-string form are irrelevant. Only the leading `./`
matters. After the change: zero stripped, zero manifest warnings.

## Why nothing local caught it

| Check | Verdict | Why it missed |
|---|---|---|
| `npm run build` | pass | tsc never reads `bin` |
| `npm test` (34) | pass | spawns `dist/cli.js` by path, not by bin name |
| `npm pack` | pass | keeps the field intact in the tarball |
| CI (41 checks) | pass | never publishes |
| `npm publish` | warn | the only signal, and only a warning |

Worth stating plainly: I had cited `npm pack --dry-run` as evidence the package
was ready to ship. It is not an oracle for this, because pack and publish
normalize differently.

## Guard

`tests/package-publish.test.ts` asserts on the manifest rather than the build,
since the build was never what was wrong: no bin value may start with `./`, be
absolute, or escape the package; every target must sit under a published
directory and, in a built tree, exist with its shebang.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/fix/cli-bin-stripped-on-publish/docs/fix--cli-bin-stripped-on-publish/index.html)**

Toggle between the two manifests and see what the registry would have stored,
plus the table of which local checks pass while the package is broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
