### PR TITLE
chore(build): regenerate the docs-site index for paired-probe

### DIFF
--- a/docs/site/lib/generated/docs-search-index.ts
+++ b/docs/site/lib/generated/docs-search-index.ts
@@ -1313,7 +1313,7 @@ export const DOCS_SEARCH_INDEX: DocSearchEntry[] = [
   {
     "url": "/docs/skills/reference-skills",
     "title": "Reference Skills",
-    "description": "The 70 user-invocable:false skills auto-injected into agent context — the knowledge library behind OrchestKit agents."
+    "description": "The 71 user-invocable:false skills auto-injected into agent context — the knowledge library behind OrchestKit agents."
   },
   {
     "url": "/docs/skills/skill-composition",

--- a/docs/site/lib/generated/skills-data.ts
+++ b/docs/site/lib/generated/skills-data.ts
@@ -4814,7 +4814,7 @@ export const SKILLS: Record<string, SkillMeta> = {
     "name": "verify",
     "description": "Grade work that already exists and decide whether it can merge. Runs the project's current unit, integration, and E2E suites plus security scanning and type checking, scores every dimension 0-10, and returns a merge verdict with a VERIFIED-vs-CLAIMED evidence manifest. Writes no test files and edits no source. Use when verifying changes are ready to merge. Use /ork:cover instead when the tests still have to be written.",
     "version": "4.6.0",
-    "sha256": "b25a6567c8ae8ef4a3d4d19fb9ccfd0198d3bd0ac45871576f7bf9db681a36f2",
+    "sha256": "6570bc1574d58670abac0d9b8a8d84084bcce3ca7bd86818658b4f53167dd219",
     "author": "OrchestKit",
     "tags": [
       "verification",


### PR DESCRIPTION
Targets `feat/paired-probe`. Finishes what #3668 started.

#3668 wired paired-probe's chain reach by editing `src/skills/verify/SKILL.md`, but did not stage the regenerated mirror. Build then failed on drift:

```
Build drift detected! Run 'npm run build' and commit the changes
(plugins/ src/hooks/dist/ README.md docs/site/lib/generated/)
```

**That was my omission**, not a new defect. This repo generates `plugins/` and `docs/site/lib/generated/` from `src/`, and the regenerated diff must be staged with the `src/` change. Editing a SKILL.md *body* moves the docs-site search index and skills data, because both embed skill text.

`npm run build` regenerates exactly two files:

- `docs/site/lib/generated/docs-search-index.ts`
- `docs/site/lib/generated/skills-data.ts`

`plugins/` is untouched: verify's frontmatter did not change, only its body, and the mirror was already rebuilt for paired-probe itself.

With this, #3664 goes from 5 red gates to 0. No playground: the diff is generated files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)