### PR TITLE
chore(ci): allow autoheal plugin.json mirrors on the release branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -304,7 +304,10 @@ jobs:
           git checkout --quiet -B "$BRANCH" "origin/${BRANCH}"
 
           # Only release-owned paths may differ from main before branch code runs.
-          ALLOWED='^(CHANGELOG\.md|\.release-please-manifest\.json|version\.txt|package\.json|package-lock\.json|\.claude-plugin/marketplace\.json|manifests/ork\.json|plugins/ork/\.claude-plugin/plugin\.json|plugins/ork/plugin\.json|plugin\.json|server\.json|pyproject\.toml|CLAUDE\.md|README\.md|docs/site/lib/generated/(plugins-data|changelog-data)\.ts|plugins/ork/hooks/bin/stop-uncommitted-check\.mjs|src/hooks/dist/.*|plugins/ork/hooks/dist/.*)$'
+          # The two plugin.json mirrors are what skill-autobuild regenerates on the
+          # release branch after the version bump (seen on #3879, 22227583a); they
+          # are data, not code, so they are allowed alongside release-please's own.
+          ALLOWED='^(CHANGELOG\.md|\.release-please-manifest\.json|version\.txt|package\.json|package-lock\.json|\.claude-plugin/marketplace\.json|manifests/ork\.json|plugins/ork/\.claude-plugin/plugin\.json|plugins/ork/plugin\.json|plugin\.json|server\.json|pyproject\.toml|CLAUDE\.md|README\.md|docs/site/lib/generated/(plugins-data|changelog-data)\.ts|plugins/ork/hooks/bin/stop-uncommitted-check\.mjs|plugins/ork-codex/\.codex-plugin/plugin\.json|plugins/ork/\.cursor-plugin/plugin\.json|src/hooks/dist/.*|plugins/ork/hooks/dist/.*)$'
           # silent: known-noise (grep -v returns 1 when every changed path is allowed; that is the pass case)
           OUTSIDE=$(git diff --name-only "origin/main...${BRANCH}" | grep -Ev "$ALLOWED" || true)
           if [ -n "$OUTSIDE" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #3875 (release-owned hook bundles), found on the step's first live run.

Run 33613788421 (release-please on f43cee670) executed the new "Rebuild hook bundles on the release PR" step end to end: the trust gate passed, `npm ci` and `npm run build` ran, and it ended with `Hook bundles already current on release-please--branches--main` (correct: no hook source changed since alpha.69). Two minutes later skill-autobuild pushed 22227583a onto the same release branch (#3879) touching two version mirrors that release-please does not list in its extra-files:

- `plugins/ork-codex/.codex-plugin/plugin.json`
- `plugins/ork/.cursor-plugin/plugin.json`

On the next push to main the trust gate would see those paths, refuse the rebuild with a warning, and the first hooks change of the cycle would turn the release PR red on the dist gate with no bot to heal it. This PR adds the two files to the allowlist; they are generated data, not code, so allowing them does not widen what can execute with the App token in scope.

## Verification

- `actionlint -shellcheck=` clean on the workflow.
- The regex change is the only diff (1 file, +4/-1).
- Live proof comes from the next release-please run after merge: its rebuild step should log the "already current" notice (or a rebuild) instead of the "differs from main outside release-owned paths" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRq6ymBZb7oMJDNUXFUPSd
