### PR TITLE
fix(ci): playground gate blocked the playground prune

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,14 @@ jobs:
           # alternation, so a bare `\.github/` would only match a file literally
           # named ".github/" and every real workflow path would fall through to
           # "playground required".
-          INERT='^(README\.md|CHANGELOG\.md|CONTRIBUTING\.md|SECURITY\.md|CODE_OF_CONDUCT\.md|LICENSE|\.github/.*|vercel\.json|[^/]*\.toml)$'
+          # `docs/<type>--<slug>/` is the Lab itself. A diff confined to those
+          # dirs is Lab maintenance, not feature work that needs documenting,
+          # and requiring a playground for it is circular: the periodic prune
+          # (scripts/prune-playgrounds.sh) deletes 77 playground dirs and was
+          # then blocked for not adding a 78th, which would immediately become
+          # the next cycle's prune fodder. Feature PRs are unaffected because
+          # they also touch src/, docs/site/ or tests/, which are not inert.
+          INERT='^(README\.md|CHANGELOG\.md|CONTRIBUTING\.md|SECURITY\.md|CODE_OF_CONDUCT\.md|LICENSE|\.github/.*|vercel\.json|[^/]*\.toml|docs/[^/]*--[^/]*/.*)$'
 
           FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
           if [ -z "$FILES" ]; then


### PR DESCRIPTION

The periodic prune (scripts/prune-playgrounds.sh) archives merged
docs/<type>--<slug>/ dirs off main. PR #3660 removes 77 of them and was blocked
by the PR Playground gate for not adding a 78th, which would have become the
next cycle's prune fodder. The gate that creates these dirs was preventing the
tooling that removes them.

Adds docs/[^/]*--[^/]*/.* to the INERT list: a diff confined to playground dirs
is Lab maintenance, not feature work that needs documenting. Feature PRs are
unaffected, since they also touch src/, docs/site/ or tests/, none of which are
inert. Verified against real paths:

  INERT     docs/feat--foo/index.html
  INERT     docs/chore--prune-playgrounds-2026/index.html
  requires  src/skills/x/SKILL.md
  requires  docs/site/lib/agent-404.ts
  requires  docs/adr/0001.md

Note docs/adr/ and docs/site/ still require a playground: the pattern needs the
`--` slug separator, so only branch-named playground dirs match.

The gate stays fail-closed for anything unmatched.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

No playground dir for this PR: the diff is `.github/` only, which the gate already treats as inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)