### PR TITLE
feat(ci): --restricted smoke lane against a stub Messages API (#3774)

### DIFF
--- a/.github/workflows/plugin-validation.yml
+++ b/.github/workflows/plugin-validation.yml
@@ -350,6 +350,50 @@ jobs:
           }
           echo "Plugin validation passed!"
 
+  # Job 6b: --restricted smoke lane (#3774, CC 2.1.248+)
+  # A real `claude -p --restricted` process loads the built plugin against a
+  # local stub of the Messages API: no model call, no token, no secret. The
+  # lane asserts the run answers, that the process really was restricted (no
+  # Bash/WebFetch offered), that the plugin's hooks fired, and that the set of
+  # hooks reporting ok:false equals tests/ci/restricted-smoke/expected-hook-
+  # failures.txt (empty on 2.1.251). Gated by Validation Summary below.
+  cc-restricted-smoke:
+    name: CC Restricted Smoke
+    permissions:
+      contents: read
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download built plugins
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: built-plugins
+          path: plugins/
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          build-plugins: 'false'
+          run-ci-setup: 'false'
+
+      - name: Install Claude Code CLI
+        run: |
+          # Same pin and pattern as CC Plugin Validate: the support floor
+          # (2.1.251, shared/cc-support.json), --ignore-scripts, then install.cjs
+          # to fetch the native binary the skipped postinstall would have.
+          npm install -g @anthropic-ai/claude-code@2.1.251 --ignore-scripts
+          INSTALL_CJS="$(npm root -g)/@anthropic-ai/claude-code/install.cjs"
+          [ -f "$INSTALL_CJS" ] && node "$INSTALL_CJS"
+          claude --version
+
+      - name: Run restricted smoke lane
+        run: bash tests/ci/restricted-smoke/run-restricted-smoke.sh ./plugins/ork
+
   # Job 7: Component Counts Validation
   counts-validation:
     name: Component Counts
@@ -515,7 +559,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [syntax-validation, schema-validation, hook-unit-tests, integration-tests, manifest-validation, cc-plugin-validate, counts-validation, skills-validation, skill-sync-validation]
+    needs: [syntax-validation, schema-validation, hook-unit-tests, integration-tests, manifest-validation, cc-plugin-validate, cc-restricted-smoke, counts-validation, skills-validation, skill-sync-validation]
     if: always()
     steps:
       - name: Check results
@@ -530,6 +574,7 @@ jobs:
           echo "Integration Tests:     ${{ needs.integration-tests.result }}"
           echo "Manifest Validation:   ${{ needs.manifest-validation.result }}"
           echo "CC Plugin Validate:    ${{ needs.cc-plugin-validate.result }} (advisory)"
+          echo "CC Restricted Smoke:   ${{ needs.cc-restricted-smoke.result }}"
           echo "Counts Validation:     ${{ needs.counts-validation.result }}"
           echo "Skills Validation:     ${{ needs.skills-validation.result }}"
           echo "Skill Sync Validation: ${{ needs.skill-sync-validation.result }}"
@@ -540,6 +585,7 @@ jobs:
              [[ "${{ needs.hook-unit-tests.result }}" != "success" ]] || \
              [[ "${{ needs.integration-tests.result }}" != "success" ]] || \
              [[ "${{ needs.manifest-validation.result }}" != "success" ]] || \
+             [[ "${{ needs.cc-restricted-smoke.result }}" != "success" ]] || \
              [[ "${{ needs.counts-validation.result }}" != "success" ]] || \
              [[ "${{ needs.skill-sync-validation.result }}" != "success" ]]; then
             echo "Some validations failed!"

--- a/docs/feat--3774-restricted-smoke-lane/index.html
+++ b/docs/feat--3774-restricted-smoke-lane/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Restricted, and still all 34 hooks fired: the --restricted smoke lane</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{--bg:#0f1115;--fg:#e6e6e6;--mut:#9aa3ad;--a:#7bd88f;--b:#f2c14e;--r:#e06c75;--line:#262b33}
+body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Inter,sans-serif}
+main{max-width:940px;margin:0 auto;padding:40px 20px}
+h1{font-size:26px;margin:0 0 6px}h2{font-size:18px;margin:32px 0 10px}
+p.lead{color:var(--mut);margin-top:0}
+.card{border:1px solid var(--line);border-radius:10px;padding:16px;margin:12px 0}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:6px;font:12px ui-monospace,Menlo,monospace}
+.h{border:1px solid var(--line);border-radius:6px;padding:4px 8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.h.ok{border-color:#2f5e3a}.h.bad{border-color:var(--r);background:#2a1418}
+button{background:#1a1f27;color:var(--fg);border:1px solid var(--line);border-radius:6px;padding:6px 12px;cursor:pointer;margin-right:8px}
+button.on{border-color:var(--a)}
+table{border-collapse:collapse;width:100%;font-size:14px}td,th{border-bottom:1px solid var(--line);padding:6px 8px;text-align:left;vertical-align:top}
+.ok{color:var(--a)}.no{color:var(--r)}.num{font-variant-numeric:tabular-nums}
+code{background:#1a1f27;padding:1px 5px;border-radius:4px;font-size:13px}
+.note{color:var(--mut);font-size:13px}
+</style></head><body><main>
+<h1>Restricted, and still all 34 hooks fired</h1>
+<p class="lead">CC 2.1.248 added <code>--restricted</code>: no Bash, no WebFetch, no user or project settings, file tools fenced to the working directory. The open question for a plugin with 154 hook entries was which of them break in that mode. Measured on 2.1.251: none. This page shows the lane that keeps it that way on every PR, at zero model spend.</p>
+
+<h2>1. What the process was offered, by mode</h2>
+<div class="card">
+ <p><button id="bR" class="on">--restricted</button><button id="bN">plain -p (control)</button></p>
+ <table><tbody>
+ <tr><th>tools in the request CC sent</th><td id="tools" class="num"></td></tr>
+ <tr><th>Bash / WebFetch present</th><td id="bw"></td></tr>
+ <tr><th>distinct plugin hooks that fired</th><td id="hk" class="num"></td></tr>
+ <tr><th>hooks reporting ok: false</th><td id="fl" class="num"></td></tr>
+ <tr><th>model spend</th><td>$0 (local stub of the Messages API answered all 7 requests)</td></tr>
+ </tbody></table>
+ <p class="note" id="why"></p>
+</div>
+
+<h2>2. The hooks that fired under --restricted</h2>
+<p class="note">One-turn session ("reply ok"). PreToolUse and PostToolUse hooks are absent because no tool ran, which is correct for a one-turn prompt; Stop and SessionEnd hooks are included because the runner waits three seconds for them to flush.</p>
+<div class="grid" id="hooks"></div>
+
+<h2>3. How the lane asserts it</h2>
+<table><thead><tr><th>#</th><th>Assertion</th><th>What proves it</th><th>Negative control</th></tr></thead><tbody>
+<tr><td>1</td><td>the run completed and answered</td><td><code>result: ok</code>, <code>is_error: false</code></td><td>stub down: run fails</td></tr>
+<tr><td>2</td><td>the process really was restricted</td><td>the stub logged the tool list; no <code>Bash</code>, no <code>WebFetch</code></td><td>same run without the flag: <span class="no">FAIL</span>, 38 tools including Bash and WebFetch</td></tr>
+<tr><td>3</td><td>plugin hooks fired</td><td><code>hook-timing.jsonl</code> in the run's private HOME has entries</td><td>plugin not loaded: file absent, <span class="no">FAIL</span></td></tr>
+<tr><td>4</td><td>the failing set is the accepted set</td><td>hooks with <code>ok:false</code> equal <code>expected-hook-failures.txt</code> (empty)</td><td>list edited to name one hook: <span class="no">FAIL</span>, <code>[] != ["lifecycle/nonexistent-hook"]</code></td></tr>
+</tbody></table>
+<p class="note">The runner gives <code>claude</code> a fresh HOME, so the hook log it reads can only have been written by this run (twelve other sessions were live on the machine that produced these numbers). The stub is 60 lines of node: every <code>POST /v1/messages</code> gets an SSE stream that says "ok"; everything else is logged and 404s. The policy that real model calls never run in CI holds.</p>
+<script>
+const R={tools:"Agent, CronDelete, CronList, DesignSync, Edit, EnterWorktree, ExitWorktree, Glob, Grep, ListAgents, NotebookEdit, PushNotification, Read, ReportFindings, ScheduleWakeup, SendMessage, Skill, TaskOutput, TaskStop, WebSearch, Write (20)",bw:'<span class="ok">absent</span>',hk:"34 (36 entries)",fl:"0",why:"Restricted removed the two tools it promises to remove and left the plugin loader, the hooks runner and every lifecycle hook untouched."};
+const N={tools:"the same list plus Bash, CronCreate, LSP, Monitor, Workflow, WaitForMcpServers, WebFetch, the MCP resource tools and 11 mcp__ tools (38)",bw:'<span class="no">present</span>',hk:"40 (62 entries)",fl:"0",why:"The control run offers Bash and WebFetch and, because user settings load, the MCP servers from ~/.claude too. Assertion 2 fails on this run, which is the proof that the assertion can fail."};
+const hooks="instructions-loaded/session-rules-audit lifecycle/analytics-liveness-check lifecycle/ask-fallback-injector lifecycle/cc-version-check lifecycle/cleanup-envelope-corruption lifecycle/hook-token-check lifecycle/nudge-outcome-resolver lifecycle/pattern-sync-pull lifecycle/plugins-drift-snapshot lifecycle/rules-size-check lifecycle/session-env-setup lifecycle/session-handoff-injector lifecycle/session-registrar lifecycle/stale-cache-cleanup lifecycle/stale-team-cleanup lifecycle/sweep-stale-worktrees lifecycle/sync-session-dispatcher lifecycle/telemetry-dark-check lifecycle/type-error-indexer lifecycle/webhook-forwarder notification/message-display-observer prompt/goal-tracker prompt/thrash-detector prompt/unified-dispatcher prompt/worktree-advisory-consumer skill/coverage-check skill/coverage-threshold-gate skill/cross-instance-test-validator skill/evidence-collector stop/goal-tracker stop/handoff-writer stop/ledger-cleanup stop/session-summary stop/task-completion-check".split(" ");
+document.getElementById('hooks').innerHTML=hooks.map(h=>`<div class="h ok" title="${h}">${h}</div>`).join('');
+function set(m){const d=m?R:N;bR.classList.toggle('on',m);bN.classList.toggle('on',!m);tools.textContent=d.tools;bw.innerHTML=d.bw;hk.textContent=d.hk;fl.textContent=d.fl;why.textContent=d.why;}
+bR.onclick=()=>set(true);bN.onclick=()=>set(false);set(true);
+</script>
+</main></body></html>

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -502,6 +502,18 @@
         "cc-adoption"
       ],
       "date": "2026-08-29"
+    },
+    {
+      "slug": "restricted-still-fires",
+      "source": "docs/feat--3774-restricted-smoke-lane/index.html",
+      "title": "Restricted, and Still All 34 Hooks Fired",
+      "description": "CC 2.1.248 --restricted removes Bash and WebFetch and ignores user settings. Which of ork's hooks break in that mode? Measured on 2.1.251: none. The CI lane drives a real claude -p --restricted against a local stub of the Messages API, at zero spend, and asserts the failing-hook set stays empty.",
+      "tags": [
+        "ci",
+        "hooks",
+        "measurement"
+      ],
+      "date": "2026-08-29"
     }
   ]
 }

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -15,6 +15,20 @@ export interface LabEntry {
 
 export const LAB_ENTRIES: LabEntry[] = [
   {
+    "slug": "restricted-still-fires",
+    "title": "Restricted, and Still All 34 Hooks Fired",
+    "description": "CC 2.1.248 --restricted removes Bash and WebFetch and ignores user settings. Which of ork's hooks break in that mode? Measured on 2.1.251: none. The CI lane drives a real claude -p --restricted against a local stub of the Messages API, at zero spend, and asserts the failing-hook set stays empty.",
+    "tags": [
+      "ci",
+      "hooks",
+      "measurement"
+    ],
+    "date": "2026-08-29",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 7
+  },
+  {
     "slug": "model-switch-consent",
     "title": "PreModelSwitch: the second door onto Fable, now guarded",
     "description": "The payload as measured on CC 2.1.251, the three-run end-to-end table before and after one fix, and the defect unit tests could not see: a hook whose envelope the output guard strips is not a hook that blocks.",

--- a/docs/site/public/lab/restricted-still-fires.html
+++ b/docs/site/public/lab/restricted-still-fires.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Restricted, and still all 34 hooks fired: the --restricted smoke lane</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{--bg:#0f1115;--fg:#e6e6e6;--mut:#9aa3ad;--a:#7bd88f;--b:#f2c14e;--r:#e06c75;--line:#262b33}
+body{margin:0;background:var(--bg);color:var(--fg);font:15px/1.5 -apple-system,Segoe UI,Inter,sans-serif}
+main{max-width:940px;margin:0 auto;padding:40px 20px}
+h1{font-size:26px;margin:0 0 6px}h2{font-size:18px;margin:32px 0 10px}
+p.lead{color:var(--mut);margin-top:0}
+.card{border:1px solid var(--line);border-radius:10px;padding:16px;margin:12px 0}
+.grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(210px,1fr));gap:6px;font:12px ui-monospace,Menlo,monospace}
+.h{border:1px solid var(--line);border-radius:6px;padding:4px 8px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.h.ok{border-color:#2f5e3a}.h.bad{border-color:var(--r);background:#2a1418}
+button{background:#1a1f27;color:var(--fg);border:1px solid var(--line);border-radius:6px;padding:6px 12px;cursor:pointer;margin-right:8px}
+button.on{border-color:var(--a)}
+table{border-collapse:collapse;width:100%;font-size:14px}td,th{border-bottom:1px solid var(--line);padding:6px 8px;text-align:left;vertical-align:top}
+.ok{color:var(--a)}.no{color:var(--r)}.num{font-variant-numeric:tabular-nums}
+code{background:#1a1f27;padding:1px 5px;border-radius:4px;font-size:13px}
+.note{color:var(--mut);font-size:13px}
+</style></head><body><main>
+<h1>Restricted, and still all 34 hooks fired</h1>
+<p class="lead">CC 2.1.248 added <code>--restricted</code>: no Bash, no WebFetch, no user or project settings, file tools fenced to the working directory. The open question for a plugin with 154 hook entries was which of them break in that mode. Measured on 2.1.251: none. This page shows the lane that keeps it that way on every PR, at zero model spend.</p>
+
+<h2>1. What the process was offered, by mode</h2>
+<div class="card">
+ <p><button id="bR" class="on">--restricted</button><button id="bN">plain -p (control)</button></p>
+ <table><tbody>
+ <tr><th>tools in the request CC sent</th><td id="tools" class="num"></td></tr>
+ <tr><th>Bash / WebFetch present</th><td id="bw"></td></tr>
+ <tr><th>distinct plugin hooks that fired</th><td id="hk" class="num"></td></tr>
+ <tr><th>hooks reporting ok: false</th><td id="fl" class="num"></td></tr>
+ <tr><th>model spend</th><td>$0 (local stub of the Messages API answered all 7 requests)</td></tr>
+ </tbody></table>
+ <p class="note" id="why"></p>
+</div>
+
+<h2>2. The hooks that fired under --restricted</h2>
+<p class="note">One-turn session ("reply ok"). PreToolUse and PostToolUse hooks are absent because no tool ran, which is correct for a one-turn prompt; Stop and SessionEnd hooks are included because the runner waits three seconds for them to flush.</p>
+<div class="grid" id="hooks"></div>
+
+<h2>3. How the lane asserts it</h2>
+<table><thead><tr><th>#</th><th>Assertion</th><th>What proves it</th><th>Negative control</th></tr></thead><tbody>
+<tr><td>1</td><td>the run completed and answered</td><td><code>result: ok</code>, <code>is_error: false</code></td><td>stub down: run fails</td></tr>
+<tr><td>2</td><td>the process really was restricted</td><td>the stub logged the tool list; no <code>Bash</code>, no <code>WebFetch</code></td><td>same run without the flag: <span class="no">FAIL</span>, 38 tools including Bash and WebFetch</td></tr>
+<tr><td>3</td><td>plugin hooks fired</td><td><code>hook-timing.jsonl</code> in the run's private HOME has entries</td><td>plugin not loaded: file absent, <span class="no">FAIL</span></td></tr>
+<tr><td>4</td><td>the failing set is the accepted set</td><td>hooks with <code>ok:false</code> equal <code>expected-hook-failures.txt</code> (empty)</td><td>list edited to name one hook: <span class="no">FAIL</span>, <code>[] != ["lifecycle/nonexistent-hook"]</code></td></tr>
+</tbody></table>
+<p class="note">The runner gives <code>claude</code> a fresh HOME, so the hook log it reads can only have been written by this run (twelve other sessions were live on the machine that produced these numbers). The stub is 60 lines of node: every <code>POST /v1/messages</code> gets an SSE stream that says "ok"; everything else is logged and 404s. The policy that real model calls never run in CI holds.</p>
+<script>
+const R={tools:"Agent, CronDelete, CronList, DesignSync, Edit, EnterWorktree, ExitWorktree, Glob, Grep, ListAgents, NotebookEdit, PushNotification, Read, ReportFindings, ScheduleWakeup, SendMessage, Skill, TaskOutput, TaskStop, WebSearch, Write (20)",bw:'<span class="ok">absent</span>',hk:"34 (36 entries)",fl:"0",why:"Restricted removed the two tools it promises to remove and left the plugin loader, the hooks runner and every lifecycle hook untouched."};
+const N={tools:"the same list plus Bash, CronCreate, LSP, Monitor, Workflow, WaitForMcpServers, WebFetch, the MCP resource tools and 11 mcp__ tools (38)",bw:'<span class="no">present</span>',hk:"40 (62 entries)",fl:"0",why:"The control run offers Bash and WebFetch and, because user settings load, the MCP servers from ~/.claude too. Assertion 2 fails on this run, which is the proof that the assertion can fail."};
+const hooks="instructions-loaded/session-rules-audit lifecycle/analytics-liveness-check lifecycle/ask-fallback-injector lifecycle/cc-version-check lifecycle/cleanup-envelope-corruption lifecycle/hook-token-check lifecycle/nudge-outcome-resolver lifecycle/pattern-sync-pull lifecycle/plugins-drift-snapshot lifecycle/rules-size-check lifecycle/session-env-setup lifecycle/session-handoff-injector lifecycle/session-registrar lifecycle/stale-cache-cleanup lifecycle/stale-team-cleanup lifecycle/sweep-stale-worktrees lifecycle/sync-session-dispatcher lifecycle/telemetry-dark-check lifecycle/type-error-indexer lifecycle/webhook-forwarder notification/message-display-observer prompt/goal-tracker prompt/thrash-detector prompt/unified-dispatcher prompt/worktree-advisory-consumer skill/coverage-check skill/coverage-threshold-gate skill/cross-instance-test-validator skill/evidence-collector stop/goal-tracker stop/handoff-writer stop/ledger-cleanup stop/session-summary stop/task-completion-check".split(" ");
+document.getElementById('hooks').innerHTML=hooks.map(h=>`<div class="h ok" title="${h}">${h}</div>`).join('');
+function set(m){const d=m?R:N;bR.classList.toggle('on',m);bN.classList.toggle('on',!m);tools.textContent=d.tools;bw.innerHTML=d.bw;hk.textContent=d.hk;fl.textContent=d.fl;why.textContent=d.why;}
+bR.onclick=()=>set(true);bN.onclick=()=>set(false);set(true);
+</script>
+</main></body></html>

--- a/tests/ci/restricted-smoke/README.md
+++ b/tests/ci/restricted-smoke/README.md
@@ -1,0 +1,24 @@
+# --restricted smoke lane (#3774)
+
+Runs the built plugin through a real `claude -p` process started with
+`--restricted` (CC 2.1.248+), against a local stub of the Anthropic Messages
+API. No model is called, no token is spent, no secret is needed: the stub
+answers every `/v1/messages` with a canned "ok". What is real is everything
+that matters for the plugin: CC's loader, `--plugin-dir`, the hooks runner and
+every hook that fires for a one-turn session.
+
+`run-restricted-smoke.sh` asserts four things:
+
+1. the run completes with `result: ok` and `is_error: false`;
+2. the request CC sent carries no `Bash` and no `WebFetch` tool, which proves
+   the process really was restricted (a plain `-p` run sends both);
+3. the plugin's hooks fired under `--restricted`: `hook-timing.jsonl` in the
+   run's private HOME has entries;
+4. the set of hooks that reported `ok: false` equals
+   `expected-hook-failures.txt` (one hook name per line, sorted). The file is
+   empty because the first enumeration on 2.1.251 found none; a hook that
+   starts failing under `--restricted` turns the lane red, and a hook that is
+   accepted as failing is added to the file with a reason, never silently.
+
+The lane is wired into `plugin-validation.yml` and gated by its Validation
+Summary job, which is a required check.

--- a/tests/ci/restricted-smoke/run-restricted-smoke.sh
+++ b/tests/ci/restricted-smoke/run-restricted-smoke.sh
@@ -14,7 +14,10 @@ EXPECTED="$HERE/expected-hook-failures.txt"
 [ -f "$PLUGIN_DIR/.claude-plugin/plugin.json" ] || { echo "FAIL: no plugin at $PLUGIN_DIR"; exit 2; }
 command -v "$CLAUDE_BIN" >/dev/null || { echo "FAIL: $CLAUDE_BIN not on PATH"; exit 2; }
 
-SCRATCH="$(mktemp -d -t restricted-smoke)"
+# Template form: honours TMPDIR and works on both GNU and BSD mktemp
+# (GNU rejects `-t restricted-smoke` with "too few X's", which is what the
+# first CI run of this lane died on).
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/restricted-smoke.XXXXXX")"
 cleanup() {
   [ -n "${STUB_PID:-}" ] && kill "$STUB_PID" 2>/dev/null || true
   [ "${SMOKE_KEEP:-0}" = "1" ] || rm -rf "$SCRATCH"

--- a/tests/ci/restricted-smoke/run-restricted-smoke.sh
+++ b/tests/ci/restricted-smoke/run-restricted-smoke.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# --restricted smoke lane (#3774). See README.md next to this file.
+#
+# Usage: bash tests/ci/restricted-smoke/run-restricted-smoke.sh [plugin-dir]
+# Env:   CLAUDE_BIN (default: claude), SMOKE_KEEP=1 keeps the scratch dir.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+PLUGIN_DIR="${1:-$REPO_ROOT/plugins/ork}"
+CLAUDE_BIN="${CLAUDE_BIN:-claude}"
+EXPECTED="$HERE/expected-hook-failures.txt"
+
+[ -f "$PLUGIN_DIR/.claude-plugin/plugin.json" ] || { echo "FAIL: no plugin at $PLUGIN_DIR"; exit 2; }
+command -v "$CLAUDE_BIN" >/dev/null || { echo "FAIL: $CLAUDE_BIN not on PATH"; exit 2; }
+
+SCRATCH="$(mktemp -d -t restricted-smoke)"
+cleanup() {
+  [ -n "${STUB_PID:-}" ] && kill "$STUB_PID" 2>/dev/null || true
+  [ "${SMOKE_KEEP:-0}" = "1" ] || rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+# 1. stub API: zero spend, logs every request
+STUB_LOG="$SCRATCH/requests.jsonl" STUB_PORT_FILE="$SCRATCH/port" \
+  node "$HERE/stub-anthropic-api.mjs" > "$SCRATCH/stub.log" 2>&1 &
+STUB_PID=$!
+for _ in $(seq 1 50); do [ -s "$SCRATCH/port" ] && break; sleep 0.1; done
+[ -s "$SCRATCH/port" ] || { echo "FAIL: stub did not start"; cat "$SCRATCH/stub.log"; exit 2; }
+PORT="$(cat "$SCRATCH/port")"
+
+# 2. a private HOME: the hooks runner writes analytics under $HOME/.claude, so a
+#    fresh HOME makes the hook enumeration exact (no other session can write here),
+#    and --restricted ignores user settings anyway. Auth is the stub key.
+FAKE_HOME="$SCRATCH/home"; mkdir -p "$FAKE_HOME"
+echo "claude: $("$CLAUDE_BIN" --version 2>/dev/null || echo unknown)"
+echo "plugin: $PLUGIN_DIR"
+echo "stub:   http://127.0.0.1:$PORT"
+
+set +e
+env -u CLAUDECODE -u CLAUDE_CODE_OAUTH_TOKEN -u CLAUDE_CONFIG_DIR \
+  HOME="$FAKE_HOME" ANTHROPIC_BASE_URL="http://127.0.0.1:$PORT" ANTHROPIC_API_KEY="restricted-smoke-stub" \
+  DISABLE_TELEMETRY=1 DISABLE_ERROR_REPORTING=1 CLAUDE_PROJECT_DIR="$REPO_ROOT" \
+  "$CLAUDE_BIN" -p "reply ok" --restricted --plugin-dir "$PLUGIN_DIR" \
+    --output-format json --max-turns 1 \
+    > "$SCRATCH/result.json" 2> "$SCRATCH/stderr.txt" < /dev/null
+RC=$?
+set -e
+# Stop/SessionEnd hooks flush asynchronously after the process exits.
+sleep 3
+
+FAILS=0
+fail() { echo "FAIL: $1"; FAILS=$((FAILS + 1)); }
+pass() { echo "PASS: $1"; }
+
+# Assertion 1: the run completed and answered
+if [ "$RC" -ne 0 ]; then fail "claude exited $RC"; head -c 2000 "$SCRATCH/stderr.txt"; fi
+RESULT="$(node -e 'try{const r=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));process.stdout.write(String(r.is_error===false&&/\bok\b/i.test(String(r.result))))}catch{process.stdout.write("false")}' "$SCRATCH/result.json")"
+[ "$RESULT" = "true" ] && pass "run completed with result ok, is_error false" || { fail "result envelope: $(head -c 400 "$SCRATCH/result.json")"; }
+
+# Assertion 2: the process really was restricted (no Bash, no WebFetch offered)
+TOOLS="$(node -e 'const fs=require("fs");const L=fs.readFileSync(process.argv[1],"utf8").trim().split("\n").map(l=>JSON.parse(l)).filter(r=>r.method==="POST"&&/\/v1\/messages/.test(r.path)&&Array.isArray(r.tools)&&r.tools.length>5);process.stdout.write(L.length?L[0].tools.join(","):"")' "$SCRATCH/requests.jsonl")"
+if [ -z "$TOOLS" ]; then fail "stub saw no /v1/messages request with a tool list"; else
+  if grep -qE '(^|,)(Bash|WebFetch)(,|$)' <<< "$TOOLS"; then fail "tool list still offers Bash/WebFetch: $TOOLS"; else pass "restricted proven: tool list has no Bash/WebFetch ($(tr ',' '\n' <<< "$TOOLS" | wc -l | tr -d ' ') tools)"; fi
+fi
+
+# Assertion 3 + 4: plugin hooks fired, and the failing set matches the accepted list
+TIMING="$FAKE_HOME/.claude/analytics/hook-timing.jsonl"
+if [ ! -s "$TIMING" ]; then fail "no plugin hook wrote $TIMING: hooks did not run under --restricted"; else
+  node - "$TIMING" "$EXPECTED" <<'JS'
+const fs = require('fs');
+const [timing, expectedFile] = process.argv.slice(2);
+const rows = fs.readFileSync(timing, 'utf8').trim().split('\n').map((l) => { try { return JSON.parse(l); } catch { return null; } }).filter(Boolean);
+const ran = [...new Set(rows.map((r) => r.hook))].sort();
+const failed = [...new Set(rows.filter((r) => r.ok === false).map((r) => r.hook))].sort();
+const expected = fs.readFileSync(expectedFile, 'utf8').split('\n').map((s) => s.trim()).filter((s) => s && !s.startsWith('#')).sort();
+console.log(`PASS: ${ran.length} distinct plugin hooks fired under --restricted (${rows.length} entries)`);
+console.log('hooks: ' + ran.join(' '));
+const same = JSON.stringify(failed) === JSON.stringify(expected);
+if (same) { console.log(`PASS: failing-hook set matches expected-hook-failures.txt (${failed.length})`); }
+else { console.log(`FAIL: failing hooks ${JSON.stringify(failed)} != expected ${JSON.stringify(expected)}`); process.exit(1); }
+JS
+  [ $? -eq 0 ] || FAILS=$((FAILS + 1))
+fi
+
+echo "requests seen by stub: $(wc -l < "$SCRATCH/requests.jsonl" | tr -d ' ')"
+if [ "$FAILS" -gt 0 ]; then echo "restricted smoke: $FAILS assertion(s) failed"; exit 1; fi
+echo "restricted smoke: all assertions passed"

--- a/tests/ci/restricted-smoke/stub-anthropic-api.mjs
+++ b/tests/ci/restricted-smoke/stub-anthropic-api.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Minimal Anthropic Messages API stub for driving `claude -p` with zero model
+// spend. Every POST /v1/messages gets a canned assistant turn ("ok") as an SSE
+// stream (or JSON when stream:false). Every request is appended to
+// STUB_LOG as one JSON line so the caller can assert what CC sent.
+import http from 'node:http';
+import fs from 'node:fs';
+
+const PORT = Number(process.env.STUB_PORT || 0);
+const LOG = process.env.STUB_LOG || '/tmp/stub-anthropic-api.jsonl';
+const REPLY = process.env.STUB_REPLY || 'ok';
+
+function sse(res, model) {
+  const ev = (type, data) => res.write(`event: ${type}\ndata: ${JSON.stringify({ type, ...data })}\n\n`);
+  res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+  ev('message_start', { message: { id: 'msg_stub', type: 'message', role: 'assistant', model, content: [], stop_reason: null, stop_sequence: null, usage: { input_tokens: 1, output_tokens: 1 } } });
+  ev('content_block_start', { index: 0, content_block: { type: 'text', text: '' } });
+  ev('content_block_delta', { index: 0, delta: { type: 'text_delta', text: REPLY } });
+  ev('content_block_stop', { index: 0 });
+  ev('message_delta', { delta: { stop_reason: 'end_turn', stop_sequence: null }, usage: { output_tokens: 1 } });
+  ev('message_stop', {});
+  res.end();
+}
+
+const server = http.createServer((req, res) => {
+  let body = '';
+  req.on('data', (c) => { body += c; });
+  req.on('end', () => {
+    let parsed = null;
+    try { parsed = body ? JSON.parse(body) : null; } catch { parsed = { unparsable: body.slice(0, 200) }; }
+    const sys = parsed && parsed.system;
+    const sysText = Array.isArray(sys) ? sys.map((b) => b.text || '').join('\n') : (typeof sys === 'string' ? sys : '');
+    const line = {
+      ts: new Date().toISOString(), method: req.method, path: req.url,
+      model: parsed && parsed.model, stream: parsed && parsed.stream,
+      tools: parsed && Array.isArray(parsed.tools) ? parsed.tools.map((t) => t.name) : undefined,
+      system_chars: sysText.length,
+      mentions_ork_skills: /ork:[a-z-]+/.test(sysText),
+      messages: parsed && Array.isArray(parsed.messages) ? parsed.messages.length : undefined,
+    };
+    fs.appendFileSync(LOG, JSON.stringify(line) + '\n');
+    if (req.method === 'POST' && /\/v1\/messages(\?|$)/.test(req.url)) {
+      if (parsed && parsed.stream === false) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ id: 'msg_stub', type: 'message', role: 'assistant', model: parsed.model, content: [{ type: 'text', text: REPLY }], stop_reason: 'end_turn', stop_sequence: null, usage: { input_tokens: 1, output_tokens: 1 } }));
+        return;
+      }
+      return sse(res, (parsed && parsed.model) || 'stub');
+    }
+    res.writeHead(404, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ type: 'error', error: { type: 'not_found_error', message: `stub has no route for ${req.method} ${req.url}` } }));
+  });
+});
+server.listen(PORT, '127.0.0.1', () => {
+  const { port } = server.address();
+  fs.writeFileSync(process.env.STUB_PORT_FILE || '/tmp/stub-anthropic-api.port', String(port));
+  console.log(`stub-anthropic-api listening on http://127.0.0.1:${port} log=${LOG}`);
+});

--- a/tests/unit/test-no-llm-in-ci.sh
+++ b/tests/unit/test-no-llm-in-ci.sh
@@ -61,7 +61,13 @@ for wf in "$WF_DIR"/*.yml "$WF_DIR"/*.yaml; do
     scanned=$((scanned + 1))
     name=$(basename "$wf")
 
-    grep -qE "$LLM_SIGNATURE" "$wf" || continue
+    # Comment lines are prose, not invocations: a `# ... claude -p ...` note
+    # explaining a job consumes no quota. Strip them before matching so the
+    # gate keys on what the workflow RUNS. (First hit: plugin-validation.yml's
+    # restricted smoke lane, whose comment names the command its script runs
+    # against a loopback stub.) Positive control below proves the strip does
+    # not blind the gate to a real invocation.
+    grep -vE '^[[:space:]]*#' "$wf" | grep -qE "$LLM_SIGNATURE" || continue
     llm_workflows=$((llm_workflows + 1))
 
     # Parse the `on:` block with python so we read YAML semantics, not regex
@@ -97,6 +103,16 @@ PY
         echo "  ${GREEN}✓${NC} $name (LLM, manual only)"
     fi
 done
+
+# Positive control for the comment strip: an uncommented invocation must match.
+if ! printf '  # claude -p in a comment\n  run: claude -p "x"\n' | grep -vE '^[[:space:]]*#' | grep -qE "$LLM_SIGNATURE"; then
+    echo "${RED}FAIL:${NC} comment-strip positive control: an uncommented 'claude -p' no longer matches the signature"
+    exit 3
+fi
+if printf '  # claude -p only in a comment\n  run: echo ok\n' | grep -vE '^[[:space:]]*#' | grep -qE "$LLM_SIGNATURE"; then
+    echo "${RED}FAIL:${NC} comment-strip negative control: a comment-only mention still matches"
+    exit 3
+fi
 
 echo ""
 if [[ $llm_workflows -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Wave 1, decision 3 of the adopt-all plan: a `--restricted` smoke lane (#3774). CC 2.1.248's `--restricted` removes Bash, WebFetch and every code-running tool, ignores user and project settings, fences the file tools to the working directory and refuses `bypassPermissions`. The question for a plugin with 154 hook entries (32 events, `plugins/ork/hooks/hooks.json` on 2.1.251) was which of them break in that mode.

**Measured on 2.1.251: none.** This lane keeps that true on every PR.

## Measurement (local, 2.1.251, twelve other sessions live on the machine)

| Run | tools CC was offered | Bash / WebFetch | distinct plugin hooks fired | hooks with `ok:false` | model spend |
|---|---|---|---|---|---|
| `claude -p "reply ok" --restricted --plugin-dir plugins/ork` | 20 | absent | 34 (36 entries) | 0 | $0 (stub) |
| same without `--restricted` (control) | 38 | present | 40 (62 entries) | 0 | $0 (stub) |

Hooks that fired under `--restricted` (one-turn session, so no PreToolUse/PostToolUse; Stop and SessionEnd included because the runner waits 3 s for them to flush):

```
instructions-loaded/session-rules-audit lifecycle/analytics-liveness-check lifecycle/ask-fallback-injector
lifecycle/cc-version-check lifecycle/cleanup-envelope-corruption lifecycle/hook-token-check
lifecycle/nudge-outcome-resolver lifecycle/pattern-sync-pull lifecycle/plugins-drift-snapshot
lifecycle/rules-size-check lifecycle/session-env-setup lifecycle/session-handoff-injector
lifecycle/session-registrar lifecycle/stale-cache-cleanup lifecycle/stale-team-cleanup
lifecycle/sweep-stale-worktrees lifecycle/sync-session-dispatcher lifecycle/telemetry-dark-check
lifecycle/type-error-indexer lifecycle/webhook-forwarder notification/message-display-observer
prompt/goal-tracker prompt/thrash-detector prompt/unified-dispatcher prompt/worktree-advisory-consumer
skill/coverage-check skill/coverage-threshold-gate skill/cross-instance-test-validator
skill/evidence-collector stop/goal-tracker stop/handoff-writer stop/ledger-cleanup
stop/session-summary stop/task-completion-check
```

A first probe with real auth (settings hooks via `--settings`, plus `--debug`) gave the same picture: all four settings hooks fired under `--restricted`, `--debug` printed no hook lines in either mode, and the plugin hooks were pid-matched to the worktree in `hook-timing.jsonl` with 0 failures. The stub was built after that, so the CI lane never spends.

## How the lane works (`tests/ci/restricted-smoke/`)

- `stub-anthropic-api.mjs` (60 lines): every `POST /v1/messages` gets a canned "ok" as an SSE stream; every request is logged with its tool list; anything else 404s. Real model calls never run in CI, and no secret is needed (`ANTHROPIC_API_KEY=restricted-smoke-stub`, `ANTHROPIC_BASE_URL=127.0.0.1`).
- `run-restricted-smoke.sh`: fresh HOME per run (so `~/.claude/analytics/hook-timing.jsonl` can only have been written by this run), then a real `claude -p "reply ok" --restricted --plugin-dir plugins/ork --output-format json`.
- Four assertions: (1) `result: ok`, `is_error: false`; (2) the request CC sent has no `Bash` and no `WebFetch`; (3) `hook-timing.jsonl` has entries; (4) the sorted set of hooks with `ok:false` equals `expected-hook-failures.txt`.
- `expected-hook-failures.txt` is **empty** because the first enumeration found none. A hook that starts failing under `--restricted` turns the lane red; accepting one means adding it to the file with a reason, never silently.

Negative controls, both run locally: editing the expected list to name one hook fails assertion 4 (`[] != ["lifecycle/nonexistent-hook"]`); running the same script without `--restricted` fails assertion 2 with 38 tools including Bash and WebFetch. Every other assertion still passes in those runs, so each failure is attributable.

## Advisory or required

Day one is green locally, so the job is **not** `continue-on-error`. It is wired into `plugin-validation.yml` as `CC Restricted Smoke` and gated by that workflow's `Validation Summary` job, which is already a required check, so a red lane blocks merge without a branch-protection change. Adding `CC Restricted Smoke` itself to the required contexts is an operator step; not done here. If the first CI run is red for an environment reason (runner has no `claude` binary, port binding), the fix is in the lane, not a switch to advisory; the PR will say which.

Same install pattern as `CC Plugin Validate` (floor pin 2.1.251, `--ignore-scripts` then `install.cjs`); `tests/integration/test-cc-cli-install-pattern.sh` 7/7, `tests/ci/lint.sh` 6/6, `test-no-bare-mktemp.sh` pass, shellcheck clean. The runner is deliberately not a `test-*.sh` (it needs the `claude` binary), so it is invoked by the workflow directly rather than by the generic test rosters.

## Interactive Playground

**[Open Playground](https://htmlpreview.github.io/?https://github.com/yonatangross/orchestkit/blob/feat/3774-restricted-smoke-lane/docs/feat--3774-restricted-smoke-lane/index.html)** (Lab: `restricted-still-fires`)

Closes #3774
