### PR TITLE
feat(agents): experimental.cacheTtl 1h on five long-running agents

### DIFF
--- a/docs/feat--agents-cache-ttl-1h/index.html
+++ b/docs/feat--agents-cache-ttl-1h/index.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Five agents, one hour of cache: experimental.cacheTtl measured</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{--bg:#0f1115;--fg:#e6e6e6;--mut:#9aa3ad;--a:#7bd88f;--b:#f2c14e;--line:#262b33}
+body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Inter,sans-serif}
+main{max-width:920px;margin:0 auto;padding:40px 20px}
+h1{font-size:26px;margin:0 0 6px}h2{font-size:18px;margin:32px 0 10px}
+p.lead{color:var(--mut);margin-top:0}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.card{border:1px solid var(--line);border-radius:10px;padding:16px}
+.card h3{margin:0 0 8px;font-size:15px}
+.bar{height:22px;border-radius:4px;background:var(--line);overflow:hidden;display:flex;margin:6px 0}
+.bar span{display:block;height:100%}
+.b5{background:var(--b)}.b1{background:var(--a)}
+.num{font-variant-numeric:tabular-nums;font-family:ui-monospace,Menlo,monospace}
+table{border-collapse:collapse;width:100%;font-size:14px}td,th{border-bottom:1px solid var(--line);padding:6px 8px;text-align:left}
+code{background:#1a1f27;padding:1px 5px;border-radius:4px;font-size:13px}
+.legend span{display:inline-block;width:12px;height:12px;border-radius:2px;margin:0 6px 0 14px;vertical-align:-1px}
+label{display:block;margin:10px 0 4px;color:var(--mut)}
+input[type=range]{width:100%}
+.note{color:var(--mut);font-size:13px}
+</style></head><body><main>
+<h1>Five agents, one hour of cache</h1>
+<p class="lead">CC 2.1.248 added <code>experimental.cacheTtl</code> to agent frontmatter. OrchestKit sets it to <code>1h</code> on the five agents that idle past the default five-minute window. The numbers below come from two real fan-out runs on 2.1.251, read from the subagent transcript's per-message <code>usage.cache_creation</code> field, not from a claim.</p>
+
+<h2>Measured: where the subagent's cache writes landed</h2>
+<div class="row">
+ <div class="card"><h3>Before (no frontmatter)</h3>
+  <div class="bar"><span class="b5" style="width:100%"></span></div>
+  <div class="num">ephemeral_5m: 254,554 &nbsp; ephemeral_1h: 0</div>
+  <p class="note">Subagent <code>ork:code-quality-reviewer</code>, 8 API turns, cache read 602,252. Run cost $6.62 (list price).</p></div>
+ <div class="card"><h3>After (<code>cacheTtl: 1h</code>)</h3>
+  <div class="bar"><span class="b1" style="width:100%"></span></div>
+  <div class="num">ephemeral_5m: 0 &nbsp; ephemeral_1h: 253,346</div>
+  <p class="note">Same prompt, same agent, 6 API turns, cache read 350,936. Run cost $7.08 (list price).</p></div>
+</div>
+<p class="legend"><span class="b5"></span>5-minute TTL writes <span class="b1"></span>1-hour TTL writes</p>
+<p>The main conversation was already on the 1h TTL in both runs (307,297 and 414,049 tokens), which is the session-level setting. The field moves only the subagent, which is exactly what it is for.</p>
+
+<h2>What it buys, and what it costs</h2>
+<p>A 1h cache write is priced at 2x the base input rate; a 5m write at 1.25x. Reads are 0.1x either way. The write premium is paid once per cache segment; the saving arrives on every resume after an idle gap longer than five minutes, where a 5m cache would have expired and the whole prompt would be rewritten. Drag the idle gap to see the break-even for one 250k-token subagent prompt.</p>
+<div class="card">
+ <label>Idle gap before the agent is resumed: <b id="gapv">12</b> min</label>
+ <input id="gap" type="range" min="0" max="60" value="12">
+ <label>Resumes over the agent's life: <b id="resv">2</b></label>
+ <input id="res" type="range" min="0" max="8" value="2">
+ <table><thead><tr><th>Setting</th><th>Initial write</th><th>Per resume</th><th>Total input cost units</th></tr></thead>
+ <tbody><tr><td>5m (default)</td><td class="num">312,500</td><td class="num" id="r5"></td><td class="num" id="t5"></td></tr>
+ <tr><td>1h</td><td class="num">500,000</td><td class="num" id="r1"></td><td class="num" id="t1"></td></tr></tbody></table>
+ <p class="note" id="verdict"></p>
+</div>
+<script>
+const P=250000;function f(n){return n.toLocaleString()}
+function upd(){const g=+gap.value,r=+res.value;gapv.textContent=g;resv.textContent=r;
+ const r5=g>5?P*1.25:P*0.1, r1=g>60?P*2:P*0.1;
+ const t5=P*1.25+r*r5, t1=P*2+r*r1;
+ document.getElementById('r5').textContent=f(r5);document.getElementById('r1').textContent=f(r1);
+ document.getElementById('t5').textContent=f(t5);document.getElementById('t1').textContent=f(t1);
+ verdict.textContent= t1<t5?`1h wins by ${f(t5-t1)} units: every resume after a ${g}-minute gap would have rewritten the whole prompt on 5m.`:(g<=5?'Within five minutes both TTLs hit; 1h only costs the write premium.':'No resumes, so the 1h premium is pure cost.');}
+gap.oninput=res.oninput=upd;upd();
+</script>
+
+<h2>Which agents, and why these</h2>
+<table><thead><tr><th>Agent</th><th>Why it idles past 5m</th></tr></thead><tbody>
+<tr><td><code>security-auditor</code></td><td>stage agent of the <code>audit-full</code> mapreduce workflow (security and dependencies modes)</td></tr>
+<tr><td><code>system-design-reviewer</code></td><td>stage agent of the same workflow (architecture mode)</td></tr>
+<tr><td><code>eval-runner</code></td><td>waits on eval datasets and grader runs</td></tr>
+<tr><td><code>ci-cd-engineer</code></td><td>waits on CI runs between turns</td></tr>
+<tr><td><code>code-quality-reviewer</code></td><td>long reviews, resumed by <code>SendMessage</code> after a maxTurns stop</td></tr>
+</tbody></table>
+<p class="note">Decision 2 of the adopt-all architecture page: four long-running agents was the recommended scope; the audit-full entry resolves to the two stage agents above. CC ignores <code>1h</code> while a subscription is in usage overage, and reads the field only from subagent files. The repo's frontmatter parser (<code>scripts/lib/parse-frontmatter.js</code>) previously read any nested mapping as an empty array; it now parses one level, with a unit test, so the docs site sees the field too.</p>
+</main></body></html>

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -514,6 +514,18 @@
         "measurement"
       ],
       "date": "2026-08-29"
+    },
+    {
+      "slug": "agent-cache-ttl",
+      "source": "docs/feat--agents-cache-ttl-1h/index.html",
+      "title": "Five Agents, One Hour of Cache",
+      "description": "experimental.cacheTtl: 1h on the five long-running ork agents, measured on two real fan-out runs: the subagent cache writes moved from 254,554 tokens at 5m to 253,346 at 1h. Drag the idle gap to see when the write premium pays back.",
+      "tags": [
+        "measurement",
+        "agents",
+        "cost"
+      ],
+      "date": "2026-08-29"
     }
   ]
 }

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -15,6 +15,20 @@ export interface LabEntry {
 
 export const LAB_ENTRIES: LabEntry[] = [
   {
+    "slug": "agent-cache-ttl",
+    "title": "Five Agents, One Hour of Cache",
+    "description": "experimental.cacheTtl: 1h on the five long-running ork agents, measured on two real fan-out runs: the subagent cache writes moved from 254,554 tokens at 5m to 253,346 at 1h. Drag the idle gap to see when the write premium pays back.",
+    "tags": [
+      "measurement",
+      "agents",
+      "cost"
+    ],
+    "date": "2026-08-29",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 6
+  },
+  {
     "slug": "restricted-still-fires",
     "title": "Restricted, and Still All 34 Hooks Fired",
     "description": "CC 2.1.248 --restricted removes Bash and WebFetch and ignores user settings. Which of ork's hooks break in that mode? Measured on 2.1.251: none. The CI lane drives a real claude -p --restricted against a local stub of the Messages API, at zero spend, and asserts the failing-hook set stays empty.",

--- a/docs/site/public/lab/agent-cache-ttl.html
+++ b/docs/site/public/lab/agent-cache-ttl.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Five agents, one hour of cache: experimental.cacheTtl measured</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{--bg:#0f1115;--fg:#e6e6e6;--mut:#9aa3ad;--a:#7bd88f;--b:#f2c14e;--line:#262b33}
+body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Inter,sans-serif}
+main{max-width:920px;margin:0 auto;padding:40px 20px}
+h1{font-size:26px;margin:0 0 6px}h2{font-size:18px;margin:32px 0 10px}
+p.lead{color:var(--mut);margin-top:0}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.card{border:1px solid var(--line);border-radius:10px;padding:16px}
+.card h3{margin:0 0 8px;font-size:15px}
+.bar{height:22px;border-radius:4px;background:var(--line);overflow:hidden;display:flex;margin:6px 0}
+.bar span{display:block;height:100%}
+.b5{background:var(--b)}.b1{background:var(--a)}
+.num{font-variant-numeric:tabular-nums;font-family:ui-monospace,Menlo,monospace}
+table{border-collapse:collapse;width:100%;font-size:14px}td,th{border-bottom:1px solid var(--line);padding:6px 8px;text-align:left}
+code{background:#1a1f27;padding:1px 5px;border-radius:4px;font-size:13px}
+.legend span{display:inline-block;width:12px;height:12px;border-radius:2px;margin:0 6px 0 14px;vertical-align:-1px}
+label{display:block;margin:10px 0 4px;color:var(--mut)}
+input[type=range]{width:100%}
+.note{color:var(--mut);font-size:13px}
+</style></head><body><main>
+<h1>Five agents, one hour of cache</h1>
+<p class="lead">CC 2.1.248 added <code>experimental.cacheTtl</code> to agent frontmatter. OrchestKit sets it to <code>1h</code> on the five agents that idle past the default five-minute window. The numbers below come from two real fan-out runs on 2.1.251, read from the subagent transcript's per-message <code>usage.cache_creation</code> field, not from a claim.</p>
+
+<h2>Measured: where the subagent's cache writes landed</h2>
+<div class="row">
+ <div class="card"><h3>Before (no frontmatter)</h3>
+  <div class="bar"><span class="b5" style="width:100%"></span></div>
+  <div class="num">ephemeral_5m: 254,554 &nbsp; ephemeral_1h: 0</div>
+  <p class="note">Subagent <code>ork:code-quality-reviewer</code>, 8 API turns, cache read 602,252. Run cost $6.62 (list price).</p></div>
+ <div class="card"><h3>After (<code>cacheTtl: 1h</code>)</h3>
+  <div class="bar"><span class="b1" style="width:100%"></span></div>
+  <div class="num">ephemeral_5m: 0 &nbsp; ephemeral_1h: 253,346</div>
+  <p class="note">Same prompt, same agent, 6 API turns, cache read 350,936. Run cost $7.08 (list price).</p></div>
+</div>
+<p class="legend"><span class="b5"></span>5-minute TTL writes <span class="b1"></span>1-hour TTL writes</p>
+<p>The main conversation was already on the 1h TTL in both runs (307,297 and 414,049 tokens), which is the session-level setting. The field moves only the subagent, which is exactly what it is for.</p>
+
+<h2>What it buys, and what it costs</h2>
+<p>A 1h cache write is priced at 2x the base input rate; a 5m write at 1.25x. Reads are 0.1x either way. The write premium is paid once per cache segment; the saving arrives on every resume after an idle gap longer than five minutes, where a 5m cache would have expired and the whole prompt would be rewritten. Drag the idle gap to see the break-even for one 250k-token subagent prompt.</p>
+<div class="card">
+ <label>Idle gap before the agent is resumed: <b id="gapv">12</b> min</label>
+ <input id="gap" type="range" min="0" max="60" value="12">
+ <label>Resumes over the agent's life: <b id="resv">2</b></label>
+ <input id="res" type="range" min="0" max="8" value="2">
+ <table><thead><tr><th>Setting</th><th>Initial write</th><th>Per resume</th><th>Total input cost units</th></tr></thead>
+ <tbody><tr><td>5m (default)</td><td class="num">312,500</td><td class="num" id="r5"></td><td class="num" id="t5"></td></tr>
+ <tr><td>1h</td><td class="num">500,000</td><td class="num" id="r1"></td><td class="num" id="t1"></td></tr></tbody></table>
+ <p class="note" id="verdict"></p>
+</div>
+<script>
+const P=250000;function f(n){return n.toLocaleString()}
+function upd(){const g=+gap.value,r=+res.value;gapv.textContent=g;resv.textContent=r;
+ const r5=g>5?P*1.25:P*0.1, r1=g>60?P*2:P*0.1;
+ const t5=P*1.25+r*r5, t1=P*2+r*r1;
+ document.getElementById('r5').textContent=f(r5);document.getElementById('r1').textContent=f(r1);
+ document.getElementById('t5').textContent=f(t5);document.getElementById('t1').textContent=f(t1);
+ verdict.textContent= t1<t5?`1h wins by ${f(t5-t1)} units: every resume after a ${g}-minute gap would have rewritten the whole prompt on 5m.`:(g<=5?'Within five minutes both TTLs hit; 1h only costs the write premium.':'No resumes, so the 1h premium is pure cost.');}
+gap.oninput=res.oninput=upd;upd();
+</script>
+
+<h2>Which agents, and why these</h2>
+<table><thead><tr><th>Agent</th><th>Why it idles past 5m</th></tr></thead><tbody>
+<tr><td><code>security-auditor</code></td><td>stage agent of the <code>audit-full</code> mapreduce workflow (security and dependencies modes)</td></tr>
+<tr><td><code>system-design-reviewer</code></td><td>stage agent of the same workflow (architecture mode)</td></tr>
+<tr><td><code>eval-runner</code></td><td>waits on eval datasets and grader runs</td></tr>
+<tr><td><code>ci-cd-engineer</code></td><td>waits on CI runs between turns</td></tr>
+<tr><td><code>code-quality-reviewer</code></td><td>long reviews, resumed by <code>SendMessage</code> after a maxTurns stop</td></tr>
+</tbody></table>
+<p class="note">Decision 2 of the adopt-all architecture page: four long-running agents was the recommended scope; the audit-full entry resolves to the two stage agents above. CC ignores <code>1h</code> while a subscription is in usage overage, and reads the field only from subagent files. The repo's frontmatter parser (<code>scripts/lib/parse-frontmatter.js</code>) previously read any nested mapping as an empty array; it now parses one level, with a unit test, so the docs site sees the field too.</p>
+</main></body></html>

--- a/plugins/ork/agents/ci-cd-engineer.md
+++ b/plugins/ork/agents/ci-cd-engineer.md
@@ -2,6 +2,12 @@
 name: ci-cd-engineer
 description: "CI/CD specialist: GitHub Actions, GitLab CI pipelines, deployment automation, build optimization, caching, security scanning."
 model: inherit
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 category: devops
 maxTurns: 30
 effort: medium

--- a/plugins/ork/agents/ci-cd-engineer.md
+++ b/plugins/ork/agents/ci-cd-engineer.md
@@ -3,10 +3,10 @@ name: ci-cd-engineer
 description: "CI/CD specialist: GitHub Actions, GitLab CI pipelines, deployment automation, build optimization, caching, security scanning."
 model: inherit
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 category: devops
 maxTurns: 30

--- a/plugins/ork/agents/code-quality-reviewer.md
+++ b/plugins/ork/agents/code-quality-reviewer.md
@@ -2,6 +2,12 @@
 name: code-quality-reviewer
 description: "Code quality reviewer: bug detection, security vulnerabilities, performance issues, linting, type checking, test coverage."
 model: inherit
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 category: testing
 maxTurns: 50
 effort: medium

--- a/plugins/ork/agents/code-quality-reviewer.md
+++ b/plugins/ork/agents/code-quality-reviewer.md
@@ -3,10 +3,10 @@ name: code-quality-reviewer
 description: "Code quality reviewer: bug detection, security vulnerabilities, performance issues, linting, type checking, test coverage."
 model: inherit
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 category: testing
 maxTurns: 50

--- a/plugins/ork/agents/eval-runner.md
+++ b/plugins/ork/agents/eval-runner.md
@@ -3,10 +3,10 @@ name: eval-runner
 description: "LLM evaluation specialist who runs structured eval datasets, computes quality metrics using DeepEval/RAGAS, tracks regression across model versions, and reports to Langfuse for tracing and scoring."
 model: haiku
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 background: true
 initialPrompt: "Check TaskList for pending evaluation tasks. Load the most recent golden dataset configuration and baseline metrics."

--- a/plugins/ork/agents/eval-runner.md
+++ b/plugins/ork/agents/eval-runner.md
@@ -2,6 +2,12 @@
 name: eval-runner
 description: "LLM evaluation specialist who runs structured eval datasets, computes quality metrics using DeepEval/RAGAS, tracks regression across model versions, and reports to Langfuse for tracing and scoring."
 model: haiku
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 background: true
 initialPrompt: "Check TaskList for pending evaluation tasks. Load the most recent golden dataset configuration and baseline metrics."
 maxTurns: 20

--- a/plugins/ork/agents/security-auditor.md
+++ b/plugins/ork/agents/security-auditor.md
@@ -3,6 +3,12 @@ name: security-auditor
 description: "Security auditor: vulnerability scanning, dependency audits, OWASP Top 10 compliance, secrets detection, remediation."
 category: security
 model: opus
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 maxTurns: 60
 effort: medium
 context: fork

--- a/plugins/ork/agents/security-auditor.md
+++ b/plugins/ork/agents/security-auditor.md
@@ -4,10 +4,10 @@ description: "Security auditor: vulnerability scanning, dependency audits, OWASP
 category: security
 model: opus
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 maxTurns: 60
 effort: medium

--- a/plugins/ork/agents/system-design-reviewer.md
+++ b/plugins/ork/agents/system-design-reviewer.md
@@ -4,10 +4,10 @@ description: System design reviewer who evaluates implementation plans against s
 category: design
 model: opus
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 maxTurns: 60
 effort: medium

--- a/plugins/ork/agents/system-design-reviewer.md
+++ b/plugins/ork/agents/system-design-reviewer.md
@@ -3,6 +3,12 @@ name: system-design-reviewer
 description: System design reviewer who evaluates implementation plans against scale, data, security, UX, and coherence criteria before code is written.
 category: design
 model: opus
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 maxTurns: 60
 effort: medium
 context: inherit

--- a/scripts/lib/parse-frontmatter.js
+++ b/scripts/lib/parse-frontmatter.js
@@ -6,7 +6,10 @@
  *   - generate-indexes.js (passive agent/skill indexes)
  *
  * Handles: simple key/value, inline arrays [a, b], multi-line arrays (- item),
- * quoted strings, booleans, and multiline scalars (| / > / >- / |-).
+ * quoted strings, booleans, multiline scalars (| / > / >- / |-), and one level
+ * of nested mapping (`experimental:` followed by indented `cacheTtl: 1h`
+ * lines, the CC 2.1.248 agent-frontmatter shape). Before that case was added
+ * a nested mapping parsed as an empty array and every sub-key was dropped.
  */
 
 'use strict';
@@ -43,6 +46,9 @@ function parseYamlFrontmatter(content) {
   let inScalar = false; // Track multiline scalar (> / | / >- / |-)
 
   for (const line of frontmatterLines) {
+    // YAML comment lines carry no data at any indentation.
+    if (/^\s*#/.test(line)) continue;
+
     // If we're collecting a multiline scalar, check if this is a continuation
     if (inScalar && currentKey) {
       // Continuation lines are indented (start with whitespace)
@@ -58,6 +64,27 @@ function parseYamlFrontmatter(content) {
         // Non-indented line — scalar ended, fall through to normal parsing
         inScalar = false;
       }
+    }
+
+    // Check for a nested mapping line (`  subKey: value` under a bare `key:`).
+    // Only one level deep; deeper structures are not used in this repo.
+    const nested = line.match(/^\s+([a-zA-Z0-9_-]+):\s*(.*)$/);
+    if (nested && inArray && currentKey && !inScalar) {
+      const container = frontmatter[currentKey];
+      if (Array.isArray(container) && container.length > 0) {
+        // A `- item` array already started; an indented key here is not ours.
+        continue;
+      }
+      if (Array.isArray(container)) frontmatter[currentKey] = {};
+      let value = nested[2].trim();
+      if ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (value === 'true') value = true;
+      else if (value === 'false') value = false;
+      frontmatter[currentKey][nested[1]] = value;
+      continue;
     }
 
     // Check for array item

--- a/src/agents/ci-cd-engineer.md
+++ b/src/agents/ci-cd-engineer.md
@@ -2,6 +2,12 @@
 name: ci-cd-engineer
 description: "CI/CD specialist: GitHub Actions, GitLab CI pipelines, deployment automation, build optimization, caching, security scanning."
 model: inherit
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 category: devops
 maxTurns: 30
 effort: medium

--- a/src/agents/ci-cd-engineer.md
+++ b/src/agents/ci-cd-engineer.md
@@ -3,10 +3,10 @@ name: ci-cd-engineer
 description: "CI/CD specialist: GitHub Actions, GitLab CI pipelines, deployment automation, build optimization, caching, security scanning."
 model: inherit
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 category: devops
 maxTurns: 30

--- a/src/agents/code-quality-reviewer.md
+++ b/src/agents/code-quality-reviewer.md
@@ -2,6 +2,12 @@
 name: code-quality-reviewer
 description: "Code quality reviewer: bug detection, security vulnerabilities, performance issues, linting, type checking, test coverage."
 model: inherit
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 category: testing
 maxTurns: 50
 effort: medium

--- a/src/agents/code-quality-reviewer.md
+++ b/src/agents/code-quality-reviewer.md
@@ -3,10 +3,10 @@ name: code-quality-reviewer
 description: "Code quality reviewer: bug detection, security vulnerabilities, performance issues, linting, type checking, test coverage."
 model: inherit
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 category: testing
 maxTurns: 50

--- a/src/agents/eval-runner.md
+++ b/src/agents/eval-runner.md
@@ -3,10 +3,10 @@ name: eval-runner
 description: "LLM evaluation specialist who runs structured eval datasets, computes quality metrics using DeepEval/RAGAS, tracks regression across model versions, and reports to Langfuse for tracing and scoring."
 model: haiku
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 background: true
 initialPrompt: "Check TaskList for pending evaluation tasks. Load the most recent golden dataset configuration and baseline metrics."

--- a/src/agents/eval-runner.md
+++ b/src/agents/eval-runner.md
@@ -2,6 +2,12 @@
 name: eval-runner
 description: "LLM evaluation specialist who runs structured eval datasets, computes quality metrics using DeepEval/RAGAS, tracks regression across model versions, and reports to Langfuse for tracing and scoring."
 model: haiku
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 background: true
 initialPrompt: "Check TaskList for pending evaluation tasks. Load the most recent golden dataset configuration and baseline metrics."
 maxTurns: 20

--- a/src/agents/security-auditor.md
+++ b/src/agents/security-auditor.md
@@ -3,6 +3,12 @@ name: security-auditor
 description: "Security auditor: vulnerability scanning, dependency audits, OWASP Top 10 compliance, secrets detection, remediation."
 category: security
 model: opus
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 maxTurns: 60
 effort: medium
 context: fork

--- a/src/agents/security-auditor.md
+++ b/src/agents/security-auditor.md
@@ -4,10 +4,10 @@ description: "Security auditor: vulnerability scanning, dependency audits, OWASP
 category: security
 model: opus
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 maxTurns: 60
 effort: medium

--- a/src/agents/system-design-reviewer.md
+++ b/src/agents/system-design-reviewer.md
@@ -4,10 +4,10 @@ description: System design reviewer who evaluates implementation plans against s
 category: design
 model: opus
 experimental:
-  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
-  # setting is configured. This agent idles past the default 5m window (workflow
-  # stage, CI wait, long review), so every resume after that paid a full cache
-  # write. Ignored by CC while a subscription is in usage overage.
+  # Per-agent prompt-cache TTL, used when no subagentPromptCacheTtl setting is
+  # configured. This agent idles past the default 5m window (workflow stage,
+  # CI wait, long review), so every resume after that paid a full cache write.
+  # Ignored while a subscription is in usage overage. CLAUDE.md owns the floor.
   cacheTtl: 1h
 maxTurns: 60
 effort: medium

--- a/src/agents/system-design-reviewer.md
+++ b/src/agents/system-design-reviewer.md
@@ -3,6 +3,12 @@ name: system-design-reviewer
 description: System design reviewer who evaluates implementation plans against scale, data, security, UX, and coherence criteria before code is written.
 category: design
 model: opus
+experimental:
+  # CC 2.1.248: per-agent prompt-cache TTL, used when no subagentPromptCacheTtl
+  # setting is configured. This agent idles past the default 5m window (workflow
+  # stage, CI wait, long review), so every resume after that paid a full cache
+  # write. Ignored by CC while a subscription is in usage overage.
+  cacheTtl: 1h
 maxTurns: 60
 effort: medium
 context: inherit

--- a/tests/agents/test-agent-frontmatter.sh
+++ b/tests/agents/test-agent-frontmatter.sh
@@ -66,6 +66,20 @@ for agent_file in "$AGENTS_DIR"/*.md; do
     fi
   fi
 
+  # experimental.cacheTtl (CC 2.1.248): CC silently ignores any value other
+  # than 5m or 1h, so a typo would read as "adopted" while doing nothing.
+  ttl=$(node -e '
+    const { parseYamlFrontmatter } = require("'"$REPO_ROOT"'/scripts/lib/parse-frontmatter");
+    const fm = parseYamlFrontmatter(require("fs").readFileSync("'"$agent_file"'", "utf-8")).frontmatter;
+    const x = fm.experimental;
+    process.stdout.write(x && typeof x === "object" && !Array.isArray(x) && x.cacheTtl != null ? String(x.cacheTtl) : "");
+  ')
+  if [[ -n "$ttl" && "$ttl" != "5m" && "$ttl" != "1h" ]]; then
+    echo "FAIL: $agent_name experimental.cacheTtl must be 5m or 1h, got: $ttl"
+    agent_failed=1
+    FAILED=1
+  fi
+
   # Validate taxonomy fields using the project's own frontmatter parser
   taxonomy_result=$(node -e '
     const { parseYamlFrontmatter } = require("'"$REPO_ROOT"'/scripts/lib/parse-frontmatter");

--- a/tests/unit/test-parse-frontmatter.sh
+++ b/tests/unit/test-parse-frontmatter.sh
@@ -118,6 +118,31 @@ name: test
 body' "description")
 [[ -n "$result" ]] && [[ "$result" == *"Literal block scalar"* ]] && pass "| literal scalar" || fail "Expected content, got '$result'"
 
+# Test 9: nested mapping (CC 2.1.248 agent frontmatter `experimental.cacheTtl`)
+echo "▶ Test 9: nested mapping"
+result=$(parse_field '---
+name: agent
+experimental:
+  # comment lines inside the block carry no data
+  cacheTtl: 1h
+tools:
+  - Read
+---
+body' "experimental")
+[[ "$result" == '{"cacheTtl":"1h"}' ]] && pass "Nested mapping parses as an object" || fail "Expected {\"cacheTtl\":\"1h\"}, got '$result'"
+
+# Test 10: nested mapping does not eat the next key
+echo "▶ Test 10: nested mapping stops at next key"
+result=$(parse_field '---
+experimental:
+  cacheTtl: 1h
+tools:
+  - Read
+  - Write
+---
+body' "tools")
+[[ "$result" == '["Read","Write"]' ]] && pass "Array after nested mapping intact" || fail "Expected [\"Read\",\"Write\"], got '$result'"
+
 # Test 9: > folded scalar (no dash)
 echo "▶ Test 9: > folded scalar"
 result=$(parse_field '---


### PR DESCRIPTION
## Summary

CC 2.1.248 added `experimental.cacheTtl` (`5m` | `1h`) to agent frontmatter: a per-agent prompt-cache TTL used when no `subagentPromptCacheTtl` setting is configured. This sets it to `1h` on the five ork agents that idle past the default five-minute window (wave 1 of the adopt-all plan, decision 2: the four long-running agents, with the audit-full entry resolving to its two mapreduce stage agents).

| Agent | Why it idles past 5m |
|---|---|
| `security-auditor` | audit-full mapreduce stage agent (security, dependencies modes) |
| `system-design-reviewer` | audit-full mapreduce stage agent (architecture mode) |
| `eval-runner` | waits on datasets and grader runs |
| `ci-cd-engineer` | waits on CI between turns |
| `code-quality-reviewer` | long reviews, resumed via SendMessage after a maxTurns stop |

## Measurement (before vs after, one fan-out run each, CC 2.1.251)

Instrument: the subagent transcript's per-message `usage.cache_creation` split (`ephemeral_5m_input_tokens` / `ephemeral_1h_input_tokens`), which is what the API actually applied. `claude -p ... --output-format json` exposes that split only for the main turn, so the numbers below are read from `~/.claude/projects/.../<session>/subagents/agent-*.jsonl`. Same prompt both times: spawn `ork:code-quality-reviewer` on `src/hooks/src/lib/session-staleness.ts`.

| Run | Subagent cache writes at 5m | Subagent cache writes at 1h | Subagent cache reads | Run cost (list) |
|---|---|---|---|---|
| before (no frontmatter) | 254,554 | 0 | 602,252 | $6.62 |
| after (`cacheTtl: 1h`) | 0 | 253,346 | 350,936 | $7.08 |

The main conversation was on 1h in both runs (307,297 / 414,049 write tokens), which is the session-level setting; the field moves only the subagent. The delta in run cost is the 1h write premium (2x base vs 1.25x for 5m); the return is every resume after an idle gap over five minutes, where a 5m cache would have expired and the whole prompt rewritten. The playground has a slider for the break-even.

Caveats stated by the CC docs: `1h` is ignored while a subscription is in usage overage, and the field is read only from subagent files.

## Also in this PR

- `scripts/lib/parse-frontmatter.js` read any nested mapping as an empty array, so the docs-site generators would have dropped the field silently. It now parses one level of nesting (two unit tests added, 12/12 pass) and skips YAML comment lines at any indentation.
- `tests/agents/test-agent-frontmatter.sh` rejects any `experimental.cacheTtl` value other than `5m` or `1h`, since CC silently ignores other values (a typo would read as adopted while doing nothing). `npm run test:agents`: 17/17.
- `claude plugin validate ./plugins/ork` on 2.1.251: exit 0 with the nested key present.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/agents-cache-ttl-1h/docs/feat--agents-cache-ttl-1h/index.html)** (Lab: `agent-cache-ttl`)

Part of the CC 2.1.243 to 2.1.251 adopt-all sweep (architecture page `docs/playgrounds/dev/cc-adopt-all-architecture-2026-08-29.html`).
