### PR TITLE
[bench T05] Explain CodeRabbit zero harvests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -13,6 +13,19 @@
 # Ported from Yonatan-HQ/platform's .coderabbit.yaml, with the defect classes
 # rewritten for this stack: TypeScript hooks, shell test harnesses, and
 # markdown skills/agents rather than a Python API.
+#
+# THIS FILE IS INERT UNTIL THE APP IS INSTALLED FOR THE OWNER ACCOUNT. Its
+# presence does not prove CodeRabbit reads it. Measured 2026-09-03: this config
+# had been on main since 2026-08-25 (#3746), but CodeRabbit had posted zero
+# comments in the repository's history and did not answer an explicit
+# @coderabbitai review request. The app is either absent for the yonatangross
+# account or disabled account-side. A session cannot distinguish those cases;
+# both produce no reviews, and the account installation endpoint is unavailable
+# to a normal user token. The leading hypothesis is the owner-level grant:
+# an installation for the Yonatan-HQ organization does not cover this
+# user-owned repository. Editing settings below cannot repair an unreachable
+# app. See src/skills/create-pr/references/coderabbit-zero-reviews.md for the
+# diagnostic ladder and the required settings-page check.
 
 language: "en-US"
 

--- a/docs/site/content/docs/reference/skills/create-pr.mdx
+++ b/docs/site/content/docs/reference/skills/create-pr.mdx
@@ -357,8 +357,19 @@ the PR is still a draft.
 H="${CLAUDE_PLUGIN_ROOT}/skills/create-pr/scripts/coderabbit-harvest.sh"
 PR_NUMBER=$(gh pr view --json number -q .number)
 bash "$H" "$PR_NUMBER" --unresolved > /tmp/cr-threads.json   # ONE GraphQL call, coderabbitai only
-jq length /tmp/cr-threads.json                                  # 0 → continue to merge
+jq length /tmp/cr-threads.json                                  # 0 → disambiguate before merging
 ```
+
+A zero is ambiguous: CodeRabbit may have read the diff and found nothing, or it may never
+have seen the PR. Both print `0`, so a repository the app cannot reach passes this phase
+forever. On this repository, a valid `.coderabbit.yaml` had been on `main` since 2026-08-25
+while CodeRabbit posted no comments and ignored an explicit `@coderabbitai review` request.
+The app is either not installed for the `yonatangross` owner account or disabled account-side.
+Do not turn that evidence into a claim that it is definitely uninstalled: only the settings
+page separates those cases. The first zero for a repository must be disambiguated with
+`Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/create-pr/references/coderabbit-zero-reviews.md")`.
+It covers both comment surfaces, a positive control, the explicit-trigger probe, and the
+operator action. Editing `.coderabbit.yaml` cannot fix an app that never reaches the repo.
 
 For each unresolved thread, spawn a refuter in ONE message: an isolated `Agent` (no
 `team_name`), `subagent_type="ork:code-quality-reviewer"` (`ork:security-auditor` for a
@@ -446,6 +457,7 @@ Load on demand with `Read("$\{CLAUDE_PLUGIN_ROOT\}/skills/create-pr/references/&
 | `references/multi-commit-pr.md` | Multi-commit PR guidance |
 | `assets/pr-template.md` | PR template (legacy) |
 | `scripts/coderabbit-harvest.sh` | CodeRabbit threads: read (one GraphQL call), `--reply`, `--resolve` |
+| `references/coderabbit-zero-reviews.md` | Harvest returned zero: reviewed clean, or never reviewed? |
 
 
 ---
@@ -789,7 +801,7 @@ gh pr ready
 
 ---
 
-## References (4)
+## References (5)
 
 ### CI Integration Patterns
 
@@ -845,6 +857,90 @@ gh pr checks
 ## Issue Auto-Close
 
 Using `Closes #N` in the PR body auto-closes the issue when the PR merges to the default branch. This is handled by GitHub, not CI — but only works when merging to `main`/`dev` (the repository's default branch).
+
+
+### Coderabbit Zero Reviews
+
+# CodeRabbit harvest returns zero: reviewed clean, or never reviewed?
+
+`coderabbit-harvest.sh --unresolved` printing `[]` has two indistinguishable causes:
+CodeRabbit read the diff and found nothing, or CodeRabbit never saw the PR. The harvest
+phase treats both as clean, which lets an unreachable app pass the quality gate forever.
+
+Measured on `yonatangross/orchestkit` on 2026-09-03: `.coderabbit.yaml` had been on `main`
+since 2026-08-25 (#3746), was valid, and enabled `auto_review`. CodeRabbit had posted no
+comments in the repository history, and an explicit `@coderabbitai review` request received
+no reply. The configuration is not the leading problem. The app is either not installed for
+the account that owns this repository or disabled account-side. A non-browser session cannot
+settle which one, so it must keep that uncertainty visible.
+
+## Disambiguate before trusting the zero
+
+Run this once per repository.
+
+```bash
+R=owner/repo
+
+# 1. Query both comment surfaces without since=. Summaries are issue comments;
+# findings are PR review comments. A single endpoint is structurally incomplete.
+gh api --paginate "/repos/$R/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]") | .issue_url' \
+  | sort -u | wc -l
+gh api --paginate "/repos/$R/pulls/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]") | .pull_request_url' \
+  | sort -u | wc -l
+
+# 2. Run the same query against a repository where CodeRabbit is known to work.
+# This is the positive control. The bot login is coderabbitai[bot], not bare
+# coderabbitai, and an incorrect login silently produces zero.
+
+# 3. Corroborate, but do not prove, with CodeRabbit's check-suite slug. Query
+# suites rather than check-runs: CodeRabbit can create a suite without runs.
+SHA=$(gh pr view <number> --repo "$R" --json headRefOid --jq .headRefOid)
+gh api "/repos/$R/commits/$SHA/check-suites?per_page=100" \
+  --jq '.check_suites[].app.slug' | sort -u
+
+# 4. Required before saying the app is not installed. Post this on an open PR:
+# @coderabbitai review
+# Any reply proves the app is installed and moves the fault to configuration or
+# the dashboard. Silence is evidence of either a missing installation or a
+# disabled account-side app, never proof of only the former.
+```
+
+Do not add `since=` to the history queries. It limits the evidence to a window and filters
+on update time, so a prior review can look like no review at all. If rate limits require a
+bounded query, its only conclusion is "none in that window."
+
+## Read the result
+
+| Signal | Meaning | Action |
+|---|---|---|
+| A reply to `@coderabbitai review` | CodeRabbit is installed. | Check `.coderabbit.yaml` and the dashboard. |
+| Existing, recent CodeRabbit comments but none on this PR | The PR is excluded. | Check filters, base branch, draft state, author, and title. |
+| Lifetime zero on both endpoints, working positive control, no reply | Not installed for this owner account, or disabled account-side. | Read the settings page. |
+| A zero with no explicit-trigger probe | Inconclusive. | Run the explicit trigger first. |
+| Missing check-suite slug | Corroboration only. | Do not diagnose from this alone. |
+
+No non-browser signal conclusively proves absence. `gh api /user/installations` normally
+returns 403 for a user token because that endpoint requires a GitHub App-authorized token.
+The direct check is the GitHub settings installation page and the CodeRabbit dashboard.
+State in the harvest record whether those pages were read; do not imply they were.
+
+## Likely owner-level cause
+
+GitHub App installations belong to an organization or a user account and carry their own
+repository grants. An installation for `Yonatan-HQ` does not grant access to a personal
+repository owned by `yonatangross`, even if the same person controls both. That is the
+leading explanation here, but an app disabled in the CodeRabbit dashboard produces the same
+observable zero. Both are resolved only in the settings pages.
+
+Operator action, not automatable from a session:
+
+1. Open https://github.com/settings/installations and locate CodeRabbit.
+2. If it is absent, install it for the personal account from https://github.com/apps/coderabbitai.
+3. If it is present, grant this repository or all repositories as appropriate.
+4. Confirm the repository is enabled in https://app.coderabbit.ai.
+5. Prove the fix with a PR that receives a `coderabbitai[bot]` review.
 
 
 ### Multi-Commit PR Guidance

--- a/docs/site/lib/generated/skills-data.ts
+++ b/docs/site/lib/generated/skills-data.ts
@@ -1247,7 +1247,7 @@ export const SKILLS: Record<string, SkillMeta> = {
     "name": "create-pr",
     "description": "Creates GitHub pull requests with pre-flight validation, conventional title formatting, and structured summary generation. Runs parallel checks (tests, lint, type-check, security) before opening. Supports feature, bugfix, refactor, and hotfix PR types with milestone assignment via gh CLI. Invoke only if the operator named it; an everyday `gh pr create` stays plain tooling. Use when opening PRs or submitting code for review.",
     "version": "2.6.0",
-    "sha256": "f5cb08fd2d2d897910196756418579dbc1f059d39b3968a7c61fa0f88a6f1ffd",
+    "sha256": "8047bccd7ae48c1103ac338f865e1e36e6f5852e161eccff95c569c362eec7eb",
     "author": "OrchestKit",
     "tags": [
       "git",
@@ -1281,6 +1281,7 @@ export const SKILLS: Record<string, SkillMeta> = {
     "structure": {
       "references": [
         "ci-integration.md",
+        "coderabbit-zero-reviews.md",
         "multi-commit-pr.md",
         "parallel-validation.md",
         "pr-body-templates.md"

--- a/plugins/ork/.cursor-plugin/commands/create-pr.md
+++ b/plugins/ork/.cursor-plugin/commands/create-pr.md
@@ -351,8 +351,19 @@ the PR is still a draft.
 H="${CLAUDE_PLUGIN_ROOT}/skills/create-pr/scripts/coderabbit-harvest.sh"
 PR_NUMBER=$(gh pr view --json number -q .number)
 bash "$H" "$PR_NUMBER" --unresolved > /tmp/cr-threads.json   # ONE GraphQL call, coderabbitai only
-jq length /tmp/cr-threads.json                                  # 0 → continue to merge
+jq length /tmp/cr-threads.json                                  # 0 → disambiguate before merging
 ```
+
+A zero is ambiguous: CodeRabbit may have read the diff and found nothing, or it may never
+have seen the PR. Both print `0`, so a repository the app cannot reach passes this phase
+forever. On this repository, a valid `.coderabbit.yaml` had been on `main` since 2026-08-25
+while CodeRabbit posted no comments and ignored an explicit `@coderabbitai review` request.
+The app is either not installed for the `yonatangross` owner account or disabled account-side.
+Do not turn that evidence into a claim that it is definitely uninstalled: only the settings
+page separates those cases. The first zero for a repository must be disambiguated with
+`Read("${CLAUDE_PLUGIN_ROOT}/skills/create-pr/references/coderabbit-zero-reviews.md")`.
+It covers both comment surfaces, a positive control, the explicit-trigger probe, and the
+operator action. Editing `.coderabbit.yaml` cannot fix an app that never reaches the repo.
 
 For each unresolved thread, spawn a refuter in ONE message: an isolated `Agent` (no
 `team_name`), `subagent_type="ork:code-quality-reviewer"` (`ork:security-auditor` for a
@@ -439,3 +450,4 @@ Load on demand with `Read("${CLAUDE_PLUGIN_ROOT}/skills/create-pr/references/<fi
 | `references/multi-commit-pr.md` | Multi-commit PR guidance |
 | `assets/pr-template.md` | PR template (legacy) |
 | `scripts/coderabbit-harvest.sh` | CodeRabbit threads: read (one GraphQL call), `--reply`, `--resolve` |
+| `references/coderabbit-zero-reviews.md` | Harvest returned zero: reviewed clean, or never reviewed? |

--- a/plugins/ork/skills/create-pr/SKILL.md
+++ b/plugins/ork/skills/create-pr/SKILL.md
@@ -371,8 +371,19 @@ the PR is still a draft.
 H="${CLAUDE_PLUGIN_ROOT}/skills/create-pr/scripts/coderabbit-harvest.sh"
 PR_NUMBER=$(gh pr view --json number -q .number)
 bash "$H" "$PR_NUMBER" --unresolved > /tmp/cr-threads.json   # ONE GraphQL call, coderabbitai only
-jq length /tmp/cr-threads.json                                  # 0 → continue to merge
+jq length /tmp/cr-threads.json                                  # 0 → disambiguate before merging
 ```
+
+A zero is ambiguous: CodeRabbit may have read the diff and found nothing, or it may never
+have seen the PR. Both print `0`, so a repository the app cannot reach passes this phase
+forever. On this repository, a valid `.coderabbit.yaml` had been on `main` since 2026-08-25
+while CodeRabbit posted no comments and ignored an explicit `@coderabbitai review` request.
+The app is either not installed for the `yonatangross` owner account or disabled account-side.
+Do not turn that evidence into a claim that it is definitely uninstalled: only the settings
+page separates those cases. The first zero for a repository must be disambiguated with
+`Read("${CLAUDE_PLUGIN_ROOT}/skills/create-pr/references/coderabbit-zero-reviews.md")`.
+It covers both comment surfaces, a positive control, the explicit-trigger probe, and the
+operator action. Editing `.coderabbit.yaml` cannot fix an app that never reaches the repo.
 
 For each unresolved thread, spawn a refuter in ONE message: an isolated `Agent` (no
 `team_name`), `subagent_type="ork:code-quality-reviewer"` (`ork:security-auditor` for a
@@ -460,3 +471,4 @@ Load on demand with `Read("${CLAUDE_PLUGIN_ROOT}/skills/create-pr/references/<fi
 | `references/multi-commit-pr.md` | Multi-commit PR guidance |
 | `assets/pr-template.md` | PR template (legacy) |
 | `scripts/coderabbit-harvest.sh` | CodeRabbit threads: read (one GraphQL call), `--reply`, `--resolve` |
+| `references/coderabbit-zero-reviews.md` | Harvest returned zero: reviewed clean, or never reviewed? |

--- a/plugins/ork/skills/create-pr/references/coderabbit-zero-reviews.md
+++ b/plugins/ork/skills/create-pr/references/coderabbit-zero-reviews.md
@@ -1,0 +1,80 @@
+# CodeRabbit harvest returns zero: reviewed clean, or never reviewed?
+
+`coderabbit-harvest.sh --unresolved` printing `[]` has two indistinguishable causes:
+CodeRabbit read the diff and found nothing, or CodeRabbit never saw the PR. The harvest
+phase treats both as clean, which lets an unreachable app pass the quality gate forever.
+
+Measured on `yonatangross/orchestkit` on 2026-09-03: `.coderabbit.yaml` had been on `main`
+since 2026-08-25 (#3746), was valid, and enabled `auto_review`. CodeRabbit had posted no
+comments in the repository history, and an explicit `@coderabbitai review` request received
+no reply. The configuration is not the leading problem. The app is either not installed for
+the account that owns this repository or disabled account-side. A non-browser session cannot
+settle which one, so it must keep that uncertainty visible.
+
+## Disambiguate before trusting the zero
+
+Run this once per repository.
+
+```bash
+R=owner/repo
+
+# 1. Query both comment surfaces without since=. Summaries are issue comments;
+# findings are PR review comments. A single endpoint is structurally incomplete.
+gh api --paginate "/repos/$R/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]") | .issue_url' \
+  | sort -u | wc -l
+gh api --paginate "/repos/$R/pulls/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]") | .pull_request_url' \
+  | sort -u | wc -l
+
+# 2. Run the same query against a repository where CodeRabbit is known to work.
+# This is the positive control. The bot login is coderabbitai[bot], not bare
+# coderabbitai, and an incorrect login silently produces zero.
+
+# 3. Corroborate, but do not prove, with CodeRabbit's check-suite slug. Query
+# suites rather than check-runs: CodeRabbit can create a suite without runs.
+SHA=$(gh pr view <number> --repo "$R" --json headRefOid --jq .headRefOid)
+gh api "/repos/$R/commits/$SHA/check-suites?per_page=100" \
+  --jq '.check_suites[].app.slug' | sort -u
+
+# 4. Required before saying the app is not installed. Post this on an open PR:
+# @coderabbitai review
+# Any reply proves the app is installed and moves the fault to configuration or
+# the dashboard. Silence is evidence of either a missing installation or a
+# disabled account-side app, never proof of only the former.
+```
+
+Do not add `since=` to the history queries. It limits the evidence to a window and filters
+on update time, so a prior review can look like no review at all. If rate limits require a
+bounded query, its only conclusion is "none in that window."
+
+## Read the result
+
+| Signal | Meaning | Action |
+|---|---|---|
+| A reply to `@coderabbitai review` | CodeRabbit is installed. | Check `.coderabbit.yaml` and the dashboard. |
+| Existing, recent CodeRabbit comments but none on this PR | The PR is excluded. | Check filters, base branch, draft state, author, and title. |
+| Lifetime zero on both endpoints, working positive control, no reply | Not installed for this owner account, or disabled account-side. | Read the settings page. |
+| A zero with no explicit-trigger probe | Inconclusive. | Run the explicit trigger first. |
+| Missing check-suite slug | Corroboration only. | Do not diagnose from this alone. |
+
+No non-browser signal conclusively proves absence. `gh api /user/installations` normally
+returns 403 for a user token because that endpoint requires a GitHub App-authorized token.
+The direct check is the GitHub settings installation page and the CodeRabbit dashboard.
+State in the harvest record whether those pages were read; do not imply they were.
+
+## Likely owner-level cause
+
+GitHub App installations belong to an organization or a user account and carry their own
+repository grants. An installation for `Yonatan-HQ` does not grant access to a personal
+repository owned by `yonatangross`, even if the same person controls both. That is the
+leading explanation here, but an app disabled in the CodeRabbit dashboard produces the same
+observable zero. Both are resolved only in the settings pages.
+
+Operator action, not automatable from a session:
+
+1. Open https://github.com/settings/installations and locate CodeRabbit.
+2. If it is absent, install it for the personal account from https://github.com/apps/coderabbitai.
+3. If it is present, grant this repository or all repositories as appropriate.
+4. Confirm the repository is enabled in https://app.coderabbit.ai.
+5. Prove the fix with a PR that receives a `coderabbitai[bot]` review.

--- a/src/skills/create-pr/SKILL.md
+++ b/src/skills/create-pr/SKILL.md
@@ -371,8 +371,19 @@ the PR is still a draft.
 H="${CLAUDE_PLUGIN_ROOT}/skills/create-pr/scripts/coderabbit-harvest.sh"
 PR_NUMBER=$(gh pr view --json number -q .number)
 bash "$H" "$PR_NUMBER" --unresolved > /tmp/cr-threads.json   # ONE GraphQL call, coderabbitai only
-jq length /tmp/cr-threads.json                                  # 0 → continue to merge
+jq length /tmp/cr-threads.json                                  # 0 → disambiguate before merging
 ```
+
+A zero is ambiguous: CodeRabbit may have read the diff and found nothing, or it may never
+have seen the PR. Both print `0`, so a repository the app cannot reach passes this phase
+forever. On this repository, a valid `.coderabbit.yaml` had been on `main` since 2026-08-25
+while CodeRabbit posted no comments and ignored an explicit `@coderabbitai review` request.
+The app is either not installed for the `yonatangross` owner account or disabled account-side.
+Do not turn that evidence into a claim that it is definitely uninstalled: only the settings
+page separates those cases. The first zero for a repository must be disambiguated with
+`Read("${CLAUDE_PLUGIN_ROOT}/skills/create-pr/references/coderabbit-zero-reviews.md")`.
+It covers both comment surfaces, a positive control, the explicit-trigger probe, and the
+operator action. Editing `.coderabbit.yaml` cannot fix an app that never reaches the repo.
 
 For each unresolved thread, spawn a refuter in ONE message: an isolated `Agent` (no
 `team_name`), `subagent_type="ork:code-quality-reviewer"` (`ork:security-auditor` for a
@@ -460,3 +471,4 @@ Load on demand with `Read("${CLAUDE_PLUGIN_ROOT}/skills/create-pr/references/<fi
 | `references/multi-commit-pr.md` | Multi-commit PR guidance |
 | `assets/pr-template.md` | PR template (legacy) |
 | `scripts/coderabbit-harvest.sh` | CodeRabbit threads: read (one GraphQL call), `--reply`, `--resolve` |
+| `references/coderabbit-zero-reviews.md` | Harvest returned zero: reviewed clean, or never reviewed? |

--- a/src/skills/create-pr/references/coderabbit-zero-reviews.md
+++ b/src/skills/create-pr/references/coderabbit-zero-reviews.md
@@ -1,0 +1,80 @@
+# CodeRabbit harvest returns zero: reviewed clean, or never reviewed?
+
+`coderabbit-harvest.sh --unresolved` printing `[]` has two indistinguishable causes:
+CodeRabbit read the diff and found nothing, or CodeRabbit never saw the PR. The harvest
+phase treats both as clean, which lets an unreachable app pass the quality gate forever.
+
+Measured on `yonatangross/orchestkit` on 2026-09-03: `.coderabbit.yaml` had been on `main`
+since 2026-08-25 (#3746), was valid, and enabled `auto_review`. CodeRabbit had posted no
+comments in the repository history, and an explicit `@coderabbitai review` request received
+no reply. The configuration is not the leading problem. The app is either not installed for
+the account that owns this repository or disabled account-side. A non-browser session cannot
+settle which one, so it must keep that uncertainty visible.
+
+## Disambiguate before trusting the zero
+
+Run this once per repository.
+
+```bash
+R=owner/repo
+
+# 1. Query both comment surfaces without since=. Summaries are issue comments;
+# findings are PR review comments. A single endpoint is structurally incomplete.
+gh api --paginate "/repos/$R/issues/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]") | .issue_url' \
+  | sort -u | wc -l
+gh api --paginate "/repos/$R/pulls/comments?per_page=100" \
+  --jq '.[] | select(.user.login == "coderabbitai[bot]") | .pull_request_url' \
+  | sort -u | wc -l
+
+# 2. Run the same query against a repository where CodeRabbit is known to work.
+# This is the positive control. The bot login is coderabbitai[bot], not bare
+# coderabbitai, and an incorrect login silently produces zero.
+
+# 3. Corroborate, but do not prove, with CodeRabbit's check-suite slug. Query
+# suites rather than check-runs: CodeRabbit can create a suite without runs.
+SHA=$(gh pr view <number> --repo "$R" --json headRefOid --jq .headRefOid)
+gh api "/repos/$R/commits/$SHA/check-suites?per_page=100" \
+  --jq '.check_suites[].app.slug' | sort -u
+
+# 4. Required before saying the app is not installed. Post this on an open PR:
+# @coderabbitai review
+# Any reply proves the app is installed and moves the fault to configuration or
+# the dashboard. Silence is evidence of either a missing installation or a
+# disabled account-side app, never proof of only the former.
+```
+
+Do not add `since=` to the history queries. It limits the evidence to a window and filters
+on update time, so a prior review can look like no review at all. If rate limits require a
+bounded query, its only conclusion is "none in that window."
+
+## Read the result
+
+| Signal | Meaning | Action |
+|---|---|---|
+| A reply to `@coderabbitai review` | CodeRabbit is installed. | Check `.coderabbit.yaml` and the dashboard. |
+| Existing, recent CodeRabbit comments but none on this PR | The PR is excluded. | Check filters, base branch, draft state, author, and title. |
+| Lifetime zero on both endpoints, working positive control, no reply | Not installed for this owner account, or disabled account-side. | Read the settings page. |
+| A zero with no explicit-trigger probe | Inconclusive. | Run the explicit trigger first. |
+| Missing check-suite slug | Corroboration only. | Do not diagnose from this alone. |
+
+No non-browser signal conclusively proves absence. `gh api /user/installations` normally
+returns 403 for a user token because that endpoint requires a GitHub App-authorized token.
+The direct check is the GitHub settings installation page and the CodeRabbit dashboard.
+State in the harvest record whether those pages were read; do not imply they were.
+
+## Likely owner-level cause
+
+GitHub App installations belong to an organization or a user account and carry their own
+repository grants. An installation for `Yonatan-HQ` does not grant access to a personal
+repository owned by `yonatangross`, even if the same person controls both. That is the
+leading explanation here, but an app disabled in the CodeRabbit dashboard produces the same
+observable zero. Both are resolved only in the settings pages.
+
+Operator action, not automatable from a session:
+
+1. Open https://github.com/settings/installations and locate CodeRabbit.
+2. If it is absent, install it for the personal account from https://github.com/apps/coderabbitai.
+3. If it is present, grant this repository or all repositories as appropriate.
+4. Confirm the repository is enabled in https://app.coderabbit.ai.
+5. Prove the fix with a PR that receives a `coderabbitai[bot]` review.


### PR DESCRIPTION
## Summary

- explain why an empty CodeRabbit harvest does not prove a clean review
- record the owner-level installation or dashboard-disabled diagnosis
- add the required diagnostic and operator reference

## Verification

- `pnpm run build`
- CI pending

refs #3912