### PR TITLE
ci(windows): red control for #3817, do not merge

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -14,10 +14,12 @@ on:
     branches: [main]
     paths:
       - 'src/hooks/**'
+      - 'tests/hooks/verdict-probes/**'
       - '.github/workflows/windows-smoke.yml'
   pull_request:
     paths:
       - 'src/hooks/**'
+      - 'tests/hooks/verdict-probes/**'
       - '.github/workflows/windows-smoke.yml'
   workflow_dispatch:
 
@@ -71,3 +73,15 @@ jobs:
           $result = $payload | node src/hooks/bin/run-hook.mjs pretool/bash/dangerous-command-blocker
           Write-Output "Hook result: $result"
           if ($LASTEXITCODE -ne 0) { throw "Hook invocation failed with exit $LASTEXITCODE" }
+
+      # #3817: the step above asserts only the exit code, and a dispatcher whose
+      # dist import fails on win32 exited 0 with the silent-success envelope for
+      # the entire life of that bug. This step drives the real runner with a
+      # payload that MUST be denied and asserts the verdict. PLUGIN_ROOT=src
+      # points the probe runner at src/hooks/bin/run-hook.mjs, whose dist is the
+      # one built above; the probe needs no fixture files or env of its own.
+      - name: Verdict probe through the dispatcher (asserts deny, not exit code)
+        shell: pwsh
+        env:
+          PLUGIN_ROOT: src
+        run: node tests/hooks/verdict-probes/run-probes.mjs tests/hooks/verdict-probes/probes.json --only bash-catastrophic-rm-deny

--- a/tests/hooks/verdict-probes/run-probes.mjs
+++ b/tests/hooks/verdict-probes/run-probes.mjs
@@ -83,6 +83,8 @@ function runCase(probe, variant) {
       hook_event_name: probe.event,
       ...(variant.payload || {}),
     }, real);
+    // HOME is unset on Windows; Node drops an undefined env value, and the runner's
+    // homedir() falls back to USERPROFILE, so telemetry still lands. Leave as-is.
     const env = { ...process.env, CLAUDE_PROJECT_DIR: real, CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT, HOME: process.env.HOME };
     for (const k of Object.keys(variant.env || probe.env || {})) env[k] = (variant.env || probe.env)[k];
     for (const k of variant.unsetEnv || probe.unsetEnv || []) delete env[k];
@@ -92,7 +94,13 @@ function runCase(probe, variant) {
     const line = String(r.stdout || '').trim().split('\n').filter((l) => l.startsWith('{')).pop();
     let result = null;
     try { result = line ? JSON.parse(line) : null; } catch { result = null; }
-    return { verdict: r.status === null ? 'timeout' : classify(result), status: r.status, ms, reason: (result && (result.stopReason || result.hookSpecificOutput?.permissionDecisionReason || '')) || '', stderr: String(r.stderr || '').slice(0, 300) };
+    // #3817: a bundle that exists but cannot be imported exits non-zero with
+    // nothing on stdout and a named stderr line; report it as its own verdict
+    // rather than the ambiguous `silent` a missing envelope would classify as.
+    const stderrText = String(r.stderr || '');
+    let verdict = r.status === null ? 'timeout' : classify(result);
+    if (result === null && r.status !== null && r.status !== 0 && /exists but failed to load|bundle-error/.test(stderrText)) verdict = 'bundle-error';
+    return { verdict, status: r.status, ms, reason: (result && (result.stopReason || result.hookSpecificOutput?.permissionDecisionReason || '')) || '', stderr: String(r.stderr || '').slice(0, 300) };
   } finally {
     if (process.env.PROBES_KEEP !== '1') fs.rmSync(dir, { recursive: true, force: true });
   }


### PR DESCRIPTION
Draft, never to merge. Carries only the new Windows verdict-probe step and the `run-probes.mjs` `bundle-error` mirror, WITHOUT the `pathToFileURL` runner fix, so the Windows runner shows the red (`trip=bundle-error`, expected `deny`) that the fix PR turns green. Closed once the run finishes and its URL is linked from the fix PR.

No playground: `ci/` branch, gate-exempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD8MnvP5vBRBCvhHbF4yQs