### PR TITLE
feat(ork-codex): ship ork-implement and one install matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,20 +40,34 @@
 - [Community](#community)
 
 
-## Quick Start (Claude Code)
+## Quick Start
+
+Pick the host you actually use. Claude Code is the full plugin (skills + agents + hooks). Cursor gets the same `ork` plugin minus Claude hook scripts. skills.sh is skills only — start with the 12 below, not the whole catalog.
+
+### Claude Code
 
 ```bash
 /plugin marketplace add yonatangross/orchestkit
 /plugin install ork
 ```
 
-Then start your personalized onboarding:
+Then `/ork:setup`. The wizard scans the repo, recommends skills, and writes MCP config.
+
+CLI equivalent: `claude install orchestkit/ork`.
+
+### Cursor
+
+Settings → Plugins / marketplaces → add `yonatangross/orchestkit` → enable **ork** → **open a new chat**. Same plugin Claude Code installs, not a five-skill fork. See [Install → Cursor](#cursor).
+
+### skills.sh (Cursor, Codex, OpenCode, …)
+
+Starter 12 — doctor, setup, explore, implement, verify, review-pr, commit, expect, assess, brainstorm, create-pr, remember:
 
 ```bash
-/ork:setup
+npx skills add yonatangross/orchestkit -s doctor -s setup -s explore -s implement -s verify -s review-pr -s commit -s expect -s assess -s brainstorm -s create-pr -s remember
 ```
 
-The setup wizard scans your codebase, detects your tech stack, recommends skills for your needs, configures MCP servers, and creates a readiness score — all in one command.
+The skill named `implement` is the implement workflow (`/ork:implement` in Claude Code). There is no `ork-implement` on the Claude plugin; Codex uses `$ork-implement` after the Codex pack is installed. Full catalog: `npx skills add yonatangross/orchestkit` (hundreds of SKILL.md files — do not treat that as unique users).
 
 ---
 
@@ -218,11 +232,13 @@ anything.
 
 No tiering. No version confusion. Just one powerful plugin.
 
-Not on Claude Code? Pull the skills into any agent (Cursor, Codex, OpenCode, …) via [skills.sh](https://skills.sh):
+Not on Claude Code? Pull a **starter 12** into any agent (Cursor, Codex, OpenCode, …) via [skills.sh](https://www.skills.sh/yonatangross/orchestkit) — do not install the whole firehose on day one:
 
 ```bash
-npx skills add yonatangross/orchestkit
+npx skills add yonatangross/orchestkit -s doctor -s setup -s explore -s implement -s verify -s review-pr -s commit -s expect -s assess -s brainstorm -s create-pr -s remember
 ```
+
+All skills: `npx skills add yonatangross/orchestkit`. The implement skill is [`implement`](https://www.skills.sh/yonatangross/orchestkit/implement), not `ork-implement`.
 
 ### Cursor
 
@@ -251,8 +267,8 @@ codex plugin add ork-codex@orchestkit-codex
 ```
 
 Restart Codex after installation. Invoke a workflow explicitly with
-`$ork-brainstorm`, `$ork-explore`, `$ork-assess`, `$ork-verify`, or
-`$ork-review-pr`; their narrow descriptions also let Codex select the relevant
+`$ork-brainstorm`, `$ork-explore`, `$ork-implement`, `$ork-assess`, `$ork-verify`,
+or `$ork-review-pr`; their narrow descriptions also let Codex select the relevant
 workflow automatically.
 
 The plugin intentionally ships roles as templates because Codex loads custom
@@ -325,6 +341,12 @@ Run `/ork:doctor` to diagnose.
 Requires **≥2.1.220** (supported floor; Opus 5 as the default Opus, `xhigh` effort, dynamic workflows, `sandbox.network.strictAllowlist`, native binary, hardened `Bash(rm:*)`/`Bash(find:*)` rules). Check with `claude --version`.
 
 Raising this floor is a breaking change and ships as a major release. See [STABILITY.md](STABILITY.md) for the full contract, and `shared/cc-support.json` for the authoritative window.
+</details>
+
+<details>
+<summary><strong>Superpowers vs OrchestKit?</strong></summary>
+
+Complementary, not a rival listing. Superpowers (official Anthropic marketplace) is process — how the agent works a task. OrchestKit is production patterns plus lifecycle hooks. Honest split: [docs](https://orchestkit.yonyon.ai/docs/getting-started/superpowers) · [yonyon.ai](https://yonyon.ai/compare/orchestkit-superpowers).
 </details>
 
 ---

--- a/docs/chore--oss-surface-hygiene/install-matrix.html
+++ b/docs/chore--oss-surface-hygiene/install-matrix.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Install matrix — Claude Code, Cursor, skills.sh, Codex</title>
+  <style>
+    :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--text:#e6edf3;--muted:#8b949e;--blue:#58a6ff;--green:#3fb950;--amber:#d29922;--red:#f85149;--mono:ui-monospace,SFMono-Regular,Menlo,monospace}
+    *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:16px system-ui,sans-serif;padding:28px}
+    main{max-width:880px;margin:auto}h1{margin:0 0 6px}.sub{color:var(--muted);line-height:1.5}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(155px,1fr));gap:10px;margin:24px 0}
+    .card,section{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px}
+    .card button{width:100%;background:none;border:0;color:var(--text);text-align:left;cursor:pointer;font:inherit}
+    .card.active{border-color:var(--blue);box-shadow:0 0 0 1px var(--blue)}
+    .tag{font:12px var(--mono);color:var(--blue)}.ok{color:var(--green)}.warn{color:var(--amber)}.no{color:var(--red)}
+    code,pre{font-family:var(--mono)}pre{white-space:pre-wrap;background:#010409;border:1px solid var(--line);border-radius:7px;padding:13px;line-height:1.5}
+    li{margin:.45rem 0}footer{color:var(--muted);font-size:13px;margin-top:18px}
+    table{width:100%;border-collapse:collapse;font-size:14px}th,td{text-align:left;padding:8px 6px;border-bottom:1px solid var(--line)}
+    th{color:var(--muted);font-size:11px;text-transform:uppercase}
+  </style>
+</head>
+<body><main>
+  <h1>One plugin. Four first commands.</h1>
+  <p class="sub">This PR kills the install zoo: README, docs, and skills.sh all pointed at different first commands, doctor still showed <code>ork v8.63.2</code> / 113 skills, and Codex had no <code>$ork-implement</code> so skills.sh 404ed it.</p>
+  <div class="grid" id="modes">
+    <div class="card active" data-mode="cc"><button><span class="tag">Claude Code</span><br>Full plugin + hooks</button></div>
+    <div class="card" data-mode="cursor"><button><span class="tag">Cursor</span><br>Same ork, no CC hooks</button></div>
+    <div class="card" data-mode="skills"><button><span class="tag">skills.sh</span><br>Starter 12, not 298</button></div>
+    <div class="card" data-mode="codex"><button><span class="tag">Codex</span><br>$ork-implement exists</button></div>
+  </div>
+  <section>
+    <div class="tag" id="label">Claude Code</div>
+    <h2 id="title">Marketplace add, then install ork</h2>
+    <p id="body">The full plugin: 106 skills, 36 agents, 171 hooks. Doctor prints the installed version from <code>claude plugins</code>, not a frozen v8.x sample.</p>
+    <pre id="command">/plugin marketplace add yonatangross/orchestkit
+/plugin install ork
+# or: claude install orchestkit/ork</pre>
+    <ul id="points">
+      <li><span class="ok">✓</span> Hooks fire without being asked</li>
+      <li><span class="ok">✓</span> <code>/ork:implement</code> is the Claude command</li>
+      <li><span class="no">✗</span> Do not quote skills.sh 29.4K as unique users</li>
+    </ul>
+  </section>
+  <h2>What 404ed</h2>
+  <section>
+    <table>
+      <thead><tr><th>URL / command</th><th>Before</th><th>After</th></tr></thead>
+      <tbody>
+        <tr><td><code>skills.sh/.../ork-implement</code></td><td class="no">404</td><td class="ok">Codex skill ships</td></tr>
+        <tr><td><code>skills.sh/.../implement</code></td><td class="ok">Claude skill, always existed</td><td class="ok">still the CC name</td></tr>
+        <tr><td>npx skills add (no -s)</td><td class="warn">298 SKILL.md firehose</td><td>starter 12 is the advertised path</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <footer>Click a host. Superpowers is process (official marketplace). OrchestKit is production patterns + hooks. Complementary, not a rival listing.</footer>
+</main>
+<script>
+const data={
+  cc:{
+    label:'Claude Code',
+    title:'Marketplace add, then install ork',
+    body:'The full plugin: 106 skills, 36 agents, 171 hooks. Doctor prints the installed version from claude plugins, not a frozen v8.x sample.',
+    command:'/plugin marketplace add yonatangross/orchestkit\n/plugin install ork\n# or: claude install orchestkit/ork',
+    points:['<span class="ok">✓</span> Hooks fire without being asked','<span class="ok">✓</span> /ork:implement is the Claude command','<span class="no">✗</span> Do not quote skills.sh 29.4K as unique users']
+  },
+  cursor:{
+    label:'Cursor',
+    title:'Marketplace yonatangross/orchestkit, enable ork, new chat',
+    body:'Same plugins/ork tree Claude Code installs. Claude hook scripts are not registered (they need CLAUDE_PLUGIN_ROOT). A leftover SKILL.md from Include third-party Plugins is not an install.',
+    command:'Settings → Plugins / marketplaces → yonatangross/orchestkit\nenable ork\nopen a NEW chat',
+    points:['<span class="ok">✓</span> Full skill catalog, not a five-skill fork','<span class="no">✗</span> Hooks stay in the consuming project .cursor/hooks.json','<span class="warn">→</span> Existing threads will not pick the plugin up']
+  },
+  skills:{
+    label:'skills.sh',
+    title:'Starter 12. Not the indexer firehose.',
+    body:'www.skills.sh/yonatangross/orchestkit lists every SKILL.md it can see (~298). That is skill-install events, not unique people, and not the 106 plugin skills.',
+    command:'npx skills add yonatangross/orchestkit -s doctor -s setup -s explore -s implement -s verify -s review-pr -s commit -s expect -s assess -s brainstorm -s create-pr -s remember',
+    points:['<span class="ok">✓</span> implement is the CC skill URL','<span class="no">✗</span> ork-implement was a Codex-shaped 404','<span class="warn">→</span> npx skills add with no -s is the firehose']
+  },
+  codex:{
+    label:'Codex',
+    title:'ork-codex now has six workflows',
+    body:'The pack already had brainstorm, explore, assess, verify, review-pr, plus ork_implementer as a role. The missing piece was the $ork-implement skill, which skills.sh indexed as a 404.',
+    command:'codex plugin marketplace add yonatangross/orchestkit --ref main --sparse .agents/plugins --sparse plugins/ork-codex\ncodex plugin add ork-codex@orchestkit-codex\n$ork-implement',
+    points:['<span class="ok">✓</span> src/codex and plugins/ork-codex stay in diff lockstep','<span class="ok">✓</span> test-codex-plugin.sh expects 6 skills','<span class="warn">→</span> Superpowers remains the official process plugin']
+  }
+};
+for (const card of document.querySelectorAll('.card')) card.onclick=()=>{
+  document.querySelector('.active').classList.remove('active');
+  card.classList.add('active');
+  const d=data[card.dataset.mode];
+  document.querySelector('#label').textContent=d.label;
+  document.querySelector('#title').textContent=d.title;
+  document.querySelector('#body').textContent=d.body;
+  document.querySelector('#command').textContent=d.command;
+  document.querySelector('#points').innerHTML=d.points.map(p=>'<li>'+p+'</li>').join('');
+};
+</script>
+</body>
+</html>

--- a/docs/site/content/docs/getting-started/installation.mdx
+++ b/docs/site/content/docs/getting-started/installation.mdx
@@ -1,12 +1,22 @@
 ---
 title: Installation
-description: Install OrchestKit in Claude Code — marketplace, CLI, or manual setup.
+description: Install OrchestKit in Claude Code, Cursor, or any agent via skills.sh.
 ---
 
 import { Card, Cards } from 'fumadocs-ui/components/card';
 import { Callout } from 'fumadocs-ui/components/callout';
 import { LazySetupWizard } from '@/components/lazy';
 import { Count, MinCC } from '@/components/count';
+
+## Choose a host
+
+| Host | What you get | Command |
+|---|---|---|
+| **Claude Code** (full plugin) | <Count k="skills" /> skills, <Count k="agents" /> agents, <Count k="hooks" /> hooks | `claude install orchestkit/ork` |
+| **Cursor** | Same `ork` plugin minus Claude hook scripts | Marketplace `yonatangross/orchestkit` → enable **ork** → new chat |
+| **skills.sh** | Skills only. Start with 12, not the whole catalog | see below |
+
+Coming from Superpowers (official Anthropic marketplace)? They are complementary — [OrchestKit vs Superpowers](/docs/getting-started/superpowers).
 
 ## From Claude Code Marketplace (Recommended)
 
@@ -15,6 +25,25 @@ claude install orchestkit/ork
 ```
 
 This installs all <Count k="skills" /> skills, <Count k="agents" /> agents, and <Count k="hooks" /> hooks.
+
+Slash-command equivalent:
+
+```bash
+/plugin marketplace add yonatangross/orchestkit
+/plugin install ork
+```
+
+## Cursor
+
+Add the GitHub repo as a Cursor marketplace (`yonatangross/orchestkit`), enable **ork**, then open a **new** chat. That is the same plugin Claude Code installs, not a five-skill fork. Claude hook scripts are not registered in Cursor (`CLAUDE_PLUGIN_ROOT`).
+
+## skills.sh starter (any agent)
+
+```bash
+npx skills add yonatangross/orchestkit -s doctor -s setup -s explore -s implement -s verify -s review-pr -s commit -s expect -s assess -s brainstorm -s create-pr -s remember
+```
+
+The implement workflow is [`implement`](https://www.skills.sh/yonatangross/orchestkit/implement). Codex's portable pack uses `$ork-implement` after `codex plugin add ork-codex@orchestkit-codex`. `npx skills add yonatangross/orchestkit` with no `-s` pulls every SKILL.md the indexer found — hundreds of files, not unique users.
 
 ## Interactive Setup
 
@@ -28,15 +57,15 @@ Run the health check after installing:
 /ork:doctor
 ```
 
-Expected output:
+A healthy report shows the **installed** plugin version (not a docs pin) and loaded counts matching <Count k="skills" /> skills, <Count k="agents" /> agents, and <Count k="hooks" /> hooks:
 
 ```
 OrchestKit Health Check
 =======================
-Plugin:     ork v8.63.2
-Skills:     113 loaded (32 commands, 81 reference)
-Agents:     36 registered
-Hooks:      171 active (150 global, 0 agent, 21 skill-scoped)
+Plugin:     ork <version from `claude plugins`>
+Skills:     loaded (commands + reference)
+Agents:     registered
+Hooks:      active (global / agent / skill-scoped)
 Memory:     Graph ✓  Local ✓  CC Native ✓
 MCP:        context7 ✓  memory ✓  tavily ○
 
@@ -61,7 +90,7 @@ Most issues are fixed by ensuring Node.js >= 18 is installed and restarting Clau
 ## Required: context7 MCP
 
 OrchestKit installs cleanly without it and `/ork:doctor` reports Healthy either way.
-But 22 of the 36 agents grant `mcp__context7__*` in their frontmatter, and the plugin
+But 22 of the <Count k="agents" /> agents grant `mcp__context7__*` in their frontmatter, and the plugin
 ships no server definition for it: `.mcp.json` is user-owned and project-scoped, so the
 grant refers to a server you supply. Without it, those agents answer from training data
 instead of current library docs, with no error to tell you so.

--- a/docs/site/content/docs/getting-started/meta.json
+++ b/docs/site/content/docs/getting-started/meta.json
@@ -3,6 +3,7 @@
   "icon": "Rocket",
   "pages": [
     "installation",
+    "superpowers",
     "first-10-minutes",
     "navigating",
     "configuration"

--- a/docs/site/content/docs/getting-started/superpowers.mdx
+++ b/docs/site/content/docs/getting-started/superpowers.mdx
@@ -1,0 +1,38 @@
+---
+title: OrchestKit vs Superpowers
+description: Superpowers is Anthropic's official process plugin. OrchestKit is production patterns plus lifecycle hooks. Complementary, not a rival listing.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+<Callout type="info">
+Superpowers is on the official Anthropic marketplace. Do not treat OrchestKit as a replacement listing for it. Use both, or pick one, based on what you actually need.
+</Callout>
+
+## The split
+
+| | [Superpowers](https://github.com/obra/superpowers) | OrchestKit |
+|---|---|---|
+| Home | Official Anthropic marketplace | `yonatangross/orchestkit` |
+| Job | Process: how the agent works a task (TDD, planning, review loops) | Production patterns: FastAPI, React, RAG, security, CI, plus lifecycle hooks |
+| Shape | Small, official, workflow | Broad catalog + `/ork:doctor` + hooks that fire without being asked |
+
+If you want the agent to follow a disciplined process, start with Superpowers. If you want it to already know how you ship a FastAPI endpoint, a TanStack query, or a pgvector retriever — and to block a commit that skips tests — that is OrchestKit.
+
+## Install either, or both
+
+Claude Code:
+
+```bash
+claude install orchestkit/ork
+```
+
+Cursor: Settings → marketplaces → `yonatangross/orchestkit` → enable **ork** → new chat.
+
+A 12-skill starter (not the skills.sh firehose):
+
+```bash
+npx skills add yonatangross/orchestkit -s doctor -s setup -s explore -s implement -s verify -s review-pr -s commit -s expect -s assess -s brainstorm -s create-pr -s remember
+```
+
+Public write-up on yonyon.ai: [OrchestKit vs Superpowers](https://yonyon.ai/compare/orchestkit-superpowers).

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "oss-surface-hygiene",
+      "source": "docs/chore--oss-surface-hygiene/install-matrix.html",
+      "title": "One plugin. Four first commands.",
+      "description": "Claude Code, Cursor, skills.sh starter 12, and Codex $ork-implement used to disagree. Click a host to see the first command that actually works, and why ork-implement 404ed on skills.sh.",
+      "tags": [
+        "install",
+        "codex",
+        "explainer"
+      ],
+      "date": "2026-08-25"
+    },
+    {
       "slug": "cursor-marketplace-source",
       "source": "docs/fix--cursor-marketplace-source/import.html",
       "title": "Cursor Import Marketplace rejects ./plugins/ork",

--- a/docs/site/lib/generated/docs-search-index.ts
+++ b/docs/site/lib/generated/docs-search-index.ts
@@ -163,12 +163,17 @@ export const DOCS_SEARCH_INDEX: DocSearchEntry[] = [
   {
     "url": "/docs/getting-started/installation",
     "title": "Installation",
-    "description": "Install OrchestKit in Claude Code — marketplace, CLI, or manual setup."
+    "description": "Install OrchestKit in Claude Code, Cursor, or any agent via skills.sh."
   },
   {
     "url": "/docs/getting-started/navigating",
     "title": "Find What You Need",
     "description": "Hub-and-spoke navigation — find the right skills and agents for your role and task."
+  },
+  {
+    "url": "/docs/getting-started/superpowers",
+    "title": "OrchestKit vs Superpowers",
+    "description": "Superpowers is Anthropic's official process plugin. OrchestKit is production patterns plus lifecycle hooks. Complementary, not a rival listing."
   },
   {
     "url": "/docs/guides/ask-fallback",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -83,6 +83,20 @@ export const LAB_ENTRIES: LabEntry[] = [
     "sizeKb": 5
   },
   {
+    "slug": "oss-surface-hygiene",
+    "title": "One plugin. Four first commands.",
+    "description": "Claude Code, Cursor, skills.sh starter 12, and Codex $ork-implement used to disagree. Click a host to see the first command that actually works, and why ork-implement 404ed on skills.sh.",
+    "tags": [
+      "install",
+      "codex",
+      "explainer"
+    ],
+    "date": "2026-08-25",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 7
+  },
+  {
     "slug": "watcher-first-harvest",
     "title": "Two defects the watcher found on its first run",
     "description": "The platform release-notes watcher's first live harvest caught a Sonnet 5 price that made every cost report read 50 percent high, and a model-ID gate that waved through a model the API had already retired. Interactive cost-delta slider and a pin checker showing the new RETIRED tier.",

--- a/docs/site/public/lab/oss-surface-hygiene.html
+++ b/docs/site/public/lab/oss-surface-hygiene.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Install matrix — Claude Code, Cursor, skills.sh, Codex</title>
+  <style>
+    :root{--bg:#0d1117;--panel:#161b22;--line:#30363d;--text:#e6edf3;--muted:#8b949e;--blue:#58a6ff;--green:#3fb950;--amber:#d29922;--red:#f85149;--mono:ui-monospace,SFMono-Regular,Menlo,monospace}
+    *{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:16px system-ui,sans-serif;padding:28px}
+    main{max-width:880px;margin:auto}h1{margin:0 0 6px}.sub{color:var(--muted);line-height:1.5}
+    .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(155px,1fr));gap:10px;margin:24px 0}
+    .card,section{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:15px}
+    .card button{width:100%;background:none;border:0;color:var(--text);text-align:left;cursor:pointer;font:inherit}
+    .card.active{border-color:var(--blue);box-shadow:0 0 0 1px var(--blue)}
+    .tag{font:12px var(--mono);color:var(--blue)}.ok{color:var(--green)}.warn{color:var(--amber)}.no{color:var(--red)}
+    code,pre{font-family:var(--mono)}pre{white-space:pre-wrap;background:#010409;border:1px solid var(--line);border-radius:7px;padding:13px;line-height:1.5}
+    li{margin:.45rem 0}footer{color:var(--muted);font-size:13px;margin-top:18px}
+    table{width:100%;border-collapse:collapse;font-size:14px}th,td{text-align:left;padding:8px 6px;border-bottom:1px solid var(--line)}
+    th{color:var(--muted);font-size:11px;text-transform:uppercase}
+  </style>
+</head>
+<body><main>
+  <h1>One plugin. Four first commands.</h1>
+  <p class="sub">This PR kills the install zoo: README, docs, and skills.sh all pointed at different first commands, doctor still showed <code>ork v8.63.2</code> / 113 skills, and Codex had no <code>$ork-implement</code> so skills.sh 404ed it.</p>
+  <div class="grid" id="modes">
+    <div class="card active" data-mode="cc"><button><span class="tag">Claude Code</span><br>Full plugin + hooks</button></div>
+    <div class="card" data-mode="cursor"><button><span class="tag">Cursor</span><br>Same ork, no CC hooks</button></div>
+    <div class="card" data-mode="skills"><button><span class="tag">skills.sh</span><br>Starter 12, not 298</button></div>
+    <div class="card" data-mode="codex"><button><span class="tag">Codex</span><br>$ork-implement exists</button></div>
+  </div>
+  <section>
+    <div class="tag" id="label">Claude Code</div>
+    <h2 id="title">Marketplace add, then install ork</h2>
+    <p id="body">The full plugin: 106 skills, 36 agents, 171 hooks. Doctor prints the installed version from <code>claude plugins</code>, not a frozen v8.x sample.</p>
+    <pre id="command">/plugin marketplace add yonatangross/orchestkit
+/plugin install ork
+# or: claude install orchestkit/ork</pre>
+    <ul id="points">
+      <li><span class="ok">✓</span> Hooks fire without being asked</li>
+      <li><span class="ok">✓</span> <code>/ork:implement</code> is the Claude command</li>
+      <li><span class="no">✗</span> Do not quote skills.sh 29.4K as unique users</li>
+    </ul>
+  </section>
+  <h2>What 404ed</h2>
+  <section>
+    <table>
+      <thead><tr><th>URL / command</th><th>Before</th><th>After</th></tr></thead>
+      <tbody>
+        <tr><td><code>skills.sh/.../ork-implement</code></td><td class="no">404</td><td class="ok">Codex skill ships</td></tr>
+        <tr><td><code>skills.sh/.../implement</code></td><td class="ok">Claude skill, always existed</td><td class="ok">still the CC name</td></tr>
+        <tr><td>npx skills add (no -s)</td><td class="warn">298 SKILL.md firehose</td><td>starter 12 is the advertised path</td></tr>
+      </tbody>
+    </table>
+  </section>
+  <footer>Click a host. Superpowers is process (official marketplace). OrchestKit is production patterns + hooks. Complementary, not a rival listing.</footer>
+</main>
+<script>
+const data={
+  cc:{
+    label:'Claude Code',
+    title:'Marketplace add, then install ork',
+    body:'The full plugin: 106 skills, 36 agents, 171 hooks. Doctor prints the installed version from claude plugins, not a frozen v8.x sample.',
+    command:'/plugin marketplace add yonatangross/orchestkit\n/plugin install ork\n# or: claude install orchestkit/ork',
+    points:['<span class="ok">✓</span> Hooks fire without being asked','<span class="ok">✓</span> /ork:implement is the Claude command','<span class="no">✗</span> Do not quote skills.sh 29.4K as unique users']
+  },
+  cursor:{
+    label:'Cursor',
+    title:'Marketplace yonatangross/orchestkit, enable ork, new chat',
+    body:'Same plugins/ork tree Claude Code installs. Claude hook scripts are not registered (they need CLAUDE_PLUGIN_ROOT). A leftover SKILL.md from Include third-party Plugins is not an install.',
+    command:'Settings → Plugins / marketplaces → yonatangross/orchestkit\nenable ork\nopen a NEW chat',
+    points:['<span class="ok">✓</span> Full skill catalog, not a five-skill fork','<span class="no">✗</span> Hooks stay in the consuming project .cursor/hooks.json','<span class="warn">→</span> Existing threads will not pick the plugin up']
+  },
+  skills:{
+    label:'skills.sh',
+    title:'Starter 12. Not the indexer firehose.',
+    body:'www.skills.sh/yonatangross/orchestkit lists every SKILL.md it can see (~298). That is skill-install events, not unique people, and not the 106 plugin skills.',
+    command:'npx skills add yonatangross/orchestkit -s doctor -s setup -s explore -s implement -s verify -s review-pr -s commit -s expect -s assess -s brainstorm -s create-pr -s remember',
+    points:['<span class="ok">✓</span> implement is the CC skill URL','<span class="no">✗</span> ork-implement was a Codex-shaped 404','<span class="warn">→</span> npx skills add with no -s is the firehose']
+  },
+  codex:{
+    label:'Codex',
+    title:'ork-codex now has six workflows',
+    body:'The pack already had brainstorm, explore, assess, verify, review-pr, plus ork_implementer as a role. The missing piece was the $ork-implement skill, which skills.sh indexed as a 404.',
+    command:'codex plugin marketplace add yonatangross/orchestkit --ref main --sparse .agents/plugins --sparse plugins/ork-codex\ncodex plugin add ork-codex@orchestkit-codex\n$ork-implement',
+    points:['<span class="ok">✓</span> src/codex and plugins/ork-codex stay in diff lockstep','<span class="ok">✓</span> test-codex-plugin.sh expects 6 skills','<span class="warn">→</span> Superpowers remains the official process plugin']
+  }
+};
+for (const card of document.querySelectorAll('.card')) card.onclick=()=>{
+  document.querySelector('.active').classList.remove('active');
+  card.classList.add('active');
+  const d=data[card.dataset.mode];
+  document.querySelector('#label').textContent=d.label;
+  document.querySelector('#title').textContent=d.title;
+  document.querySelector('#body').textContent=d.body;
+  document.querySelector('#command').textContent=d.command;
+  document.querySelector('#points').innerHTML=d.points.map(p=>'<li>'+p+'</li>').join('');
+};
+</script>
+</body>
+</html>

--- a/manifests/codex/ork-codex.json
+++ b/manifests/codex/ork-codex.json
@@ -9,7 +9,8 @@
     "ork-explore",
     "ork-assess",
     "ork-verify",
-    "ork-review-pr"
+    "ork-review-pr",
+    "ork-implement"
   ],
   "roles": [
     "ork_explorer",

--- a/plugins/ork-codex/.codex-plugin/plugin.json
+++ b/plugins/ork-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ork-codex",
   "version": "10.0.0-alpha.60",
-  "description": "Portable OrchestKit workflows for Codex: brainstorm, explore, assess, verify, and review pull requests.",
+  "description": "Portable OrchestKit workflows for Codex: brainstorm, explore, implement, assess, verify, and review pull requests.",
   "author": {
     "name": "Yonatan Gross",
     "url": "https://github.com/yonatangross"
@@ -20,7 +20,7 @@
   "interface": {
     "displayName": "OrchestKit for Codex",
     "shortDescription": "Evidence-first orchestration workflows for Codex.",
-    "longDescription": "A small, Codex-native OrchestKit pack for deliberate planning, codebase exploration, assessment, verification, and pull-request review. It uses Codex skills and subagents without Claude-only commands or hooks.",
+    "longDescription": "A small, Codex-native OrchestKit pack for deliberate planning, codebase exploration, scoped implementation, assessment, verification, and pull-request review. It uses Codex skills and subagents without Claude-only commands or hooks.",
     "developerName": "Yonatan Gross",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/ork-codex/skills/ork-implement/SKILL.md
+++ b/plugins/ork-codex/skills/ork-implement/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ork-implement
+description: Make an approved, scoped change and prove the affected behavior. Use when a request asks to implement, build, add, or land a feature that already has an agreed approach. Do not use to explore, review, or verify existing work, or to choose between approaches.
+---
+
+# Ork Implement
+
+Implement only the agreed scope. Read repository instructions first and use an isolated worktree whenever a shared primary checkout may be active.
+
+Before writing against an unfamiliar third-party API, confirm its current surface through the context7 MCP server (call `resolve-library-id`, then `query-docs`) rather than recalling it.
+
+Keep the diff small. Add focused tests when behavior changes, and report the exact verification output. Do not self-certify a high-impact change: request `$ork-verify` (or `ork_verifier` when installed) after implementation.
+
+Prefer `ork_implementer` when installed; otherwise implement in this context. Delegate only independent, bounded units; keep integration in one place.

--- a/plugins/ork-codex/skills/ork-implement/agents/openai.yaml
+++ b/plugins/ork-codex/skills/ork-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Implement"
+  short_description: "Make a scoped change and prove it."
+  default_prompt: "Use $ork-implement to implement $ARGUMENTS."

--- a/src/codex/ork-codex/.codex-plugin/plugin.json
+++ b/src/codex/ork-codex/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ork-codex",
   "version": "9.5.4",
-  "description": "Portable OrchestKit workflows for Codex: brainstorm, explore, assess, verify, and review pull requests.",
+  "description": "Portable OrchestKit workflows for Codex: brainstorm, explore, implement, assess, verify, and review pull requests.",
   "author": {
     "name": "Yonatan Gross",
     "url": "https://github.com/yonatangross"
@@ -15,7 +15,7 @@
   "interface": {
     "displayName": "OrchestKit for Codex",
     "shortDescription": "Evidence-first orchestration workflows for Codex.",
-    "longDescription": "A small, Codex-native OrchestKit pack for deliberate planning, codebase exploration, assessment, verification, and pull-request review. It uses Codex skills and subagents without Claude-only commands or hooks.",
+    "longDescription": "A small, Codex-native OrchestKit pack for deliberate planning, codebase exploration, scoped implementation, assessment, verification, and pull-request review. It uses Codex skills and subagents without Claude-only commands or hooks.",
     "developerName": "Yonatan Gross",
     "category": "Productivity",
     "capabilities": ["Read", "Write"],

--- a/src/codex/ork-codex/skills/ork-implement/SKILL.md
+++ b/src/codex/ork-codex/skills/ork-implement/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: ork-implement
+description: Make an approved, scoped change and prove the affected behavior. Use when a request asks to implement, build, add, or land a feature that already has an agreed approach. Do not use to explore, review, or verify existing work, or to choose between approaches.
+---
+
+# Ork Implement
+
+Implement only the agreed scope. Read repository instructions first and use an isolated worktree whenever a shared primary checkout may be active.
+
+Before writing against an unfamiliar third-party API, confirm its current surface through the context7 MCP server (call `resolve-library-id`, then `query-docs`) rather than recalling it.
+
+Keep the diff small. Add focused tests when behavior changes, and report the exact verification output. Do not self-certify a high-impact change: request `$ork-verify` (or `ork_verifier` when installed) after implementation.
+
+Prefer `ork_implementer` when installed; otherwise implement in this context. Delegate only independent, bounded units; keep integration in one place.

--- a/src/codex/ork-codex/skills/ork-implement/agents/openai.yaml
+++ b/src/codex/ork-codex/skills/ork-implement/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ork Implement"
+  short_description: "Make a scoped change and prove it."
+  default_prompt: "Use $ork-implement to implement $ARGUMENTS."

--- a/tests/plugins/test-codex-plugin.sh
+++ b/tests/plugins/test-codex-plugin.sh
@@ -11,7 +11,7 @@ for path in "$SOURCE_ROOT" "$PLUGIN_ROOT" "$MARKETPLACE"; do
   [[ -e "$path" ]] || { echo "FAIL: missing $path"; exit 1; }
 done
 
-expected_skills=(ork-brainstorm ork-explore ork-assess ork-verify ork-review-pr)
+expected_skills=(ork-brainstorm ork-explore ork-assess ork-verify ork-review-pr ork-implement)
 for skill in "${expected_skills[@]}"; do
   skill_file="$PLUGIN_ROOT/skills/$skill/SKILL.md"
   [[ -f "$skill_file" ]] || { echo "FAIL: missing $skill"; exit 1; }
@@ -76,4 +76,4 @@ jq -e '
 diff -qr "$SOURCE_ROOT" "$PLUGIN_ROOT" \
   --exclude='plugin.json' >/dev/null
 
-echo "PASS: Codex plugin contract (5 skills, 4 roles, context7 MCP server)"
+echo "PASS: Codex plugin contract (6 skills, 4 roles, context7 MCP server)"


### PR DESCRIPTION
## Summary
- One install matrix for Claude Code / Cursor / skills.sh (starter 12, not the 298-file firehose).
- Codex pack now includes `$ork-implement` so skills.sh `ork-implement` stops 404ing.
- Doctor sample no longer pins `ork v8.63.2` / 113 skills.
- Honest Superpowers split on the docs site.

## Consumer
- [x] Codex skill is in `src/codex` and `plugins/ork-codex` (test-codex-plugin.sh requires them to match).
- [x] `tests/plugins/test-codex-plugin.sh` expects 6 skills.

## Test plan
- [x] `bash tests/plugins/test-codex-plugin.sh`
- [x] `node scripts/check-docs-facts.mjs`
- [x] `node scripts/check-readme-commands.mjs`
- [x] `npm run test:manifests`

## Issue close-out

No tracked issue.

## Interactive Playground

Production Lab is `main` only, so https://orchestkit.yonyon.ai/lab/oss-surface-hygiene.html 404s until this merges.

**[Open Playground](https://github.com/yonatangross/orchestkit/blob/6776e07e5bb935c9c8f55933e10b5fae469c43de/docs/chore--oss-surface-hygiene/install-matrix.html)** (SHA-pinned source; GitHub does not render HTML)

Vercel preview (SSO): https://orchestkit-git-chore-oss-surface-hygiene-yonyon.vercel.app/lab/oss-surface-hygiene.html

Made with [Cursor](https://cursor.com)