### PR TITLE
fix(announce): preflight release API credential

### DIFF
--- a/.github/scripts/npm-audit-with-retry.sh
+++ b/.github/scripts/npm-audit-with-retry.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Run npm audit with a bounded retry for a stalled registry request.
+#
+# npm audit exits nonzero both for advisory findings and for operational errors,
+# so retrying every nonzero result could hide a real critical vulnerability.
+# GNU timeout gives a distinct status for the failure seen in CI: a registry
+# request that never completes. Retry only that status and preserve all other
+# npm exit statuses unchanged.
+#
+# Usage: npm-audit-with-retry.sh [directory]
+#
+# Environment:
+#   NPM_AUDIT_TIMEOUT_SECONDS  Seconds per audit attempt (default: 60).
+#   NPM_AUDIT_MAX_ATTEMPTS     Attempts for a timeout only (default: 2).
+#   NPM_AUDIT_RETRY_DELAY_SECONDS  Delay before retrying (default: 5).
+
+set -euo pipefail
+
+AUDIT_DIRECTORY="${1:-.}"
+TIMEOUT_SECONDS="${NPM_AUDIT_TIMEOUT_SECONDS:-60}"
+MAX_ATTEMPTS="${NPM_AUDIT_MAX_ATTEMPTS:-2}"
+RETRY_DELAY_SECONDS="${NPM_AUDIT_RETRY_DELAY_SECONDS:-5}"
+
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+if ! is_positive_integer "$TIMEOUT_SECONDS" || ! is_positive_integer "$MAX_ATTEMPTS"; then
+  echo "npm-audit-with-retry: timeout and max attempts must be positive integers" >&2
+  exit 2
+fi
+
+if ! [[ "$RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "npm-audit-with-retry: retry delay must be a non-negative integer" >&2
+  exit 2
+fi
+
+if [[ ! -d "$AUDIT_DIRECTORY" ]]; then
+  echo "npm-audit-with-retry: directory not found: $AUDIT_DIRECTORY" >&2
+  exit 2
+fi
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  echo "npm-audit-with-retry: attempt ${attempt}/${MAX_ATTEMPTS} in ${AUDIT_DIRECTORY}"
+
+  status=0
+  (
+    cd "$AUDIT_DIRECTORY"
+    timeout --signal=TERM --kill-after=10s "${TIMEOUT_SECONDS}s" \
+      npm audit --audit-level=critical
+  ) || status=$?
+
+  if [[ "$status" -eq 0 ]]; then
+    exit 0
+  fi
+
+  # 124 is GNU timeout's normal expiration status. 137 is possible when the
+  # audit ignores TERM and timeout has to send KILL after the grace period.
+  if [[ "$status" -ne 124 && "$status" -ne 137 ]]; then
+    echo "npm-audit-with-retry: npm audit exited ${status}; not retrying" >&2
+    exit "$status"
+  fi
+
+  if [[ "$attempt" -eq "$MAX_ATTEMPTS" ]]; then
+    echo "npm-audit-with-retry: npm audit timed out after ${MAX_ATTEMPTS} attempt(s)" >&2
+    exit "$status"
+  fi
+
+  echo "npm-audit-with-retry: registry request timed out after ${TIMEOUT_SECONDS}s; retrying once" >&2
+  sleep "$RETRY_DELAY_SECONDS"
+done

--- a/.github/scripts/npm-audit-with-retry.sh
+++ b/.github/scripts/npm-audit-with-retry.sh
@@ -7,7 +7,7 @@
 # request that never completes. Retry only that status and preserve all other
 # npm exit statuses unchanged.
 #
-# Usage: npm-audit-with-retry.sh [directory]
+# Usage: npm-audit-with-retry.sh [directory] [npm-audit arguments...]
 #
 # Environment:
 #   NPM_AUDIT_TIMEOUT_SECONDS  Seconds per audit attempt (default: 60).
@@ -18,6 +18,13 @@
 set -euo pipefail
 
 AUDIT_DIRECTORY="${1:-.}"
+if [[ "$#" -gt 0 ]]; then
+  shift
+fi
+AUDIT_ARGUMENTS=("$@")
+if [[ "${#AUDIT_ARGUMENTS[@]}" -eq 0 ]]; then
+  AUDIT_ARGUMENTS=(--audit-level=critical)
+fi
 TIMEOUT_SECONDS="${NPM_AUDIT_TIMEOUT_SECONDS:-60}"
 MAX_ATTEMPTS="${NPM_AUDIT_MAX_ATTEMPTS:-3}"
 MAX_RETRY_DELAY_SECONDS=15
@@ -43,13 +50,13 @@ if [[ ! -d "$AUDIT_DIRECTORY" ]]; then
 fi
 
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
-  echo "npm-audit-with-retry: attempt ${attempt}/${MAX_ATTEMPTS} in ${AUDIT_DIRECTORY}"
+  echo "npm-audit-with-retry: attempt ${attempt}/${MAX_ATTEMPTS} in ${AUDIT_DIRECTORY}" >&2
 
   status=0
   (
     cd "$AUDIT_DIRECTORY"
     timeout --signal=TERM --kill-after=10s "${TIMEOUT_SECONDS}s" \
-      npm audit --audit-level=critical
+      npm audit "${AUDIT_ARGUMENTS[@]}"
   ) || status=$?
 
   if [[ "$status" -eq 0 ]]; then

--- a/.github/scripts/npm-audit-with-retry.sh
+++ b/.github/scripts/npm-audit-with-retry.sh
@@ -11,14 +11,16 @@
 #
 # Environment:
 #   NPM_AUDIT_TIMEOUT_SECONDS  Seconds per audit attempt (default: 60).
-#   NPM_AUDIT_MAX_ATTEMPTS     Attempts for a timeout only (default: 2).
-#   NPM_AUDIT_RETRY_DELAY_SECONDS  Delay before retrying (default: 5).
+#   NPM_AUDIT_MAX_ATTEMPTS     Attempts for a timeout only (default: 3).
+#   NPM_AUDIT_RETRY_DELAY_SECONDS  Initial retry delay in seconds (default: 5).
+#     Each delay increases by this value and never exceeds 15 seconds.
 
 set -euo pipefail
 
 AUDIT_DIRECTORY="${1:-.}"
 TIMEOUT_SECONDS="${NPM_AUDIT_TIMEOUT_SECONDS:-60}"
-MAX_ATTEMPTS="${NPM_AUDIT_MAX_ATTEMPTS:-2}"
+MAX_ATTEMPTS="${NPM_AUDIT_MAX_ATTEMPTS:-3}"
+MAX_RETRY_DELAY_SECONDS=15
 RETRY_DELAY_SECONDS="${NPM_AUDIT_RETRY_DELAY_SECONDS:-5}"
 
 is_positive_integer() {
@@ -66,6 +68,11 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
     exit "$status"
   fi
 
-  echo "npm-audit-with-retry: registry request timed out after ${TIMEOUT_SECONDS}s; retrying once" >&2
-  sleep "$RETRY_DELAY_SECONDS"
+  retry_delay=$((RETRY_DELAY_SECONDS * attempt))
+  if [[ "$retry_delay" -gt "$MAX_RETRY_DELAY_SECONDS" ]]; then
+    retry_delay="$MAX_RETRY_DELAY_SECONDS"
+  fi
+
+  echo "npm-audit-with-retry: registry request timed out after ${TIMEOUT_SECONDS}s; retrying in ${retry_delay}s" >&2
+  sleep "$retry_delay"
 done

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,37 @@
+# Release announce rail
+
+`release-announce.yml` sends published release facts to the Yonatan-HQ marketing
+intake. The platform creates drafts only. It never publishes a social post.
+
+For a live announce, the workflow first runs an authenticated platform dry-run.
+This validates `HQ_API_TOKEN` before the live POST and does not create drafts.
+Manual dispatches with `dry_run: true` remain fully local and skip the preflight.
+
+## Rotate `HQ_API_TOKEN`
+
+If the preflight reports an authentication failure, rotate
+`op://Platform/API-Static-Token/credential`. Read the replacement once through
+the estate chokepoint with a bounded cache, then update the repository secret:
+
+```bash
+HQ_API_TOKEN="$(~/.claude/hooks/op-read.sh --cache 3600 \
+  op://Platform/API-Static-Token/credential)"
+op_read_status=$?
+if [[ "$op_read_status" -ne 0 ]]; then
+  echo "Failed to read the replacement token through op-read.sh" >&2
+  exit "$op_read_status"
+fi
+if [[ -z "$HQ_API_TOKEN" ]]; then
+  echo "op-read.sh returned an empty replacement token" >&2
+  exit 1
+fi
+printf '%s' "$HQ_API_TOKEN" | \
+  gh secret set HQ_API_TOKEN --repo yonatangross/orchestkit
+unset HQ_API_TOKEN
+```
+
+Do not put a token in this repository or add a raw `op read` command to the
+workflow. The GitHub secret is the rail's credential boundary. After updating
+it, manually dispatch `Release Announce` with the target version and
+`dry_run: false`; a successful run queues drafts for the normal human approval
+flow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,11 +201,10 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Audit root dependencies
-        run: npm audit --audit-level=critical
+        run: bash .github/scripts/npm-audit-with-retry.sh .
 
       - name: Audit hooks dependencies
-        working-directory: src/hooks
-        run: npm audit --audit-level=critical
+        run: bash .github/scripts/npm-audit-with-retry.sh src/hooks
 
   # ============================================================================
   # STAGE 1c: Secret Scanning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
     permissions:
       contents: read
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -141,6 +141,24 @@ jobs:
           echo "### 📣 Release announce skipped" >> "$GITHUB_STEP_SUMMARY"
           echo "Patch release \`${{ steps.meta.outputs.version }}\` — announcements fire on minor/major (X.Y.0) only." >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Credential preflight (platform dry-run)
+        # Fail before the live POST when a provisioned secret was revoked or
+        # retired. The preflight sends the same release facts with dry_run=true,
+        # which the platform authenticates and composes without creating drafts.
+        if: steps.meta.outputs.skip == 'false' && github.event.inputs.dry_run != 'true'
+        id: credential_preflight
+        env:
+          RELEASE_VERSION: ${{ steps.meta.outputs.version }}
+          RELEASE_URL: ${{ github.event.release.html_url || format('https://github.com/{0}/releases/tag/v{1}', github.repository, steps.meta.outputs.version) }}
+          RELEASE_NOTES: ${{ github.event.release.body }}
+          REPO: ${{ github.repository }}
+          ANNOUNCE_CHANNELS: twitter,devto,hashnode,substack,threads
+          ANNOUNCE_ACCOUNT: yonyon2ai
+          HQ_API_URL: ${{ secrets.HQ_API_URL }}
+          HQ_API_TOKEN: ${{ secrets.HQ_API_TOKEN }}
+          PREFLIGHT: "true"
+        run: node scripts/announce-release.mjs
+
       - name: Announce (draft via platform marketing)
         if: steps.meta.outputs.skip == 'false'
         id: announce

--- a/docs/fix--announce-rail-token-3650/index.html
+++ b/docs/fix--announce-rail-token-3650/index.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Release announce credential preflight</title>
+<style>
+  :root { --bg:#0b1020; --panel:#121a2e; --line:#293653; --text:#e8edf8; --muted:#9ca9c3; --accent:#7c9cff; --ok:#48c78e; --bad:#ff6b7a; --warn:#ffc45e; --mono:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:radial-gradient(circle at top right,#202b50 0,transparent 38%),var(--bg); color:var(--text); font:15px/1.55 system-ui,sans-serif; }
+  main { max-width:940px; margin:0 auto; padding:38px 20px 72px; }
+  h1 { margin:0; font-size:clamp(25px,4vw,38px); letter-spacing:-.03em; }
+  h2 { font-size:17px; margin:0 0 8px; }
+  p { color:var(--muted); margin:8px 0; }
+  code,pre { font-family:var(--mono); }
+  code { color:#d5ddff; font-size:.9em; }
+  .eyebrow { color:var(--accent); font:12px var(--mono); letter-spacing:.08em; text-transform:uppercase; }
+  .card { background:color-mix(in srgb,var(--panel) 94%,transparent); border:1px solid var(--line); border-radius:16px; padding:20px; margin-top:18px; }
+  .chooser { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-top:16px; }
+  button { appearance:none; border:1px solid var(--line); border-radius:10px; background:#17223c; color:var(--text); cursor:pointer; padding:10px 12px; font:13px var(--mono); }
+  button:hover,button:focus-visible { border-color:var(--accent); outline:none; }
+  button[aria-pressed="true"] { background:#26365f; border-color:var(--accent); }
+  .flow { display:grid; grid-template-columns:repeat(4,1fr); gap:10px; margin-top:18px; }
+  .step { min-height:120px; border:1px solid var(--line); border-radius:12px; background:#0e1628; padding:13px; }
+  .num { color:var(--muted); font:12px var(--mono); }
+  .name { font-weight:700; margin-top:8px; }
+  .state { margin-top:9px; font:12px var(--mono); color:var(--muted); }
+  .step.ok { border-color:color-mix(in srgb,var(--ok) 58%,var(--line)); } .step.ok .state { color:var(--ok); }
+  .step.bad { border-color:color-mix(in srgb,var(--bad) 62%,var(--line)); } .step.bad .state { color:var(--bad); }
+  .step.warn { border-color:color-mix(in srgb,var(--warn) 62%,var(--line)); } .step.warn .state { color:var(--warn); }
+  .step.dim { opacity:.42; }
+  .result { border-left:3px solid var(--accent); background:#101a31; border-radius:8px; padding:14px 16px; margin-top:16px; }
+  .result strong { display:block; font-family:var(--mono); }
+  pre { margin:14px 0 0; padding:14px; overflow:auto; background:#09101e; border:1px solid var(--line); border-radius:10px; color:#c4cfe9; font-size:12px; }
+  .facts { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+  .facts li { color:var(--muted); margin:8px 0; }
+  .facts ul { margin:8px 0 0; padding-left:20px; }
+  .note { font-size:13px; }
+  @media (max-width:700px) { .chooser,.flow,.facts { grid-template-columns:1fr 1fr; } }
+  @media (max-width:420px) { .chooser,.flow,.facts { grid-template-columns:1fr; } }
+  @media (prefers-reduced-motion:reduce) { * { transition:none !important; } }
+</style>
+</head>
+<body>
+<main>
+  <div class="eyebrow">Issue #3650 · release announce rail</div>
+  <h1>Fail before the live release post</h1>
+  <p>The release announce rail now sends an authenticated platform dry-run before a live POST. It catches a missing, retired, or unreachable credential without creating drafts or publishing content.</p>
+
+  <section class="card" aria-labelledby="scenario-title">
+    <h2 id="scenario-title">Try a credential state</h2>
+    <p>Select a simulated result. This page has no token and makes no network request.</p>
+    <div class="chooser" role="group" aria-label="Credential state">
+      <button data-mode="valid" aria-pressed="true">valid token</button>
+      <button data-mode="missing" aria-pressed="false">missing secret</button>
+      <button data-mode="retired" aria-pressed="false">retired token</button>
+      <button data-mode="timeout" aria-pressed="false">slow platform</button>
+    </div>
+    <div class="flow" id="flow" aria-live="polite"></div>
+    <div class="result" id="result"></div>
+  </section>
+
+  <div class="facts">
+    <section class="card">
+      <h2>What the preflight does</h2>
+      <ul>
+        <li>Uses the same release facts and bearer credential as the live request.</li>
+        <li>Sets <code>dry_run: true</code>, so the platform composes but does not create drafts.</li>
+        <li>Uses a 10 second abort signal for both preflight and live POSTs.</li>
+      </ul>
+    </section>
+    <section class="card">
+      <h2>What it does not do</h2>
+      <ul>
+        <li>It does not rotate a credential.</li>
+        <li>It does not reveal a token in the workflow or this page.</li>
+        <li>It does not bypass the platform's human approval flow.</li>
+      </ul>
+    </section>
+  </div>
+
+  <section class="card">
+    <h2>Operator recovery path</h2>
+    <p>For a rejected token, rotate the canonical 1Password item through the estate chokepoint, validate the result, then update only the GitHub repository secret.</p>
+    <pre>HQ_API_TOKEN="$(~/.claude/hooks/op-read.sh --cache 3600 \
+  op://Platform/API-Static-Token/credential)"
+op_read_status=$?
+if [[ "$op_read_status" -ne 0 || -z "$HQ_API_TOKEN" ]]; then exit 1; fi
+printf '%s' "$HQ_API_TOKEN" | gh secret set HQ_API_TOKEN --repo yonatangross/orchestkit
+unset HQ_API_TOKEN</pre>
+    <p class="note">The real rail reports the exact reference when the secret is missing or the platform returns 401. A manual dispatch with <code>dry_run: true</code> remains local and skips the preflight.</p>
+  </section>
+</main>
+<script>
+  const modes = {
+    valid: {
+      steps: [["ok","credential preflight","200 dry-run"],["ok","platform compose","no drafts created"],["ok","live announce","may POST"],["ok","human review","drafts await approval"]],
+      title:"Preflight passed. The live announce may continue.",
+      body:"The platform authenticated a non-persisting dry-run. A later live POST still has the same 10 second bound."
+    },
+    missing: {
+      steps: [["bad","credential preflight","missing secret"],["dim","platform compose","not called"],["dim","live announce","blocked"],["dim","human review","no drafts"]],
+      title:"Stopped before any platform request.",
+      body:"The workflow names HQ_API_TOKEN and op://Platform/API-Static-Token/credential so the rotation target is actionable."
+    },
+    retired: {
+      steps: [["bad","credential preflight","401 rejected"],["bad","platform compose","authentication failed"],["dim","live announce","blocked"],["dim","human review","no drafts"]],
+      title:"Stopped on the dry-run 401, before the live POST.",
+      body:"Rotate the referenced API_STATIC_TOKEN and update the repository secret. The preflight never persists drafts."
+    },
+    timeout: {
+      steps: [["warn","credential preflight","aborted at 10s"],["dim","platform compose","incomplete"],["dim","live announce","blocked"],["dim","human review","no drafts"]],
+      title:"Stopped on a bounded preflight failure.",
+      body:"The workflow reports a credential-preflight failure rather than holding the release job indefinitely."
+    }
+  };
+  const flow = document.getElementById("flow");
+  const result = document.getElementById("result");
+  function render(mode) {
+    const data = modes[mode];
+    flow.textContent = "";
+    data.steps.forEach((step, index) => {
+      const item = document.createElement("div");
+      item.className = "step " + step[0];
+      const number = document.createElement("div");
+      number.className = "num";
+      number.textContent = `0${index + 1}`;
+      const name = document.createElement("div");
+      name.className = "name";
+      name.textContent = step[1];
+      const state = document.createElement("div");
+      state.className = "state";
+      state.textContent = step[2];
+      item.append(number, name, state);
+      flow.append(item);
+    });
+    result.textContent = "";
+    const title = document.createElement("strong");
+    title.textContent = data.title;
+    result.append(title, document.createTextNode(data.body));
+  }
+  document.querySelectorAll("[data-mode]").forEach(button => button.addEventListener("click", () => {
+    document.querySelectorAll("[data-mode]").forEach(item => item.setAttribute("aria-pressed", String(item === button)));
+    render(button.dataset.mode);
+  }));
+  render("valid");
+</script>
+</body>
+</html>

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "announce-credential-preflight",
+      "source": "docs/fix--announce-rail-token-3650/index.html",
+      "title": "A red check before the live release announce",
+      "description": "The release announce rail now authenticates a non-persisting dry-run before its live POST. Pick valid, missing, retired, or slow credentials to see where the rail stops, what is safe, and the operator recovery path.",
+      "tags": [
+        "release",
+        "security",
+        "ci"
+      ],
+      "date": "2026-09-04"
+    },
+    {
       "slug": "coderabbit-never-installed",
       "source": "docs/fix--coderabbit-live/index.html",
       "title": "A valid config is not a running reviewer: CodeRabbit was never installed on orchestkit",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -15,6 +15,20 @@ export interface LabEntry {
 
 export const LAB_ENTRIES: LabEntry[] = [
   {
+    "slug": "announce-credential-preflight",
+    "title": "A red check before the live release announce",
+    "description": "The release announce rail now authenticates a non-persisting dry-run before its live POST. Pick valid, missing, retired, or slow credentials to see where the rail stops, what is safe, and the operator recovery path.",
+    "tags": [
+      "release",
+      "security",
+      "ci"
+    ],
+    "date": "2026-09-04",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 8
+  },
+  {
     "slug": "feat--coderabbit-harvest-stage",
     "title": "Reviews that expire unread: the CodeRabbit harvest stage in create-pr",
     "description": "Measured on 80 platform PRs: CodeRabbit posted 65 threads on 24 PRs and 23 of those PRs merged with every thread still open. The new create-pr phase reads each thread once, refutes it against the diff, fixes or dismisses, and resolves every one before merge. Walk a sample PR through the contract and watch the unresolved count reach zero.",

--- a/docs/site/public/lab/announce-credential-preflight.html
+++ b/docs/site/public/lab/announce-credential-preflight.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Release announce credential preflight</title>
+<style>
+  :root { --bg:#0b1020; --panel:#121a2e; --line:#293653; --text:#e8edf8; --muted:#9ca9c3; --accent:#7c9cff; --ok:#48c78e; --bad:#ff6b7a; --warn:#ffc45e; --mono:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  * { box-sizing:border-box; }
+  body { margin:0; background:radial-gradient(circle at top right,#202b50 0,transparent 38%),var(--bg); color:var(--text); font:15px/1.55 system-ui,sans-serif; }
+  main { max-width:940px; margin:0 auto; padding:38px 20px 72px; }
+  h1 { margin:0; font-size:clamp(25px,4vw,38px); letter-spacing:-.03em; }
+  h2 { font-size:17px; margin:0 0 8px; }
+  p { color:var(--muted); margin:8px 0; }
+  code,pre { font-family:var(--mono); }
+  code { color:#d5ddff; font-size:.9em; }
+  .eyebrow { color:var(--accent); font:12px var(--mono); letter-spacing:.08em; text-transform:uppercase; }
+  .card { background:color-mix(in srgb,var(--panel) 94%,transparent); border:1px solid var(--line); border-radius:16px; padding:20px; margin-top:18px; }
+  .chooser { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-top:16px; }
+  button { appearance:none; border:1px solid var(--line); border-radius:10px; background:#17223c; color:var(--text); cursor:pointer; padding:10px 12px; font:13px var(--mono); }
+  button:hover,button:focus-visible { border-color:var(--accent); outline:none; }
+  button[aria-pressed="true"] { background:#26365f; border-color:var(--accent); }
+  .flow { display:grid; grid-template-columns:repeat(4,1fr); gap:10px; margin-top:18px; }
+  .step { min-height:120px; border:1px solid var(--line); border-radius:12px; background:#0e1628; padding:13px; }
+  .num { color:var(--muted); font:12px var(--mono); }
+  .name { font-weight:700; margin-top:8px; }
+  .state { margin-top:9px; font:12px var(--mono); color:var(--muted); }
+  .step.ok { border-color:color-mix(in srgb,var(--ok) 58%,var(--line)); } .step.ok .state { color:var(--ok); }
+  .step.bad { border-color:color-mix(in srgb,var(--bad) 62%,var(--line)); } .step.bad .state { color:var(--bad); }
+  .step.warn { border-color:color-mix(in srgb,var(--warn) 62%,var(--line)); } .step.warn .state { color:var(--warn); }
+  .step.dim { opacity:.42; }
+  .result { border-left:3px solid var(--accent); background:#101a31; border-radius:8px; padding:14px 16px; margin-top:16px; }
+  .result strong { display:block; font-family:var(--mono); }
+  pre { margin:14px 0 0; padding:14px; overflow:auto; background:#09101e; border:1px solid var(--line); border-radius:10px; color:#c4cfe9; font-size:12px; }
+  .facts { display:grid; grid-template-columns:1fr 1fr; gap:14px; }
+  .facts li { color:var(--muted); margin:8px 0; }
+  .facts ul { margin:8px 0 0; padding-left:20px; }
+  .note { font-size:13px; }
+  @media (max-width:700px) { .chooser,.flow,.facts { grid-template-columns:1fr 1fr; } }
+  @media (max-width:420px) { .chooser,.flow,.facts { grid-template-columns:1fr; } }
+  @media (prefers-reduced-motion:reduce) { * { transition:none !important; } }
+</style>
+</head>
+<body>
+<main>
+  <div class="eyebrow">Issue #3650 · release announce rail</div>
+  <h1>Fail before the live release post</h1>
+  <p>The release announce rail now sends an authenticated platform dry-run before a live POST. It catches a missing, retired, or unreachable credential without creating drafts or publishing content.</p>
+
+  <section class="card" aria-labelledby="scenario-title">
+    <h2 id="scenario-title">Try a credential state</h2>
+    <p>Select a simulated result. This page has no token and makes no network request.</p>
+    <div class="chooser" role="group" aria-label="Credential state">
+      <button data-mode="valid" aria-pressed="true">valid token</button>
+      <button data-mode="missing" aria-pressed="false">missing secret</button>
+      <button data-mode="retired" aria-pressed="false">retired token</button>
+      <button data-mode="timeout" aria-pressed="false">slow platform</button>
+    </div>
+    <div class="flow" id="flow" aria-live="polite"></div>
+    <div class="result" id="result"></div>
+  </section>
+
+  <div class="facts">
+    <section class="card">
+      <h2>What the preflight does</h2>
+      <ul>
+        <li>Uses the same release facts and bearer credential as the live request.</li>
+        <li>Sets <code>dry_run: true</code>, so the platform composes but does not create drafts.</li>
+        <li>Uses a 10 second abort signal for both preflight and live POSTs.</li>
+      </ul>
+    </section>
+    <section class="card">
+      <h2>What it does not do</h2>
+      <ul>
+        <li>It does not rotate a credential.</li>
+        <li>It does not reveal a token in the workflow or this page.</li>
+        <li>It does not bypass the platform's human approval flow.</li>
+      </ul>
+    </section>
+  </div>
+
+  <section class="card">
+    <h2>Operator recovery path</h2>
+    <p>For a rejected token, rotate the canonical 1Password item through the estate chokepoint, validate the result, then update only the GitHub repository secret.</p>
+    <pre>HQ_API_TOKEN="$(~/.claude/hooks/op-read.sh --cache 3600 \
+  op://Platform/API-Static-Token/credential)"
+op_read_status=$?
+if [[ "$op_read_status" -ne 0 || -z "$HQ_API_TOKEN" ]]; then exit 1; fi
+printf '%s' "$HQ_API_TOKEN" | gh secret set HQ_API_TOKEN --repo yonatangross/orchestkit
+unset HQ_API_TOKEN</pre>
+    <p class="note">The real rail reports the exact reference when the secret is missing or the platform returns 401. A manual dispatch with <code>dry_run: true</code> remains local and skips the preflight.</p>
+  </section>
+</main>
+<script>
+  const modes = {
+    valid: {
+      steps: [["ok","credential preflight","200 dry-run"],["ok","platform compose","no drafts created"],["ok","live announce","may POST"],["ok","human review","drafts await approval"]],
+      title:"Preflight passed. The live announce may continue.",
+      body:"The platform authenticated a non-persisting dry-run. A later live POST still has the same 10 second bound."
+    },
+    missing: {
+      steps: [["bad","credential preflight","missing secret"],["dim","platform compose","not called"],["dim","live announce","blocked"],["dim","human review","no drafts"]],
+      title:"Stopped before any platform request.",
+      body:"The workflow names HQ_API_TOKEN and op://Platform/API-Static-Token/credential so the rotation target is actionable."
+    },
+    retired: {
+      steps: [["bad","credential preflight","401 rejected"],["bad","platform compose","authentication failed"],["dim","live announce","blocked"],["dim","human review","no drafts"]],
+      title:"Stopped on the dry-run 401, before the live POST.",
+      body:"Rotate the referenced API_STATIC_TOKEN and update the repository secret. The preflight never persists drafts."
+    },
+    timeout: {
+      steps: [["warn","credential preflight","aborted at 10s"],["dim","platform compose","incomplete"],["dim","live announce","blocked"],["dim","human review","no drafts"]],
+      title:"Stopped on a bounded preflight failure.",
+      body:"The workflow reports a credential-preflight failure rather than holding the release job indefinitely."
+    }
+  };
+  const flow = document.getElementById("flow");
+  const result = document.getElementById("result");
+  function render(mode) {
+    const data = modes[mode];
+    flow.textContent = "";
+    data.steps.forEach((step, index) => {
+      const item = document.createElement("div");
+      item.className = "step " + step[0];
+      const number = document.createElement("div");
+      number.className = "num";
+      number.textContent = `0${index + 1}`;
+      const name = document.createElement("div");
+      name.className = "name";
+      name.textContent = step[1];
+      const state = document.createElement("div");
+      state.className = "state";
+      state.textContent = step[2];
+      item.append(number, name, state);
+      flow.append(item);
+    });
+    result.textContent = "";
+    const title = document.createElement("strong");
+    title.textContent = data.title;
+    result.append(title, document.createTextNode(data.body));
+  }
+  document.querySelectorAll("[data-mode]").forEach(button => button.addEventListener("click", () => {
+    document.querySelectorAll("[data-mode]").forEach(item => item.setAttribute("aria-pressed", String(item === button)));
+    render(button.dataset.mode);
+  }));
+  render("valid");
+</script>
+</body>
+</html>

--- a/scripts/announce-release.mjs
+++ b/scripts/announce-release.mjs
@@ -22,6 +22,8 @@
  *   HQ_API_URL        platform API base                       [enables live POST]
  *   HQ_API_TOKEN      platform API_STATIC_TOKEN               [enables live POST]
  *   DRY_RUN           "true" to compose without posting
+ *   PREFLIGHT          "true" to authenticate with a non-persisting dry-run
+ *                      before the live POST
  *
  * Safe by default: with DRY_RUN set or HQ_API_URL/HQ_API_TOKEN unset, it prints
  * the payload and exits 0 (so releases never fail just because the marketing
@@ -45,9 +47,13 @@ const {
   HQ_API_URL,
   HQ_API_TOKEN,
   DRY_RUN = "false",
+  PREFLIGHT = "false",
   GITHUB_OUTPUT,
   GITHUB_STEP_SUMMARY,
 } = process.env;
+
+const HQ_API_TOKEN_REFERENCE = "op://Platform/API-Static-Token/credential";
+const REQUEST_TIMEOUT_MS = 10_000;
 
 function die(msg) {
   console.error(`[announce-release] ${msg}`);
@@ -66,6 +72,7 @@ if (!RELEASE_VERSION) die("RELEASE_VERSION is required");
 if (!RELEASE_URL) die("RELEASE_URL is required");
 
 const dryRun = DRY_RUN === "true" || DRY_RUN === "1";
+const preflight = PREFLIGHT === "true" || PREFLIGHT === "1";
 
 // Structured highlights from the changelog (best-effort — never fatal).
 let highlights = [];
@@ -103,12 +110,21 @@ const payload = {
   highlights,
   channels: ANNOUNCE_CHANNELS.split(",").map((s) => s.trim()).filter(Boolean),
   account: ANNOUNCE_ACCOUNT,
-  dry_run: dryRun,
+  // The preflight uses the platform's dry-run contract, so it authenticates
+  // and composes the exact release request without creating drafts.
+  dry_run: dryRun || preflight,
 };
 
 const haveCreds = Boolean(HQ_API_URL && HQ_API_TOKEN);
 
-if (dryRun || !haveCreds) {
+if (preflight && !haveCreds) {
+  die(
+    "credential preflight requires HQ_API_URL and HQ_API_TOKEN. " +
+      `Rotate ${HQ_API_TOKEN_REFERENCE} and update the repository HQ_API_TOKEN secret.`,
+  );
+}
+
+if ((dryRun && !preflight) || !haveCreds) {
   if (!haveCreds) {
     console.error(
       "[announce-release] HQ_API_URL/HQ_API_TOKEN unset — dry-run only. " +
@@ -122,21 +138,41 @@ if (dryRun || !haveCreds) {
 }
 
 const endpoint = `${HQ_API_URL.replace(/\/$/, "")}/api/marketing/release-announce`;
-const res = await fetch(endpoint, {
-  method: "POST",
-  headers: {
-    "content-type": "application/json",
-    authorization: `Bearer ${HQ_API_TOKEN}`,
-  },
-  body: JSON.stringify(payload),
-});
+let res;
+try {
+  res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${HQ_API_TOKEN}`,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+} catch (error) {
+  const context = preflight ? "credential preflight" : "platform request";
+  const detail = error instanceof Error ? error.message : String(error);
+  die(`${context} failed within ${REQUEST_TIMEOUT_MS}ms: ${detail}`);
+}
 
 const text = await res.text();
 if (!res.ok) {
   // The release is already published; a failed announce is a visible red check,
   // not a broken release. Surface the error clearly.
   summary(`### ⚠️ Release announce failed (${res.status})\n\`\`\`\n${text.slice(0, 800)}\n\`\`\``);
+  if (res.status === 401) {
+    die(
+      `HQ_API_TOKEN was rejected. Rotate ${HQ_API_TOKEN_REFERENCE} and update ` +
+        `the repository HQ_API_TOKEN secret. Platform response: ${text.slice(0, 500)}`,
+    );
+  }
   die(`platform returned ${res.status}: ${text.slice(0, 500)}`);
+}
+
+if (preflight) {
+  console.log(JSON.stringify({ mode: "credential-preflight", status: res.status }, null, 2));
+  summary("### Release announce credential preflight\nAuthenticated with a non-persisting platform dry-run.");
+  process.exit(0);
 }
 
 let data = {};

--- a/tests/ci/test-npm-audit-with-retry.sh
+++ b/tests/ci/test-npm-audit-with-retry.sh
@@ -53,20 +53,20 @@ run_wrapper() {
   NPM_AUDIT_MAX_ATTEMPTS=3 \
   NPM_AUDIT_RETRY_DELAY_SECONDS=0 \
   PATH="$tmpdir/bin:$PATH" \
-    bash "$WRAPPER" "$tmpdir/project"
+    bash "$WRAPPER" "$tmpdir/project" "$@"
 }
 
 rm -f "$tmpdir/args" "$tmpdir/count"
-NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=124 NPM_STUB_THIRD_STATUS=0 run_wrapper
+NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=124 NPM_STUB_THIRD_STATUS=0 run_wrapper --audit-level=moderate --package-lock-only --json
 if [[ "$(cat "$tmpdir/count")" == 3 ]]; then
   ok "retries a timed-out registry request twice"
 else
   bad "did not retry a timed-out registry request twice"
 fi
-if grep -Fxq 'audit --audit-level=critical' "$tmpdir/args"; then
-  ok "keeps the critical-severity audit gate"
+if grep -Fxq 'audit --audit-level=moderate --package-lock-only --json' "$tmpdir/args"; then
+  ok "passes through the lockfile audit arguments"
 else
-  bad "dropped the critical-severity audit gate"
+  bad "dropped the lockfile audit arguments"
 fi
 
 rm -f "$tmpdir/args" "$tmpdir/count"

--- a/tests/ci/test-npm-audit-with-retry.sh
+++ b/tests/ci/test-npm-audit-with-retry.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Regression coverage for the bounded dependency-audit wrapper. The fake npm
+# and timeout commands make the outcomes deterministic and network-free.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WRAPPER="$PROJECT_ROOT/.github/scripts/npm-audit-with-retry.sh"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/ork-audit-retry.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+mkdir -p "$tmpdir/bin" "$tmpdir/project"
+
+cat > "$tmpdir/bin/timeout" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+while [[ "$1" == --* || "$1" =~ ^[0-9]+s$ ]]; do
+  shift
+done
+exec "$@"
+EOF
+
+cat > "$tmpdir/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$NPM_STUB_ARGS"
+count=0
+[[ -f "$NPM_STUB_COUNT" ]] && count="$(cat "$NPM_STUB_COUNT")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$NPM_STUB_COUNT"
+if [[ "$count" -eq 1 ]]; then
+  exit "$NPM_STUB_FIRST_STATUS"
+fi
+exit "$NPM_STUB_SECOND_STATUS"
+EOF
+
+chmod +x "$tmpdir/bin/timeout" "$tmpdir/bin/npm"
+
+pass=0
+fail=0
+ok() { echo "  PASS: $1"; pass=$((pass + 1)); }
+bad() { echo "  FAIL: $1"; fail=$((fail + 1)); }
+
+run_wrapper() {
+  NPM_STUB_ARGS="$tmpdir/args" \
+  NPM_STUB_COUNT="$tmpdir/count" \
+  NPM_AUDIT_TIMEOUT_SECONDS=1 \
+  NPM_AUDIT_MAX_ATTEMPTS=2 \
+  NPM_AUDIT_RETRY_DELAY_SECONDS=0 \
+  PATH="$tmpdir/bin:$PATH" \
+    bash "$WRAPPER" "$tmpdir/project"
+}
+
+rm -f "$tmpdir/args" "$tmpdir/count"
+NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=0 run_wrapper
+if [[ "$(cat "$tmpdir/count")" == 2 ]]; then
+  ok "retries a timed-out registry request once"
+else
+  bad "did not retry a timed-out registry request"
+fi
+if grep -Fxq 'audit --audit-level=critical' "$tmpdir/args"; then
+  ok "keeps the critical-severity audit gate"
+else
+  bad "dropped the critical-severity audit gate"
+fi
+
+rm -f "$tmpdir/args" "$tmpdir/count"
+if NPM_STUB_FIRST_STATUS=1 NPM_STUB_SECOND_STATUS=0 run_wrapper; then
+  bad "accepted a critical-advisory exit"
+else
+  if [[ "$(cat "$tmpdir/count")" == 1 ]]; then
+    ok "does not retry a critical-advisory exit"
+  else
+    bad "retried a critical-advisory exit"
+  fi
+fi
+
+rm -f "$tmpdir/args" "$tmpdir/count"
+if NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=124 run_wrapper; then
+  bad "accepted repeated timeouts"
+else
+  if [[ "$(cat "$tmpdir/count")" == 2 ]]; then
+    ok "fails after the bounded timeout retry"
+  else
+    bad "did not enforce the timeout attempt limit"
+  fi
+fi
+
+echo "${pass} passed, ${fail} failed"
+[[ "$fail" -eq 0 ]]

--- a/tests/ci/test-npm-audit-with-retry.sh
+++ b/tests/ci/test-npm-audit-with-retry.sh
@@ -33,7 +33,10 @@ printf '%s\n' "$count" > "$NPM_STUB_COUNT"
 if [[ "$count" -eq 1 ]]; then
   exit "$NPM_STUB_FIRST_STATUS"
 fi
-exit "$NPM_STUB_SECOND_STATUS"
+if [[ "$count" -eq 2 ]]; then
+  exit "$NPM_STUB_SECOND_STATUS"
+fi
+exit "$NPM_STUB_THIRD_STATUS"
 EOF
 
 chmod +x "$tmpdir/bin/timeout" "$tmpdir/bin/npm"
@@ -47,18 +50,18 @@ run_wrapper() {
   NPM_STUB_ARGS="$tmpdir/args" \
   NPM_STUB_COUNT="$tmpdir/count" \
   NPM_AUDIT_TIMEOUT_SECONDS=1 \
-  NPM_AUDIT_MAX_ATTEMPTS=2 \
+  NPM_AUDIT_MAX_ATTEMPTS=3 \
   NPM_AUDIT_RETRY_DELAY_SECONDS=0 \
   PATH="$tmpdir/bin:$PATH" \
     bash "$WRAPPER" "$tmpdir/project"
 }
 
 rm -f "$tmpdir/args" "$tmpdir/count"
-NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=0 run_wrapper
-if [[ "$(cat "$tmpdir/count")" == 2 ]]; then
-  ok "retries a timed-out registry request once"
+NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=124 NPM_STUB_THIRD_STATUS=0 run_wrapper
+if [[ "$(cat "$tmpdir/count")" == 3 ]]; then
+  ok "retries a timed-out registry request twice"
 else
-  bad "did not retry a timed-out registry request"
+  bad "did not retry a timed-out registry request twice"
 fi
 if grep -Fxq 'audit --audit-level=critical' "$tmpdir/args"; then
   ok "keeps the critical-severity audit gate"
@@ -67,7 +70,7 @@ else
 fi
 
 rm -f "$tmpdir/args" "$tmpdir/count"
-if NPM_STUB_FIRST_STATUS=1 NPM_STUB_SECOND_STATUS=0 run_wrapper; then
+if NPM_STUB_FIRST_STATUS=1 NPM_STUB_SECOND_STATUS=0 NPM_STUB_THIRD_STATUS=0 run_wrapper; then
   bad "accepted a critical-advisory exit"
 else
   if [[ "$(cat "$tmpdir/count")" == 1 ]]; then
@@ -78,11 +81,11 @@ else
 fi
 
 rm -f "$tmpdir/args" "$tmpdir/count"
-if NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=124 run_wrapper; then
+if NPM_STUB_FIRST_STATUS=124 NPM_STUB_SECOND_STATUS=124 NPM_STUB_THIRD_STATUS=124 run_wrapper; then
   bad "accepted repeated timeouts"
 else
-  if [[ "$(cat "$tmpdir/count")" == 2 ]]; then
-    ok "fails after the bounded timeout retry"
+  if [[ "$(cat "$tmpdir/count")" == 3 ]]; then
+    ok "fails after three bounded attempts"
   else
     bad "did not enforce the timeout attempt limit"
   fi

--- a/tests/security/test-npm-audit-coverage.sh
+++ b/tests/security/test-npm-audit-coverage.sh
@@ -68,19 +68,19 @@ for tree in "${TREES[@]}"; do
 done
 
 # The count must match, so a NEW tree can't be added without wiring the gate.
-invocations=$(grep -cE '^audit_project +"' "$GATE")
+invocations=$(grep -cE '^start_audit +"' "$GATE")
 if [[ "$invocations" -eq "${#TREES[@]}" ]]; then
-  pass "audit_project invocation count (${invocations}) matches tracked lockfiles (${#TREES[@]})"
+  pass "start_audit invocation count (${invocations}) matches tracked lockfiles (${#TREES[@]})"
 else
-  fail "gate audits ${invocations} trees but ${#TREES[@]} lockfiles are tracked"
+  fail "gate starts ${invocations} audits but ${#TREES[@]} lockfiles are tracked"
 fi
 
 # 2. The audit reads the LOCKFILE, not node_modules. Dropping --package-lock-only
 #    reintroduces the install dependency that caused the silent skip.
-if grep -qE 'npm audit .*--package-lock-only' "$GATE"; then
-  pass "audits --package-lock-only (no node_modules dependency)"
+if grep -qF 'npm-audit-with-retry.sh' "$GATE" && grep -q -- '--package-lock-only' "$GATE"; then
+  pass "uses the bounded audit wrapper with --package-lock-only"
 else
-  fail "npm audit invocation lost --package-lock-only — reverts to node_modules coverage"
+  fail "bounded audit invocation lost --package-lock-only — reverts to node_modules coverage"
 fi
 
 # 3. A missing lockfile must FAIL, never pass. The original bug was a skip that

--- a/tests/security/test-npm-audit.sh
+++ b/tests/security/test-npm-audit.sh
@@ -26,6 +26,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LEVEL="${NPM_AUDIT_LEVEL:-moderate}"
 ALLOWLIST="$PROJECT_ROOT/.claude/audit-allowlist.json"
+AUDIT_WRAPPER="$PROJECT_ROOT/.github/scripts/npm-audit-with-retry.sh"
 
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
@@ -125,7 +126,7 @@ audit_project() {
   # on the report instead. stderr is captured rather than discarded: an earlier
   # version sent it to /dev/null, which is precisely how a registry 401 would
   # have been reported as the uninformative "produced no output".
-  report=$(cd "$dir" && npm audit --audit-level="$LEVEL" --package-lock-only --json 2>"$errfile")
+  report=$(bash "$AUDIT_WRAPPER" "$dir" "--audit-level=$LEVEL" --package-lock-only --json 2>"$errfile")
 
   if [[ -z "$report" ]] || ! jq -e . >/dev/null 2>&1 <<<"$report"; then
     fail "$label: npm audit produced no usable JSON report"
@@ -165,6 +166,24 @@ audit_project() {
     pass "$label: $total finding(s), all allowlisted"
   fi
   echo ""
+  [[ "$unlisted" -eq 0 ]]
+}
+
+AUDIT_LOG_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ork-audit-projects.XXXXXX")"
+trap 'rm -rf "$AUDIT_LOG_DIR"' EXIT
+AUDIT_PIDS=()
+AUDIT_LOGS=()
+
+start_audit() {
+  local label="$1"
+  local dir="$2"
+  local logfile
+
+  AUDITED_DIRS+=("$dir")
+  logfile="$(mktemp "$AUDIT_LOG_DIR/audit.XXXXXX")"
+  (audit_project "$label" "$dir") >"$logfile" 2>&1 &
+  AUDIT_PIDS+=("$!")
+  AUDIT_LOGS+=("$logfile")
 }
 
 # ─── run across EVERY tracked lockfile ──────────────────────────────
@@ -176,13 +195,24 @@ audit_project() {
 # per-manifest and this gate does not. A workspace missing from this list is
 # not "unaudited", it is silently PASSING — the same failure class the
 # --package-lock-only note above was written for.
-audit_project "root"           "$PROJECT_ROOT"
-audit_project "docs/site"      "$PROJECT_ROOT/docs/site"
-audit_project "src/hooks"      "$PROJECT_ROOT/src/hooks"
-audit_project "src/mcp-server" "$PROJECT_ROOT/src/mcp-server"
-audit_project "orchestkit-demos" "$PROJECT_ROOT/orchestkit-demos"
-audit_project "hook-contract/examples/generic-client" \
+start_audit "root"           "$PROJECT_ROOT"
+start_audit "docs/site"      "$PROJECT_ROOT/docs/site"
+start_audit "src/hooks"      "$PROJECT_ROOT/src/hooks"
+start_audit "src/mcp-server" "$PROJECT_ROOT/src/mcp-server"
+start_audit "orchestkit-demos" "$PROJECT_ROOT/orchestkit-demos"
+start_audit "hook-contract/examples/generic-client" \
               "$PROJECT_ROOT/packages/hook-contract/examples/generic-client"
+
+for index in "${!AUDIT_PIDS[@]}"; do
+  status=0
+  wait "${AUDIT_PIDS[$index]}" || status=$?
+  cat "${AUDIT_LOGS[$index]}"
+  if [[ "$status" -eq 0 ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+  fi
+done
 
 # ─── coverage assertion: every tracked lockfile must have been walked ──
 #

--- a/tests/unit/test-release-announce.sh
+++ b/tests/unit/test-release-announce.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Regression coverage for the release-announce credential preflight (#3650).
+#
+# A provisioned GitHub secret can be non-empty yet revoked. The preflight must
+# make an authenticated, non-persisting request before the live announce so a
+# rotation is actionable instead of surfacing as the release rail's final 401.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+ANNOUNCE="$PROJECT_ROOT/scripts/announce-release.mjs"
+WORKFLOW="$PROJECT_ROOT/.github/workflows/release-announce.yml"
+README="$PROJECT_ROOT/.github/workflows/README.md"
+TOKEN_REFERENCE="op://Platform/API-Static-Token/credential"
+FIXTURE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ork-announce.XXXXXX")"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; NC=$'\033[0m'
+PASS=0; FAIL=0
+pass() { echo "  ${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
+
+PRELOAD="$FIXTURE_DIR/fetch-preload.mjs"
+CAPTURE="$FIXTURE_DIR/fetch.json"
+cat > "$PRELOAD" <<'EOF'
+import { writeFileSync } from "node:fs";
+
+globalThis.fetch = async (url, options) => {
+  writeFileSync(process.env.ANNOUNCE_FETCH_CAPTURE, JSON.stringify({
+    url,
+    options,
+    hasAbortSignal: typeof options.signal?.addEventListener === "function",
+  }));
+  if (process.env.ANNOUNCE_FETCH_MODE === "abort") {
+    throw new DOMException("request timed out", "TimeoutError");
+  }
+  const status = Number(process.env.ANNOUNCE_FETCH_STATUS || "200");
+  return new Response(JSON.stringify({ dry_run: true, detail: "invalid token" }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+};
+EOF
+
+echo "=========================================="
+echo "  release announce credential preflight"
+echo "=========================================="
+
+# The request must use the real announce endpoint, bearer, and a platform
+# dry-run. The fetch preload is a local boundary double, so this never reaches
+# the network or touches the platform queue.
+OUT="$FIXTURE_DIR/preflight.out"
+ERR="$FIXTURE_DIR/preflight.err"
+if ANNOUNCE_FETCH_CAPTURE="$CAPTURE" RELEASE_VERSION="10.0.0-alpha.45" \
+  RELEASE_URL="https://example.invalid/releases/v10.0.0-alpha.45" \
+  HQ_API_URL="https://platform.example.invalid/" HQ_API_TOKEN="replacement-token" \
+  PREFLIGHT=true node --import "$PRELOAD" "$ANNOUNCE" >"$OUT" 2>"$ERR"; then
+  pass "preflight exits successfully for an authenticated dry-run"
+else
+  fail "preflight unexpectedly failed: $(<"$ERR")"
+fi
+
+if node -e '
+const fs = require("fs");
+const call = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const payload = JSON.parse(call.options.body);
+if (call.url !== "https://platform.example.invalid/api/marketing/release-announce") process.exit(1);
+if (call.options.headers.authorization !== "Bearer replacement-token") process.exit(1);
+if (payload.dry_run !== true) process.exit(1);
+if (call.hasAbortSignal !== true) process.exit(1);
+' "$CAPTURE"; then
+  pass "preflight authenticates the announce endpoint with a non-persisting payload"
+else
+  fail "preflight request did not preserve endpoint, bearer, dry_run=true, and a timeout signal"
+fi
+
+ABORTED_ERR="$FIXTURE_DIR/aborted-preflight.err"
+if ANNOUNCE_FETCH_CAPTURE="$CAPTURE" ANNOUNCE_FETCH_MODE=abort \
+  RELEASE_VERSION="10.0.0-alpha.45" RELEASE_URL="https://example.invalid/r" \
+  HQ_API_URL="https://platform.example.invalid" HQ_API_TOKEN="replacement-token" \
+  PREFLIGHT=true node --import "$PRELOAD" "$ANNOUNCE" > /dev/null 2>"$ABORTED_ERR"; then
+  fail "preflight continued after an aborted platform request"
+elif [[ "$(<"$ABORTED_ERR")" == *"credential preflight failed within 10000ms"* ]]; then
+  pass "aborted preflight stops before a live announce can continue"
+else
+  fail "aborted preflight error was not specific: $(<"$ABORTED_ERR")"
+fi
+
+REJECTED_ERR="$FIXTURE_DIR/rejected-token.err"
+if ANNOUNCE_FETCH_CAPTURE="$CAPTURE" ANNOUNCE_FETCH_STATUS=401 \
+  RELEASE_VERSION="10.0.0-alpha.45" RELEASE_URL="https://example.invalid/r" \
+  HQ_API_URL="https://platform.example.invalid" HQ_API_TOKEN="retired-token" \
+  PREFLIGHT=true node --import "$PRELOAD" "$ANNOUNCE" > /dev/null 2>"$REJECTED_ERR"; then
+  fail "preflight accepted a rejected HQ_API_TOKEN"
+elif [[ "$(<"$REJECTED_ERR")" == *"$TOKEN_REFERENCE"* ]]; then
+  pass "rejected token fails loudly with the exact rotation reference"
+else
+  fail "rejected token error omitted the rotation reference: $(<"$REJECTED_ERR")"
+fi
+
+MISSING_ERR="$FIXTURE_DIR/missing-token.err"
+if RELEASE_VERSION="10.0.0-alpha.45" RELEASE_URL="https://example.invalid/r" \
+  HQ_API_URL="https://platform.example.invalid" PREFLIGHT=true node "$ANNOUNCE" \
+  > /dev/null 2>"$MISSING_ERR"; then
+  fail "preflight accepted a missing HQ_API_TOKEN"
+elif [[ "$(<"$MISSING_ERR")" == *"$TOKEN_REFERENCE"* ]]; then
+  pass "missing token fails loudly with the exact rotation reference"
+else
+  fail "missing token error omitted the rotation reference: $(<"$MISSING_ERR")"
+fi
+
+if grep -Fq 'credential_preflight' "$WORKFLOW" && \
+  grep -Fq 'PREFLIGHT: "true"' "$WORKFLOW" && \
+  grep -Fq 'github.event.inputs.dry_run != '\''true'\''' "$WORKFLOW"; then
+  pass "workflow runs the preflight only before live announces"
+else
+  fail "workflow does not correctly wire the credential preflight"
+fi
+
+if grep -Fq "$TOKEN_REFERENCE" "$README" && \
+  grep -Fq 'gh secret set HQ_API_TOKEN --repo yonatangross/orchestkit' "$README" && \
+  grep -Fq 'op-read.sh --cache 3600' "$README" && \
+  grep -Fq 'op_read_status=$?' "$README" && \
+  grep -Fq '[[ -z "$HQ_API_TOKEN" ]]' "$README" && \
+  grep -Fq 'printf '\''%s'\'' "$HQ_API_TOKEN" |' "$README"; then
+  pass "rail README documents the chokepoint rotation procedure"
+else
+  fail "rail README is missing the token rotation procedure"
+fi
+
+echo "=========================================="
+echo "  Results: ${PASS} passed, ${FAIL} failed"
+echo "=========================================="
+
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
Closes #3650

Adds a bounded authenticated dry-run preflight before the live release announce POST, makes missing or rejected credentials actionable with the canonical rotation reference, and documents the validated 1Password chokepoint procedure.

## Interactive Playground

[Credential preflight flow](https://orchestkit.yonyon.ai/lab/announce-credential-preflight.html)

Source: `docs/fix--announce-rail-token-3650/index.html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release announcements now support authenticated preflight checks without publishing or creating drafts.
  * Dependency audits retry eligible timeout failures within configured limits and audit multiple projects concurrently.

* **Bug Fixes**
  * Improved handling of announcement network failures, timeouts, missing credentials, and unauthorized responses.
  * Dependency audits preserve non-retryable failure statuses and accurately report aggregate results.

* **Documentation**
  * Added guidance for rotating announcement credentials and manually approving live announcements.
  * Added the announcement preflight feature to the Lab gallery.

* **Tests**
  * Added regression coverage for announcement preflight and dependency audit retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->