### PR TITLE
fix(docs): resolve analytics in Vitest

### DIFF
--- a/docs/fix--docs-site-next-nav-3931/next-navigation-resolution.html
+++ b/docs/fix--docs-site-next-nav-3931/next-navigation-resolution.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>One ESM import, two resolvers</title>
+  <meta name="description" content="See why the docs build accepts an extensionless ESM subpath while Vitest needs to inline the analytics package until upstream corrects its build.">
+  <style>
+    :root { --bg: #10131b; --panel: #19202d; --edge: #344055; --ink: #e6edf8; --dim: #a9b8ce; --ok: #6ee7b7; --bad: #fca5a5; --accent: #93c5fd; }
+    * { box-sizing: border-box; } body { margin: 0; padding: 2.5rem 1.25rem; background: var(--bg); color: var(--ink); font: 16px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 52rem; margin: auto; } h1 { margin: 0; font-size: 1.45rem; } .sub { color: var(--dim); margin: .5rem 0 2rem; }
+    section { margin-top: 1rem; padding: 1.25rem; border: 1px solid var(--edge); border-radius: .75rem; background: var(--panel); } h2 { margin-top: 0; color: var(--accent); font-size: 1rem; }
+    button { margin: .25rem .5rem .25rem 0; padding: .55rem .8rem; border: 1px solid var(--edge); border-radius: .4rem; color: var(--ink); background: #111827; font: inherit; cursor: pointer; } button[aria-pressed="true"] { color: var(--accent); border-color: var(--accent); }
+    pre { overflow: auto; margin: 1rem 0 0; padding: 1rem; border-radius: .4rem; background: #0b0f16; color: var(--dim); } .ok { color: var(--ok); } .bad { color: var(--bad); } code { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>One ESM import, two resolvers</h1>
+    <p class="sub">Analytics 1.2.0 imports <code>next/navigation</code> without an extension. The build resolver accepts it. Plain Node ESM does not.</p>
+    <section>
+      <h2>Pick a test path</h2>
+      <div id="choices"></div>
+      <pre id="output"></pre>
+    </section>
+    <section>
+      <h2>Repair boundary</h2>
+      <p>The docs-site Vitest config inlines <code>@yonatan-hq/analytics</code>, so Vite resolves the subpath during tests. The package remains unmodified. Yonatan-HQ/core, <code>typescript/analytics</code>, owns the upstream correction.</p>
+    </section>
+  </main>
+  <script>
+    const paths = [
+      ["build", "Docs build", "webpack or Turbopack resolves next/navigation\n<span class='ok'>build passes</span>"],
+      ["node", "Vitest before", "Node ESM imports next/navigation literally\n<span class='bad'>Cannot find module next/navigation</span>"],
+      ["inline", "Vitest after", "Vitest inlines @yonatan-hq/analytics\nVite resolves the subpath during the test transform\n<span class='ok'>44 test files pass</span>"]
+    ];
+    const choices = document.getElementById("choices");
+    const output = document.getElementById("output");
+    function select(id) {
+      const entry = paths.find((path) => path[0] === id);
+      for (const button of choices.children) button.setAttribute("aria-pressed", String(button.dataset.id === id));
+      output.innerHTML = entry[2];
+    }
+    for (const [id, label] of paths) {
+      const button = document.createElement("button");
+      button.textContent = label;
+      button.dataset.id = id;
+      button.addEventListener("click", () => select(id));
+      choices.appendChild(button);
+    }
+    select("node");
+  </script>
+</body>
+</html>

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "next-navigation-vitest-resolution",
+      "source": "docs/fix--docs-site-next-nav-3931/next-navigation-resolution.html",
+      "title": "One ESM import, two resolvers",
+      "description": "Choose the resolver to see why the docs build accepts analytics 1.2.0 while Vitest needs to inline the package until its upstream build is corrected.",
+      "tags": [
+        "vitest",
+        "esm",
+        "analytics"
+      ],
+      "date": "2026-09-05"
+    },
+    {
       "slug": "cc-adoption-lens-259-261",
       "source": "docs/feat--adopt-cc-259-261/cc-adoption-lens.html",
       "title": "CC 2.1.259 to 2.1.261 adoption lens",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -57,6 +57,20 @@ export const LAB_ENTRIES: LabEntry[] = [
     "sizeKb": 7
   },
   {
+    "slug": "next-navigation-vitest-resolution",
+    "title": "One ESM import, two resolvers",
+    "description": "Choose the resolver to see why the docs build accepts analytics 1.2.0 while Vitest needs to inline the package until its upstream build is corrected.",
+    "tags": [
+      "vitest",
+      "esm",
+      "analytics"
+    ],
+    "date": "2026-09-05",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 3
+  },
+  {
     "slug": "feat--fh-handler-policy",
     "title": "FH-ready handlers: the policy that makes the Function Hooks port mechanical",
     "description": "Claude Code is designing Function Hooks (anthropics/claude-code#91870): in-process hooks where every side effect goes through one engine object. This page shows the same ork guard in both shapes, the ratchet gate that grandfathers 111 existing handlers and blocks new direct node:fs, child_process and fetch imports, and the 8,000 character additionalContext cap read out of the CC binary.",

--- a/docs/site/public/lab/next-navigation-vitest-resolution.html
+++ b/docs/site/public/lab/next-navigation-vitest-resolution.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>One ESM import, two resolvers</title>
+  <meta name="description" content="See why the docs build accepts an extensionless ESM subpath while Vitest needs to inline the analytics package until upstream corrects its build.">
+  <style>
+    :root { --bg: #10131b; --panel: #19202d; --edge: #344055; --ink: #e6edf8; --dim: #a9b8ce; --ok: #6ee7b7; --bad: #fca5a5; --accent: #93c5fd; }
+    * { box-sizing: border-box; } body { margin: 0; padding: 2.5rem 1.25rem; background: var(--bg); color: var(--ink); font: 16px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+    main { max-width: 52rem; margin: auto; } h1 { margin: 0; font-size: 1.45rem; } .sub { color: var(--dim); margin: .5rem 0 2rem; }
+    section { margin-top: 1rem; padding: 1.25rem; border: 1px solid var(--edge); border-radius: .75rem; background: var(--panel); } h2 { margin-top: 0; color: var(--accent); font-size: 1rem; }
+    button { margin: .25rem .5rem .25rem 0; padding: .55rem .8rem; border: 1px solid var(--edge); border-radius: .4rem; color: var(--ink); background: #111827; font: inherit; cursor: pointer; } button[aria-pressed="true"] { color: var(--accent); border-color: var(--accent); }
+    pre { overflow: auto; margin: 1rem 0 0; padding: 1rem; border-radius: .4rem; background: #0b0f16; color: var(--dim); } .ok { color: var(--ok); } .bad { color: var(--bad); } code { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>One ESM import, two resolvers</h1>
+    <p class="sub">Analytics 1.2.0 imports <code>next/navigation</code> without an extension. The build resolver accepts it. Plain Node ESM does not.</p>
+    <section>
+      <h2>Pick a test path</h2>
+      <div id="choices"></div>
+      <pre id="output"></pre>
+    </section>
+    <section>
+      <h2>Repair boundary</h2>
+      <p>The docs-site Vitest config inlines <code>@yonatan-hq/analytics</code>, so Vite resolves the subpath during tests. The package remains unmodified. Yonatan-HQ/core, <code>typescript/analytics</code>, owns the upstream correction.</p>
+    </section>
+  </main>
+  <script>
+    const paths = [
+      ["build", "Docs build", "webpack or Turbopack resolves next/navigation\n<span class='ok'>build passes</span>"],
+      ["node", "Vitest before", "Node ESM imports next/navigation literally\n<span class='bad'>Cannot find module next/navigation</span>"],
+      ["inline", "Vitest after", "Vitest inlines @yonatan-hq/analytics\nVite resolves the subpath during the test transform\n<span class='ok'>44 test files pass</span>"]
+    ];
+    const choices = document.getElementById("choices");
+    const output = document.getElementById("output");
+    function select(id) {
+      const entry = paths.find((path) => path[0] === id);
+      for (const button of choices.children) button.setAttribute("aria-pressed", String(button.dataset.id === id));
+      output.innerHTML = entry[2];
+    }
+    for (const [id, label] of paths) {
+      const button = document.createElement("button");
+      button.textContent = label;
+      button.dataset.id = id;
+      button.addEventListener("click", () => select(id));
+      choices.appendChild(button);
+    }
+    select("node");
+  </script>
+</body>
+</html>

--- a/docs/site/vitest.site.config.ts
+++ b/docs/site/vitest.site.config.ts
@@ -17,6 +17,13 @@ export default defineConfig({
       "@/lib": resolve(__dirname, "lib"),
       "@/components": resolve(__dirname, "components"),
     },
+    // Yonatan-HQ/core typescript/analytics owns the extensionless ESM import.
+    // Revert this once upstream ships a corrected build that Node ESM resolves.
+    server: {
+      deps: {
+        inline: ["@yonatan-hq/analytics"],
+      },
+    },
     setupFiles: ["./__tests__/setup.ts"],
   },
 });


### PR DESCRIPTION
Closes #3931

## Summary

Inline `@yonatan-hq/analytics` in the docs-site Vitest server dependency configuration so Vite resolves the package extensionless ESM subpath during tests. The comment identifies Yonatan-HQ/core typescript/analytics as the upstream owner and makes the workaround explicitly revertible.

## Interactive Playground

Included playground source: `docs/fix--docs-site-next-nav-3931/next-navigation-resolution.html`. It is registered in `docs/site/lab-manifest.json` and generated into the published Lab artifact.

## Verification

- `cd docs/site && npm test`: 44 test files passed, 562 tests passed.
- Deliberately removing the applied patch reproduces the `Cannot find module .../next/navigation` failure, then restoring it returns the suite to green.
- `cd docs/site && node scripts/generate-lab-data.mjs && npm run build`: passed.
- `npm run test:security`: 20 passed, 0 failed, using a local timeout compatibility function because macOS does not provide GNU `timeout`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `next-navigation-vitest-resolution` playground to the Lab gallery.
  - Includes a description and tags highlighting Vitest, ESM, analytics, and module resolution.

- **Bug Fixes**
  - Improved the playground environment’s handling of analytics modules with extensionless ESM imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->