### PR TITLE
docs(hooks): record Function Hooks watch gate (#3917)

### DIFF
--- a/.claude/rules/hooks-development.md
+++ b/.claude/rules/hooks-development.md
@@ -39,3 +39,22 @@ Claude Code is designing Function Hooks (anthropics/claude-code#91870): hooks be
 - Side effects go through `HookContext` (the #3386 DI seam) or an injected `deps` object built once by the runner. Today `deps.git` is `execSync`-backed; under Function Hooks it is `$.process`-backed; the handler does not change.
 - Existing offenders are grandfathered by path in `src/hooks/scripts/fh-ready-baseline.json` (a ratchet: shrink it, never grow it). `node scripts/fh-ready-check.mjs` runs in CI beside `validate-registry.mjs` and fails on any file not in the baseline.
 - Output caps are real and silent: CC 2.1.258 truncates `additionalContext` at 8,000 characters or 200 lines, `reason` at 2,000 characters or 20 lines, mid-word, with no report (anthropics/claude-code#91870, issuecomment-5532305564). `src/__tests__/fh-output-cap.test.ts` asserts no static payload approaches the cap.
+
+## Function Hooks watch gate (2026-09-05)
+
+Function Hooks remains a watch, not an adoption. The off-by-default prototype observed in
+Claude Code 2.1.260 and 2.1.261 is binary behavior, not a public contract
+([2.1.260 measurement](https://github.com/anthropics/claude-code/issues/91870#issuecomment-5540419526),
+[2.1.261 measurement](https://github.com/anthropics/claude-code/issues/91870#issuecomment-5549854514)).
+
+Until a Claude Code changelog names Function Hooks **or**
+[anthropics/claude-code#91870](https://github.com/anthropics/claude-code/issues/91870) closes:
+
+- Do not add a `modules` key to `hooks.json`, enable rollout flags, or document either for users.
+- Do not port handlers to Function Hooks or add Function Hooks runtime code.
+- Do not raise the Claude Code support floor or open an adoption issue for Function Hooks.
+
+When either close condition fires, link and record the outcome on #3917:
+
+- If a Claude Code changelog publicly ships and names Function Hooks, verify the public surface and open a separate adoption issue.
+- If #91870 closes without shipment, record that outcome and do not adopt.

--- a/docs/docs--3917-function-hooks-watch/function-hooks-gate.html
+++ b/docs/docs--3917-function-hooks-watch/function-hooks-gate.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Function Hooks adoption gate</title>
+  <meta name="description" content="Explore the evidence states that keep OrchestKit Function Hooks work watch-only until Claude Code ships a public contract.">
+  <style>
+    :root { --bg:#11100d; --panel:#201d18; --ink:#fff8e9; --muted:#c7bda8; --line:#4d4537; --accent:#ffc857; --go:#72e3ad; --stop:#ff8b7e; color-scheme:dark; }
+    * { box-sizing:border-box; }
+    body { margin:0; min-height:100vh; color:var(--ink); background:linear-gradient(125deg,#282014 0,transparent 36rem),var(--bg); font:1rem/1.55 ui-sans-serif,system-ui,sans-serif; }
+    main { width:min(70rem,calc(100% - 2rem)); margin:auto; padding:3rem 0; }
+    .eyebrow { color:var(--accent); font-size:.78rem; font-weight:800; letter-spacing:.12em; text-transform:uppercase; }
+    h1 { margin:.4rem 0 .8rem; font-size:clamp(2.2rem,6vw,4.8rem); line-height:.98; }
+    .intro { max-width:68ch; color:var(--muted); }
+    .panel { margin-top:2rem; padding:1.25rem; border:1px solid var(--line); border-radius:1rem; background:var(--panel); }
+    .states { display:flex; flex-wrap:wrap; gap:.65rem; }
+    button { padding:.65rem .9rem; border:1px solid var(--line); border-radius:.65rem; color:var(--ink); background:#2d281f; cursor:pointer; font:inherit; }
+    button:hover,button[aria-pressed="true"] { border-color:var(--accent); background:#4a391b; }
+    button:focus-visible { outline:3px solid var(--accent); outline-offset:3px; }
+    .verdict { display:grid; grid-template-columns:minmax(12rem,.7fr) 2fr; gap:1rem; margin-top:1.25rem; }
+    .signal,.actions { padding:1rem; border:1px solid var(--line); border-radius:.8rem; background:#171510; }
+    .signal strong { display:block; margin:.4rem 0; font-size:1.55rem; color:var(--stop); }
+    .signal.go strong { color:var(--go); }
+    ul { margin:.55rem 0 0; padding-left:1.2rem; }
+    li { margin:.35rem 0; }
+    code { color:#ffe29a; }
+    .note { color:var(--muted); }
+    @media (max-width:44rem) { .verdict { grid-template-columns:1fr; } }
+    @media (prefers-reduced-motion:reduce) { *,*::before,*::after { scroll-behavior:auto !important; transition:none !important; } }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">Function Hooks · evidence gate</p>
+    <h1>Observed is not shipped.</h1>
+    <p class="intro">A disabled prototype appeared in Claude Code 2.1.260 and 2.1.261, but OrchestKit needs a public contract before adopting it. Select the upstream evidence to see which work is allowed.</p>
+    <section class="panel" aria-labelledby="gate-title">
+      <h2 id="gate-title">Upstream evidence</h2>
+      <div class="states" role="group" aria-label="Function Hooks evidence state">
+        <button type="button" data-state="prototype" aria-pressed="true">Private prototype</button>
+        <button type="button" data-state="closed" aria-pressed="false">Issue closed, no shipment</button>
+        <button type="button" data-state="public" aria-pressed="false">Publicly shipped contract</button>
+      </div>
+      <div class="verdict">
+        <article class="signal" id="signal"><small>Gate verdict</small><strong>WATCH ONLY</strong><span id="reason">Disabled-by-default internals are not a public API.</span></article>
+        <article class="actions"><strong>Permitted OrchestKit work</strong><ul id="actions"><li>Record observed versions and evidence.</li><li>Keep handlers Function-Hooks-ready.</li><li>Do not add modules config, rollout flags, runtime adoption, or support-floor changes.</li></ul></article>
+      </div>
+      <p class="note">Public shipment and upstream issue closure are separate outcomes. Closing an issue without a shipped contract does not fire the adoption gate.</p>
+    </section>
+  </main>
+  <script>
+    const copy = {
+      prototype: { verdict:'WATCH ONLY', reason:'Disabled-by-default internals are not a public API.', go:false, actions:['Record observed versions and evidence.','Keep handlers Function-Hooks-ready.','Do not add modules config, rollout flags, runtime adoption, or support-floor changes.'] },
+      closed: { verdict:'WATCH ONLY', reason:'Issue closure without shipment is a distinct, non-adoption outcome.', go:false, actions:['Record the upstream closure separately.','Preserve the existing watch gate.','Wait for public documentation and a supported configuration surface.'] },
+      public: { verdict:'REASSESS', reason:'A public contract fires the gate; it does not pre-approve implementation.', go:true, actions:['Verify public docs and supported versions.','Open a scoped adoption plan with tests and rollback.','Revisit configuration and the support floor using fresh evidence.'] }
+    };
+    const buttons = [...document.querySelectorAll('[data-state]')];
+    const signal = document.getElementById('signal');
+    const reason = document.getElementById('reason');
+    const actions = document.getElementById('actions');
+    function render(state) {
+      const item = copy[state];
+      signal.querySelector('strong').textContent = item.verdict;
+      signal.classList.toggle('go', item.go);
+      reason.textContent = item.reason;
+      actions.replaceChildren(...item.actions.map((text) => { const li=document.createElement('li'); li.textContent=text; return li; }));
+      buttons.forEach((button) => button.setAttribute('aria-pressed', String(button.dataset.state === state)));
+    }
+    buttons.forEach((button) => button.addEventListener('click', () => render(button.dataset.state)));
+  </script>
+</body>
+</html>

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "function-hooks-adoption-gate",
+      "source": "docs/docs--3917-function-hooks-watch/function-hooks-gate.html",
+      "title": "Observed is not shipped: the Function Hooks adoption gate",
+      "description": "Choose private prototype, upstream closure, or public shipment evidence to see why OrchestKit remains watch-only until a supported Function Hooks contract actually ships.",
+      "tags": [
+        "hooks",
+        "cc-adoption",
+        "policy"
+      ],
+      "date": "2026-09-05"
+    },
+    {
       "slug": "announce-credential-preflight",
       "source": "docs/fix--announce-rail-token-3650/index.html",
       "title": "A red check before the live release announce",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -15,6 +15,20 @@ export interface LabEntry {
 
 export const LAB_ENTRIES: LabEntry[] = [
   {
+    "slug": "function-hooks-adoption-gate",
+    "title": "Observed is not shipped: the Function Hooks adoption gate",
+    "description": "Choose private prototype, upstream closure, or public shipment evidence to see why OrchestKit remains watch-only until a supported Function Hooks contract actually ships.",
+    "tags": [
+      "hooks",
+      "cc-adoption",
+      "policy"
+    ],
+    "date": "2026-09-05",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 5
+  },
+  {
     "slug": "feat--fh-handler-policy",
     "title": "FH-ready handlers: the policy that makes the Function Hooks port mechanical",
     "description": "Claude Code is designing Function Hooks (anthropics/claude-code#91870): in-process hooks where every side effect goes through one engine object. This page shows the same ork guard in both shapes, the ratchet gate that grandfathers 111 existing handlers and blocks new direct node:fs, child_process and fetch imports, and the 8,000 character additionalContext cap read out of the CC binary.",

--- a/docs/site/public/lab/function-hooks-adoption-gate.html
+++ b/docs/site/public/lab/function-hooks-adoption-gate.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Function Hooks adoption gate</title>
+  <meta name="description" content="Explore the evidence states that keep OrchestKit Function Hooks work watch-only until Claude Code ships a public contract.">
+  <style>
+    :root { --bg:#11100d; --panel:#201d18; --ink:#fff8e9; --muted:#c7bda8; --line:#4d4537; --accent:#ffc857; --go:#72e3ad; --stop:#ff8b7e; color-scheme:dark; }
+    * { box-sizing:border-box; }
+    body { margin:0; min-height:100vh; color:var(--ink); background:linear-gradient(125deg,#282014 0,transparent 36rem),var(--bg); font:1rem/1.55 ui-sans-serif,system-ui,sans-serif; }
+    main { width:min(70rem,calc(100% - 2rem)); margin:auto; padding:3rem 0; }
+    .eyebrow { color:var(--accent); font-size:.78rem; font-weight:800; letter-spacing:.12em; text-transform:uppercase; }
+    h1 { margin:.4rem 0 .8rem; font-size:clamp(2.2rem,6vw,4.8rem); line-height:.98; }
+    .intro { max-width:68ch; color:var(--muted); }
+    .panel { margin-top:2rem; padding:1.25rem; border:1px solid var(--line); border-radius:1rem; background:var(--panel); }
+    .states { display:flex; flex-wrap:wrap; gap:.65rem; }
+    button { padding:.65rem .9rem; border:1px solid var(--line); border-radius:.65rem; color:var(--ink); background:#2d281f; cursor:pointer; font:inherit; }
+    button:hover,button[aria-pressed="true"] { border-color:var(--accent); background:#4a391b; }
+    button:focus-visible { outline:3px solid var(--accent); outline-offset:3px; }
+    .verdict { display:grid; grid-template-columns:minmax(12rem,.7fr) 2fr; gap:1rem; margin-top:1.25rem; }
+    .signal,.actions { padding:1rem; border:1px solid var(--line); border-radius:.8rem; background:#171510; }
+    .signal strong { display:block; margin:.4rem 0; font-size:1.55rem; color:var(--stop); }
+    .signal.go strong { color:var(--go); }
+    ul { margin:.55rem 0 0; padding-left:1.2rem; }
+    li { margin:.35rem 0; }
+    code { color:#ffe29a; }
+    .note { color:var(--muted); }
+    @media (max-width:44rem) { .verdict { grid-template-columns:1fr; } }
+    @media (prefers-reduced-motion:reduce) { *,*::before,*::after { scroll-behavior:auto !important; transition:none !important; } }
+  </style>
+</head>
+<body>
+  <main>
+    <p class="eyebrow">Function Hooks · evidence gate</p>
+    <h1>Observed is not shipped.</h1>
+    <p class="intro">A disabled prototype appeared in Claude Code 2.1.260 and 2.1.261, but OrchestKit needs a public contract before adopting it. Select the upstream evidence to see which work is allowed.</p>
+    <section class="panel" aria-labelledby="gate-title">
+      <h2 id="gate-title">Upstream evidence</h2>
+      <div class="states" role="group" aria-label="Function Hooks evidence state">
+        <button type="button" data-state="prototype" aria-pressed="true">Private prototype</button>
+        <button type="button" data-state="closed" aria-pressed="false">Issue closed, no shipment</button>
+        <button type="button" data-state="public" aria-pressed="false">Publicly shipped contract</button>
+      </div>
+      <div class="verdict">
+        <article class="signal" id="signal"><small>Gate verdict</small><strong>WATCH ONLY</strong><span id="reason">Disabled-by-default internals are not a public API.</span></article>
+        <article class="actions"><strong>Permitted OrchestKit work</strong><ul id="actions"><li>Record observed versions and evidence.</li><li>Keep handlers Function-Hooks-ready.</li><li>Do not add modules config, rollout flags, runtime adoption, or support-floor changes.</li></ul></article>
+      </div>
+      <p class="note">Public shipment and upstream issue closure are separate outcomes. Closing an issue without a shipped contract does not fire the adoption gate.</p>
+    </section>
+  </main>
+  <script>
+    const copy = {
+      prototype: { verdict:'WATCH ONLY', reason:'Disabled-by-default internals are not a public API.', go:false, actions:['Record observed versions and evidence.','Keep handlers Function-Hooks-ready.','Do not add modules config, rollout flags, runtime adoption, or support-floor changes.'] },
+      closed: { verdict:'WATCH ONLY', reason:'Issue closure without shipment is a distinct, non-adoption outcome.', go:false, actions:['Record the upstream closure separately.','Preserve the existing watch gate.','Wait for public documentation and a supported configuration surface.'] },
+      public: { verdict:'REASSESS', reason:'A public contract fires the gate; it does not pre-approve implementation.', go:true, actions:['Verify public docs and supported versions.','Open a scoped adoption plan with tests and rollback.','Revisit configuration and the support floor using fresh evidence.'] }
+    };
+    const buttons = [...document.querySelectorAll('[data-state]')];
+    const signal = document.getElementById('signal');
+    const reason = document.getElementById('reason');
+    const actions = document.getElementById('actions');
+    function render(state) {
+      const item = copy[state];
+      signal.querySelector('strong').textContent = item.verdict;
+      signal.classList.toggle('go', item.go);
+      reason.textContent = item.reason;
+      actions.replaceChildren(...item.actions.map((text) => { const li=document.createElement('li'); li.textContent=text; return li; }));
+      buttons.forEach((button) => button.setAttribute('aria-pressed', String(button.dataset.state === state)));
+    }
+    buttons.forEach((button) => button.addEventListener('click', () => render(button.dataset.state)));
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- record the off-by-default Function Hooks prototype observed in Claude Code 2.1.260/2.1.261 as non-public behavior
- prohibit modules configuration, rollout flags, runtime adoption, support-floor changes, and adoption work until the public gate fires
- define separate outcomes for public shipment and upstream closure without shipment

This is intentionally watch-only and makes no speculative adoption changes.

## Verification

- node src/hooks/scripts/fh-ready-check.mjs — fh-ready-check: OK (111 grandfathered, 0 new)
- npm test -- --lint — Categories: 3 passed, 0 failed; ALL TESTS PASSED
- git diff --check

Refs #3917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that Function Hooks remain disabled by default and are not currently targeted for adoption.
  * Documented restrictions on adding runtime or configuration support until official shipment guidance is available.
  * Specified where related outcomes should be recorded.
  * Added a Lab gallery entry for the Function Hooks adoption-gate explainer, including its description, tags, and publication date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Interactive Playground

[Function Hooks adoption gate](https://orchestkit.yonyon.ai/lab/function-hooks-adoption-gate.html)

Compare private prototype, upstream-closure, and public-shipment evidence states against the watch-only policy.