### PR TITLE
fix(docs-site): drop the inert Vary set, route two md twins

### DIFF
--- a/docs/fix--vary-inert-and-md-twin-gap/index.html
+++ b/docs/fix--vary-inert-and-md-twin-gap/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<title>Inert Vary and the missing markdown twins</title>
+<style>body{font:15px/1.6 system-ui;max-width:52rem;margin:3rem auto;padding:0 1rem;color:#111}
+code{background:#f4f4f5;padding:.1rem .3rem;border-radius:3px}
+table{border-collapse:collapse;margin:1rem 0}td,th{border:1px solid #ddd;padding:.4rem .7rem;text-align:left}
+.bad{color:#b00}.good{color:#070}</style></head><body>
+<h1>Two fixes, both found by probing production</h1>
+
+<h2>1. The Vary header shipped in #3688 was inert</h2>
+<p>#3688 set <code>Vary</code> in middleware believing that was "the layer that holds".
+It is not. Next overwrites <code>vary</code> on any app-rendered response
+(<code>base-server.js setVaryHeader</code>), so the value never reached a client.</p>
+<table>
+<tr><th>probe</th><th>middleware ratelimit-*</th><th>middleware Vary</th></tr>
+<tr><td><code>/llms.txt</code></td><td class="good">arrives</td><td class="bad">absent</td></tr>
+<tr><td><code>/favicon.svg</code> (not app-rendered)</td><td>-</td><td class="good">arrives</td></tr>
+</table>
+<p>So it is not that middleware headers are dropped. It is <code>Vary</code> specifically.
+The layer that works is a handler building its own <code>Response</code>, and both
+Markdown handlers already do. That is the direction that matters: the Markdown entry is
+the one a cache must never hand to a browser, and it is correctly keyed.</p>
+<p><strong>Residual, stated not hidden:</strong> the HTML entry carries only Next's RSC
+tokens, so a cache may serve stored HTML to a crawler. That degrades the bot-Markdown
+feature; it does not leak Markdown to readers.</p>
+
+<h2>2. Two advertised twins answered HTML on the bare URL</h2>
+<p><code>/pricing.md</code> and <code>/api-policy.md</code> returned 200 with frontmatter and
+llms.txt advertised them, but <code>mdTarget()</code> did not know them, so a crawler asking
+for <code>/pricing</code> got HTML.</p>
+
+<h2>3. The test was the same bug, one layer along</h2>
+<p>#3688 replaced a config-grep with a response assertion, then asserted on
+<em>middleware's own return value</em> rather than the client's response. Green in unit-land,
+absent on the wire. A response assertion is only worth as much as the response you assert on.</p>
+</body></html>

--- a/docs/site/__tests__/served-markdown-contract.test.ts
+++ b/docs/site/__tests__/served-markdown-contract.test.ts
@@ -150,11 +150,28 @@ describe("Vary is carried by the response, not just declared in config", () => {
 		["/docs/foundations/overview", "docs page"],
 		["/developers", "named twin"],
 		["/yonyon", "named twin"],
-	])("%s carries Vary on the BROWSER (HTML) response", (path) => {
-		// The half that production was missing entirely: a browser response with
-		// no User-Agent in Vary lets a cache reuse it for a crawler.
+	])("%s does NOT get Vary from middleware on the HTML response", (path) => {
+		// This asserted the OPPOSITE until it was measured against production.
+		//
+		// The original test set and read `Vary` on middleware's own return value,
+		// which passes in unit-land and is meaningless in production: Next
+		// overwrites `vary` on any app-rendered response (base-server.js
+		// setVaryHeader), so the header this object carries never reaches a
+		// client. Green here, absent on the wire.
+		//
+		// That is the same defect the whole file was written to kill, moved one
+		// layer along. A response assertion is only worth as much as the response
+		// you assert on. The middleware object is NOT the client's response.
+		//
+		// Decisive probe: /llms.txt returns middleware's `ratelimit-*` headers but
+		// not middleware's `Vary`, so it is not that middleware headers are
+		// dropped, it is `Vary` specifically. /favicon.svg and /robots.txt are not
+		// app-rendered and DO carry the configured value.
+		//
+		// So the inert `set` is gone and this pins its absence, to stop anyone
+		// restoring it to make a unit test agree with a belief production refutes.
 		const res = middleware(req(path, BROWSER));
-		expect(res?.headers.get("Vary")).toBe(MARKDOWN_VARY);
+		expect(res?.headers.get("Vary")).toBeNull();
 	});
 
 	it.each([
@@ -175,13 +192,24 @@ describe("Vary is carried by the response, not just declared in config", () => {
 		expect(res?.headers.get("Vary")).toBeNull();
 	});
 
-	it("both representations of one URL agree on the cache key", () => {
-		// The actual defect was ASYMMETRY: one side named User-Agent and the other
-		// did not, so which body a cache served depended on which it stored first.
-		for (const path of ["/", "/docs/foundations/overview", "/developers"]) {
-			const html = middleware(req(path, BROWSER))?.headers.get("Vary");
-			const md = middleware(req(path, BOT))?.headers.get("Vary");
-			expect(html, `browser Vary on ${path}`).toBe(md);
+	it("the Markdown side is keyed, and the asymmetry is stated not hidden", async () => {
+		// This replaces a parity assertion (html Vary === md Vary) that could only
+		// be satisfied by the inert middleware `set`. Demanding symmetry at a layer
+		// that cannot deliver it is what kept the dead code alive.
+		//
+		// What is actually true, and is the protection that matters: the MARKDOWN
+		// response is the one a shared cache must never hand to a browser, and it
+		// IS keyed on User-Agent, by its own handler.
+		for (const slug of MARKDOWN_TWIN_SLUGS) {
+			expect((await twin(slug)).headers.get("Vary")).toBe(MARKDOWN_VARY);
 		}
+
+		// The residual, pinned rather than papered over: the HTML entry carries
+		// only Next's RSC tokens, so a cache may serve stored HTML to a crawler.
+		// That degrades the bot-Markdown feature; it does not leak Markdown to
+		// readers. If a future Next release stops overwriting `vary`, or the HTML
+		// path starts emitting it another way, this expectation flips and someone
+		// should reassess rather than delete it.
+		expect(middleware(req("/", BROWSER))?.headers.get("Vary")).toBeNull();
 	});
 });

--- a/docs/site/middleware.ts
+++ b/docs/site/middleware.ts
@@ -32,6 +32,11 @@ import {
 //   2. a `.md` suffix on the URL        (e.g. /docs/foundations/overview.md)
 //   3. ?mode=agent                      (explicit machine-readable view)
 // Browsers (Accept: text/html, no suffix, no flag) keep getting HTML.
+// Pages served as Markdown by a dedicated route rather than by app/api/page-md.
+// Keys are the BARE paths; the twin is the same path plus `.md`, which is the
+// Next route directory name (app/pricing.md/route.ts).
+const STANDALONE_MD_PAGES = new Set(["/pricing", "/api-policy"]);
+
 function mdTarget(pathname: string): string | null {
 	if (pathname === "/" || pathname === "/index.md") return "/api/md";
 	// Strip a trailing `.md` so /docs/x.md and /docs/x resolve identically.
@@ -46,6 +51,23 @@ function mdTarget(pathname: string): string | null {
 	// "yonyon developer resources" query come back with nothing usable.
 	const slug = clean.slice(1);
 	if (hasMarkdownTwin(slug)) return `/api/page-md/${slug}`;
+
+	// Pages whose Markdown twin is its OWN route rather than a page-md render:
+	// app/pricing.md/route.ts and app/api-policy.md/route.ts. Both already
+	// returned 200 with frontmatter and llms.txt already advertised them, but
+	// mdTarget() did not know them, so the BARE URL answered a crawler with HTML
+	// while the .md URL answered with Markdown. Measured on production.
+	//
+	// Deliberately NOT added to MARKDOWN_TWIN_SLUGS: that list drives
+	// app/api/page-md, which renders from lib data (developer-resources,
+	// yonyon-faqs). These two have hand-authored routes, so pointing at the
+	// existing route is the truthful mapping and keeps one source per page.
+	//
+	// Only the bare path is rewritten. `/pricing.md` already hits its route
+	// directly, and rewriting a path to itself would loop.
+	if (!pathname.endsWith(".md") && STANDALONE_MD_PAGES.has(clean)) {
+		return `${clean}.md`;
+	}
 	return null;
 }
 
@@ -58,14 +80,6 @@ function isMeteredSurface(pathname: string): boolean {
 		(pathname.startsWith("/api/") || classifyAgentSurface(pathname) !== null) &&
 		middlewareShouldMeter(pathname)
 	);
-}
-
-// Whether this path can answer with EITHER HTML or Markdown, which is exactly
-// the set of URLs whose responses must Vary on Accept and User-Agent. Derived
-// from mdTarget() rather than listed again, so a new twin cannot be added
-// without its cache key following along.
-function servesTwoRepresentations(pathname: string): boolean {
-	return mdTarget(pathname) !== null;
 }
 
 export function middleware(req: NextRequest) {
@@ -228,19 +242,27 @@ export function middleware(req: NextRequest) {
 	for (const [k, v] of Object.entries(limitHeaders)) {
 		res.headers.set(k, v);
 	}
-	// The HTML half of the content negotiation above. next.config.mjs declares
-	// this same Vary, but MEASURED on production it does not survive here: Next
-	// appends its own RSC tokens to `vary` (base-server.js setVaryHeader) and the
-	// configured value is absent from the result, even though every other header
-	// from that config block is present. Setting it on the response middleware
-	// actually returns is the layer that holds.
+	// NO Vary is set here, deliberately, and the reason is measured rather than
+	// assumed. #3688 set MARKDOWN_VARY on this response believing middleware was
+	// "the layer that holds". It is not. Next overwrites `vary` on any
+	// app-rendered response (base-server.js setVaryHeader), so the value never
+	// reached a client. The decisive probe was /llms.txt: middleware's
+	// `ratelimit-*` headers arrive while middleware's `Vary` does not, so it is
+	// not that middleware headers are dropped, it is `Vary` specifically.
+	// Confirmed from the other side by /favicon.svg and /robots.txt, which are
+	// not app-rendered and DO carry the configured value.
 	//
-	// Scoped to paths that genuinely serve two bodies. A URL with one
-	// representation gains nothing from varying on User-Agent and would only
-	// fragment its cache entries per crawler.
-	if (servesTwoRepresentations(pathname)) {
-		res.headers.set("Vary", MARKDOWN_VARY);
-	}
+	// The only layer that works is a handler constructing its own Response, and
+	// both Markdown handlers already do (app/api/md and app/api/page-md set
+	// MARKDOWN_VARY on `new Response(...)`). That is the direction that matters:
+	// the Markdown entry is the one a shared cache must not hand to a browser,
+	// and it is correctly keyed.
+	//
+	// Residual, stated honestly rather than papered over: the HTML entry carries
+	// only Next's RSC tokens, so a cache may serve stored HTML to a crawler.
+	// That degrades the bot-Markdown feature; it does not leak Markdown to
+	// readers. Re-adding an inert line here would not change it, and would read
+	// as protection that is not there.
 	return res;
 }
 


### PR DESCRIPTION
Closes #3687.

Both fixes were found by probing **live production** after #3683 and #3685 merged green. Neither was visible to CI.

## 1. The Vary set shipped in #3688 is inert

#3688 set `MARKDOWN_VARY` in middleware believing that was "the layer that holds". Measured on production, it is not. Next overwrites `vary` on any app-rendered response (`base-server.js setVaryHeader`), so the value never reached a client.

| probe | middleware `ratelimit-*` | middleware `Vary` |
|---|---|---|
| `/llms.txt` | arrives | **absent** |
| `/favicon.svg` (not app-rendered) | n/a | arrives |

So it is not that middleware headers get dropped, it is `Vary` specifically. The only layer that works is a handler constructing its own `Response`, and both Markdown handlers already do. That is the direction that matters: the Markdown entry is the one a shared cache must never hand to a browser, and it is correctly keyed.

**Residual, stated in the code rather than papered over:** the HTML entry carries only Next's RSC tokens, so a cache may serve stored HTML to a crawler. That degrades the bot-Markdown feature; it does not leak Markdown to readers. Re-adding an inert line would not change it and would read as protection that is not there.

## 2. Two advertised twins answered HTML on the bare URL

`/pricing.md` and `/api-policy.md` both returned 200 with frontmatter, and `llms.txt` advertised them, but `mdTarget()` did not know them, so a crawler asking for `/pricing` got HTML.

Deliberately **not** added to `MARKDOWN_TWIN_SLUGS`: that list drives `app/api/page-md`, which renders from lib data. These two have hand-authored routes, so pointing at the existing route keeps one source per page.

## 3. The test was the same bug, one layer along

#3688 replaced a config-grep with a response assertion, then asserted on **middleware's own return value** rather than the client's response. Green in unit-land, absent on the wire, and it could only be satisfied by keeping the dead code.

The block now pins the absence and says why, so nobody restores an inert line to make a unit test agree with a belief production refutes. **A response assertion is only worth as much as the response you assert on.**

## Verification

- `npm test` in `docs/site`: **559 passed / 44 files**, including the rewritten contract test at 21/21.
- `npx tsc --noEmit`: the same two pre-existing errors as a clean tree (`page.tsx`, `lib/source.ts`), neither in a touched file.
- Prod probes recorded in the playground at `docs/fix--vary-inert-and-md-twin-gap/`.

## Not done here

`cache-breaks.jsonl` was the third item in #3687. It needs **no code change**: its writer was already restored in #3665 (`prompt/cache-break-detector.ts` calls `appendAnalytics`), and the 140-day mtime predates that fix. Classifying it as retired or event-driven would silence a guard that is about to start working correctly.
