### PR TITLE
docs: file the 2026-09-06 session artifacts under audits

### DIFF
--- a/docs/audits/codex-alignment-readonly-2026-09-06.md
+++ b/docs/audits/codex-alignment-readonly-2026-09-06.md
@@ -1,0 +1,167 @@
+# Codex configuration: read-only alignment report (2026-09-06)
+
+Requested by Yonatan via recovery-verifier-11242. **Read-only.** Nothing was
+configured, installed, deployed or altered. No remediation was applied.
+
+Every line is tagged MEASURED (a command in this session established it) or
+UNMEASURED (not established here, stated as unknown).
+
+---
+
+## 1. Are the installed artifacts current supported targets?
+
+**Both yes.** MEASURED.
+
+| artifact | installed | canonical declares | verdict |
+|---|---|---|---|
+| `ork-codex` | `10.0.0-alpha.80` | `10.0.0-alpha.80` | current |
+| `hq-codex` | `1.41.6+codex.20260821074500` | `1.41.6+codex.20260821074500` | current |
+
+Commands:
+
+- `ls ~/.codex/plugins/cache/orchestkit-codex/ork-codex/` gives `10.0.0-alpha.80`.
+- `git show origin/main:plugins/ork-codex/.codex-plugin/plugin.json` gives `"version": "10.0.0-alpha.80"`.
+- `git show origin/main:package.json` gives `10.0.0-alpha.80`, and `scripts/build-codex-plugin.sh:28` reads the version from `package.json`, so the built artifact tracks the release train.
+- `ls ~/.codex/plugins/cache/yonatan-hq-codex/hq-codex/` gives `1.41.6+codex.20260821074500`.
+- `hq-ext-plugin/plugins/hq-codex/.codex-plugin/plugin.json` at repo HEAD `24851e2` declares the same string.
+
+Host: `codex-cli 0.153.4` (MEASURED, `codex --version`).
+
+Both installs are complete, not skeletons. MEASURED:
+
+- `ork-codex` cache carries `skills/` (6), `roles/` (4), `mcp.json`, `scripts/`.
+- `hq-codex` cache carries `skills/` (6), `hooks/`, `configs/`, `tests/`.
+
+Correction recorded: an earlier probe in this session ran `ls ~/.codex/skills | grep ^ork`
+and returned zero, which I first read as "the ork skills are not installed". That
+was wrong. Codex loads plugin skills from the plugin cache, not from `~/.codex/skills`,
+and the cache does carry all six.
+
+---
+
+## 2. Canonical source refs
+
+| what | ref |
+|---|---|
+| ork-codex source of truth | `yonatangross/orchestkit` -> `src/codex/ork-codex/` |
+| ork-codex build | `scripts/build-codex-plugin.sh` -> `plugins/ork-codex/` (generated, do not hand-edit) |
+| ork-codex roster manifest | `manifests/codex/ork-codex.json` |
+| hq-codex source of truth | `Yonatan-HQ/hq-ext-plugin` -> `plugins/hq-codex/` |
+| the bridge between them | `hq-ext-plugin/plugins/hq-codex/configs/ork-bridge.json` |
+| live host config | `~/.codex/config.toml` (260 lines), `~/.codex/agents/`, `~/.codex/AGENTS.md` |
+
+---
+
+## 3. Required skills, roles, MCP and hook settings
+
+### ork-codex (MEASURED from `manifests/codex/ork-codex.json` and the installed cache)
+
+- **Skills (6):** `ork-brainstorm`, `ork-explore`, `ork-assess`, `ork-verify`, `ork-review-pr`, `ork-implement`.
+- **Roles (4):** `ork_explorer`, `ork_implementer`, `ork_reviewer`, `ork_verifier`.
+  Installed to `~/.codex/agents/` via `plugins/ork-codex/scripts/install-codex-roles.sh`.
+  All four are present on this machine (MEASURED, `ls ~/.codex/agents`).
+- **MCP (1):** `context7`, http, `https://mcp.context7.com/mcp`, bearer via env var
+  `CONTEXT7_API_KEY_CODEX`, tools limited to `resolve-library-id` and `query-docs`.
+  `~/.codex/config.toml:56` has `[mcp_servers.context7]` with a `bearer_token_env_var`
+  key present (MEASURED; the value was deliberately not read).
+- **Hooks:** none. ork-codex ships no hook surface, by design ("without Claude-only
+  commands or hooks", its own `longDescription`).
+
+### hq-codex (MEASURED from the installed cache)
+
+- **Skills (6):** `hq-conductor`, `hq-handoff`, `hq-knowledge`, `hq-mcp-verify`, `hq-ops`, `hq-plan`.
+- **Roles:** none of its own.
+- **MCP:** registers none. Its own `longDescription` states "no credentials or
+  duplicate MCP registration"; it consumes the hq-* servers already declared in
+  `~/.codex/config.toml`. Eight are present there: `hq-ops`, `hq-knowledge`,
+  `hq-media`, `hq-calendar`, `hq-cms`, `hq-channels`, `hq-commerce`, `hq-browser`.
+- **Hooks (1):** `PreToolUse`, matcher `^Bash$`, command
+  `python3 "$PLUGIN_ROOT/hooks/ratchet_guard.py"`, timeout 5,
+  statusMessage "Checking measured-value ratchet".
+
+### Alignment with Claude Code
+
+The Claude side runs `ork` `10.0.0-alpha.80` (same release train, MEASURED from
+`CLAUDE_PLUGIN_ROOT`) and `hq-ext` `1.61.0` installed. The hq-ext repo working
+copy is at `1.60.1` (MEASURED), so the local checkout trails the installed plugin
+by one patch. That is an hq-ext checkout observation, not a Codex problem.
+
+---
+
+## 4. Approved changes since 2026-08-21
+
+**Two functional commits total across both repos.** MEASURED.
+
+| repo | commit | note |
+|---|---|---|
+| orchestkit | `dc3bfe805` | `feat(ork-codex): ship ork-implement and one install matrix (#3753)` |
+| hq-ext-plugin | `8812e9f` | `feat(codex): add HQ MCP transport contract (#1108)` |
+
+`git log origin/main --since=2026-08-21 -- src/codex/ plugins/ork-codex/ manifests/codex/ scripts/build-codex-plugin.sh`
+returns 38 commits, but 37 of them are `chore(main): release 10.0.0-alpha.NN`
+version bumps that only restamp `plugin.json`. `dc3bfe805` is the single change
+with content.
+
+---
+
+## 5. One contract mismatch found, NOT changed (corrected 2026-09-06)
+
+An earlier draft of this section filed two independent gaps and called the bridge's `pinned_ref` "dead metadata". Yonatan read `hq-ext-plugin/scripts/validate_codex_ork_bridge.py` and corrected it: `minimum_version` IS checked, the CLI requires `--ork-source-root`, and `validate_pin_provenance` compares the pinned Git manifest's version to the installed version. The two findings are therefore one.
+
+MEASURED:
+
+- `git show 5092fff91077d96e6ac109393378f233aac21809:src/codex/ork-codex/.codex-plugin/plugin.json` gives `"version": "9.5.4"`.
+- `git show 5092fff91...:manifests/codex/ork-codex.json` gives `"version": "9.5.4"`. At the pinned ref the two files agreed.
+- On `origin/main` today, `plugins/ork-codex/.codex-plugin/plugin.json` is `10.0.0-alpha.80` (stamped from `package.json` by `scripts/build-codex-plugin.sh:28`) while `manifests/codex/ork-codex.json` is still `9.5.4`. The manifest stopped being stamped.
+
+So `hq-ext-plugin/plugins/hq-codex/configs/ork-bridge.json` pins `pinned_ref: 5092fff91` (release `10.0.0-alpha.43`, 2026-08-20, 201 commits behind `origin/main`) and `minimum_version: 9.6.1`, and provenance validation compares a pinned `9.5.4` against an installed `10.0.0-alpha.80`. Static evidence predicts the provenance check fails. No runtime test was run and no change was made.
+
+## 6. Explicitly UNMEASURED
+
+- Whether `hq-codex` `1.41.6` is deliberately decoupled from `hq-ext` `1.60.1`,
+  or is lagging. The `+codex.<timestamp>` build metadata suggests independent
+  stamping, but I found no policy document stating the intent.
+- Whether `CONTEXT7_API_KEY_CODEX` is actually populated. I confirmed the config
+  references a bearer env var by name and deliberately did not read the value or
+  the environment.
+- Whether the bridge's `minimum_version` / `pinned_ref` are enforced at runtime
+  (see 5b).
+- Any behavioural verification. Nothing was executed under Codex. This report is
+  static: artifact versions, file contents and git history only.
+
+---
+
+## 7. Recommendation (advisory only, nothing applied)
+
+Ranked, and all three are someone else's call to make:
+
+1. Decide the fate of `ork-bridge.json`'s `pinned_ref`. 201 commits is far enough
+   that "pinned" now means "pinned to something nobody is running". Either
+   re-pin it to the current release, or delete the field if nothing reads it.
+   Deleting an unenforced pin is better than carrying a wrong one.
+2. Make `manifests/codex/ork-codex.json`'s `version` either stamped or removed.
+   The build already knows the right number; a hand-set copy that nothing checks
+   only creates a second, wrong answer.
+3. State the hq-codex / hq-ext version relationship somewhere, so `1.41.6`
+   against `1.60.1` is readable as intent rather than as lag.
+
+---
+
+## Coordination note for the Pi CC-alignment audit
+
+Non-overlapping split, so results can be merged without double-counting:
+
+- **This report covers:** the Codex host only. Installed versions, canonical
+  refs, the ork-codex and hq-codex skill/role/MCP/hook surfaces, `~/.codex/config.toml`
+  structure, and codex-path git history since 2026-08-21.
+- **This report does NOT cover:** the Claude Code side of alignment. The `ork`
+  and `hq-ext` Claude plugin surfaces, `.claude/settings*.json`, CC hook
+  registration, and the CC permission model are Pi's half.
+- **The one datum both halves need:** both hosts run the same OrchestKit release
+  train, `10.0.0-alpha.80`. If Pi measures a different number on the Claude side,
+  that disagreement is the finding and this file's section 1 is the counter-evidence.
+- **Shared risk worth cross-checking:** section 5's pattern (a declared value with
+  no enforcing test) is the same defect class found and fixed on the Claude side
+  today in PR #3933, where `test-cc-version-floor.sh` grepped for a marker string
+  that had never existed and logged PASS on absence. Worth asking whether the
+  Codex-side validators have the same fail-open shape.

--- a/docs/audits/epic-c-close-state-2026-09-06.md
+++ b/docs/audits/epic-c-close-state-2026-09-06.md
@@ -1,0 +1,47 @@
+# EPIC C (#3308) state as measured 2026-09-06, CC 2.1.263
+
+Input for brainstorm + assess. Every line is MEASURED (command run this session) unless tagged CLAIMED (read from an issue or page, not re-verified).
+
+## The epic
+
+- Filed 2026-08-08 from the convergence audit (archived at `100668f6f:docs/cc-convergence-audit-2026-08-08/index.html`). Last comment 2026-08-10. CC was 2.1.226 then; it is 2.1.263 now, 37 releases later.
+- Rule stated in the body: re-home the opinion FIRST, observe it firing, THEN delete the pipe. Deleting first cost two PRs once (#1797).
+- Milestone 164 (v10.0.0): 117 closed, 4 open. #3308 is one of the 4, `priority:high`.
+- **Every filed RETIRE child on milestone 164 is CLOSED.** #3312, #3314, #3317, #3322, #3329, #3349, #3393, #3438. Sub-issues: 0. The tracker is open with no open children.
+
+## Per-mechanism verdicts, epic thread (2026-08-10) vs today
+
+| # | mechanism | epic thread said | measured today | evidence |
+|---|---|---|---|---|
+| 06 | 35 generated `commands/` wrappers | KEEP, blocked upstream (35 vs 0 at 2.1.226) | **RETIRED 2026-08-30** | `plugins/ork/commands/` = 0 files; `npm run verify:cc-commands` on 2.1.263: "wrapper-free plugin, native surfacing works", rc=0; PR #3807 merged 2026-08-30. Upstream anthropics/claude-code#18949 still OPEN (CLAIMED, last updated 2026-08-08) yet the probe passes, so the repo's own tripwire, not the upstream issue, decided it. |
+| 09 | `cache-break-detector` fake cost `count x 350` | EXTEND: keep attribution, remove fabricated cost | **DONE** | `src/hooks/src/prompt/cache-break-detector.ts:246-249` now carries a comment documenting the removal; no live `* 350`. Brainstorm cites closure via #3665 (CLAIMED until verified). |
+| 10 | keybindings shipped in docs | done, no re-home existed | DONE | #3393 closed 2026-08-10; `src/hooks/src/lib/keybindings.ts` absent. |
+| 11 | `ork-elicit` skill | RETIRED, `AskUserQuestion` equivalent | DONE | `src/skills/ork-elicit/SKILL.md` absent. |
+| 13 | `sweep-stale-worktrees` | KEEP, disjoint populations | KEEP, still present | file present. Thread's argument stands: CC sweeps registered worktrees; this sweeps unregistered empty dirs. Residue: sibling `<repo>-*` scanning branch is dead weight (#3319 deprecated that layout). Not re-probed today. |
+| 05, 07, 08 | never named in any page I read | UNPROBED per thread | **cannot be located by number** | The audit page numbers items 01-31 by move counts, not by label, and says "read it off the milestone". The milestone's RETIRE children (all closed) are the only candidates: #3312 goal abort-if, #3317 goal brake, #3329 handoff loop, #3349 engine field / hand-written validator, #3322 egress guard. So 05/07/08 are most likely among those and therefore closed, but the mapping is inferred, not read. |
+| handoff | duplicate across-time handoff loop | DONE | DONE | #3329 closed 2026-08-10. |
+
+## The one live item, and it is OFF the milestone
+
+`network-egress-guard` (#3322 closed COMPLETED 2026-08-30; retirement tracked in #3877, opened 2026-09-02, milestone NONE).
+
+- Wiring today, CORRECTED after /ork:assess refuted my first read: the guard IS live. `src/hooks/hooks.json:15` registers `pretool/bash/sync-bash-dispatcher` for PreToolUse Bash; `sync-bash-dispatcher.ts:23` imports `networkEgressGuard` and `:67` runs it as a phase of every Bash command. `node src/hooks/scripts/validate-registry.mjs` (walks dispatcher fan-out): reachable closure 183 of 183 registered, dead 0, `Result: PASS`, rc=0. MEASURED. My earlier claim that its absence from hooks.json by name made it a silently-dead pipe was wrong: consolidated hooks are registered via their dispatcher, and the entries-map key in `pretool.ts:81` is the testable export every consolidated hook carries, not an orphan.
+- `sandbox-posture.ts:13` records the operator decision (2026-08-23): freeze the guard and lean on `sandbox.enabled`.
+- #3877 probes (CLAIMED from the issue, dated 2026-09-02, CC 2.1.258): sandbox boundary is real at the CONNECT proxy, covers curl and python alike, closes the #3438 bypass class. Interactive arm confirmed denied host refused without prompt, unlisted host times out, allowed host 200.
+- #3877's stated remaining gate (step 3 of its plan): the guard's surviving DENY tier blocks executing fetched bytes (`curl ... | sh`, `eval $(curl ...)`), which no network policy covers when the host is allowed. Steps 1 (doctor override warning, PR #3887) and 2 (interactive probe) are done per the brainstorm (CLAIMED until verified).
+- Brainstorm research (2026-09-06, Tavily + upstream CHANGELOG): CC 2.1.257 "Containment Escape" is an auto-mode auto-approval classifier change, not a network-layer block; upstream text does not claim it covers a staged curl to child-process chain. Net: makes "DENY tier now covered by CC" LESS likely, so keep-until-probed. CLAIMED, nobody has run `curl url | sh` under it on 2.1.263.
+- Repo-local hazard found in #3877: `orchestkit/.claude/settings.local.json:125` had `sandbox.enabled: false`, silently defeating the user-scope posture. Removed 2026-09-02 14:05 per the last comment (CLAIMED).
+
+## Precedent the brainstorm surfaced
+
+#3835 (the divergence purge #3877 spun out of) was closed with milestone NONE while its one probe-gated tail item lived on as standalone #3877. Closing a tracker while a runtime-gated tail stands alone is how this repo already operates. CLAIMED until verified.
+
+## Brainstorm recommendation (2026-09-06)
+
+Option A: close #3308 now with a closing comment carrying the final 9-mechanism verdict table; #3877 continues standalone; append today's Containment Escape reading to #3877 as the documented starting hypothesis for its step-3 probe ("likely not covered: classifier, not network policy"). Option B (keep open until the probe runs) is defensible but the epic has sat a month on a task nobody scheduled. Option C (declare DENY tier covered from docs alone) is rejected: it repeats mechanism 06's retracted docs-over-implementation mistake.
+
+## Not verified today
+
+- No mechanism was re-probed at runtime except 06 (`verify:cc-commands`). 13 and the egress guard were read, not run.
+- #3877's probe tables are the issue author's, dated 2026-09-02 on CC 2.1.258; not repeated on 2.1.263.
+- Upstream #18949 state read from the GitHub API, not re-tested against the binary beyond the repo's own probe.

--- a/docs/playgrounds/roadmap-he-2026-09-06.html
+++ b/docs/playgrounds/roadmap-he-2026-09-06.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OrchestKit · מפת דרכים · 6 בספטמבר 2026</title>
+<style>
+  :root{
+    --bg:#0f1115; --panel:#171a21; --panel2:#1e222b; --line:#2a2f3a;
+    --ink:#e6e9ef; --dim:#9aa3b2; --faint:#6b7383;
+    --hot:#ff6b5e; --warm:#d9a441; --cool:#46c08a; --info:#4ea1ff; --accent:#a78bfa;
+  }
+  @media (prefers-color-scheme:light){
+    :root{
+      --bg:#f7f8fa; --panel:#fff; --panel2:#f0f2f6; --line:#dfe3ea;
+      --ink:#12151b; --dim:#59616f; --faint:#8b93a1;
+      --hot:#c0392b; --warm:#a86a00; --cool:#1a7f57; --info:#1f6feb; --accent:#6d43d9;
+    }
+  }
+  *{box-sizing:border-box}
+  body{
+    margin:0;background:var(--bg);color:var(--ink);
+    font:16px/1.75 "Segoe UI","Noto Sans Hebrew",Arial,sans-serif;
+    padding:36px 20px 72px;
+  }
+  main{max-width:900px;margin:0 auto}
+  h1{font-size:28px;margin:0 0 6px;line-height:1.3}
+  .sub{color:var(--dim);margin:0 0 8px}
+  .stamp{color:var(--faint);font-size:14px;margin:0 0 30px}
+  h2{font-size:20px;margin:38px 0 12px;padding-bottom:8px;border-bottom:1px solid var(--line)}
+  p{margin:0 0 14px}
+  .en{direction:ltr;unicode-bidi:isolate;display:inline-block;
+      font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.88em;
+      background:var(--panel2);padding:1px 6px;border-radius:4px}
+
+  .card{border:1px solid var(--line);background:var(--panel);border-radius:12px;
+        padding:16px 20px;margin:0 0 12px}
+  .card.hot{border-right:4px solid var(--hot)}
+  .card.warm{border-right:4px solid var(--warm)}
+  .card.cool{border-right:4px solid var(--cool)}
+  .card.info{border-right:4px solid var(--info)}
+  .card h3{margin:0 0 6px;font-size:17px;display:flex;align-items:center;gap:9px;flex-wrap:wrap}
+  .card p{margin:0;color:var(--dim);font-size:15px}
+  .id{direction:ltr;unicode-bidi:isolate;font-family:ui-monospace,Menlo,monospace;
+      font-size:13px;color:var(--faint)}
+
+  .done{border:1px solid var(--line);border-right:4px solid var(--cool);
+        background:var(--panel);border-radius:12px;padding:18px 20px;margin:0 0 26px}
+  .kv{display:grid;grid-template-columns:auto 1fr;gap:4px 18px;font-size:15px;margin-top:10px}
+  .kv dt{color:var(--faint)}
+  .kv dd{margin:0}
+
+  .rail{display:flex;flex-direction:column;gap:0;margin:14px 0 0}
+  .step{display:grid;grid-template-columns:34px 1fr;gap:14px;align-items:start}
+  .node{display:flex;flex-direction:column;align-items:center;height:100%}
+  .bullet{width:30px;height:30px;border-radius:50%;border:1px solid var(--line);
+          background:var(--panel2);display:flex;align-items:center;justify-content:center;
+          font-size:15px;flex:none}
+  .line{width:2px;flex:1;background:var(--line);min-height:16px}
+  .body{padding-bottom:20px}
+  .body strong{display:block;margin-bottom:2px}
+  .body span{color:var(--dim);font-size:15px}
+
+  table{border-collapse:collapse;width:100%;margin:10px 0 0;font-size:15px}
+  th,td{text-align:right;padding:9px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--faint);font-size:13px;font-weight:600}
+  .note{border:1px solid var(--line);border-right:4px solid var(--accent);
+        background:var(--panel);border-radius:12px;padding:16px 20px;margin:20px 0 0}
+  footer{margin:48px 0 0;padding-top:16px;border-top:1px solid var(--line);
+         color:var(--faint);font-size:14px}
+</style>
+</head>
+<body>
+<main>
+
+<h1>OrchestKit · מפת דרכים</h1>
+<p class="sub">מה נסגר, מה פתוח, ובאיזה סדר כדאי לטפל בזה.</p>
+<p class="stamp">6 בספטמבר 2026 · הענף הראשי נמצא ב־<span class="en">550e5c890</span></p>
+
+<div class="done">
+  <h3 style="margin:0;font-size:18px">✅ נסגר היום · <span class="en">#3933</span></h3>
+  <p style="color:var(--dim);margin:8px 0 0">
+    אימוץ גרסאות <span class="en">2.1.262</span> ו־<span class="en">2.1.263</span> של Claude Code,
+    ובנוסף תיקון של שער בדיקה שלא היה מסוגל להיכשל.
+  </p>
+  <dl class="kv">
+    <dt>בדיקות</dt><dd>51 עברו · 0 נכשלו · 0 ממתינות</dd>
+    <dt>מיזוג</dt><dd><span class="en">squash</span>, בלי <span class="en">admin</span>, בשעה <span class="en">06:12Z</span></dd>
+    <dt>ניקיון</dt><dd>44 ענפים ירדו ל־24 · 9 עצי עבודה ירדו ל־5</dd>
+  </dl>
+</div>
+
+<h2>🎯 החוט המקשר: כלים שמשקרים</h2>
+<p>
+  כמעט כל מה שנמצא היום שייך למשפחה אחת. לא קוד שקורס, אלא כלי שמדווח תשובה
+  שהוא לא באמת מדד. זו הסיבה שהסדר למטה מתחיל דווקא בבדיקות ולא בפיצ׳רים.
+</p>
+
+<div class="note">
+  <p style="margin:0">
+    <strong>הדוגמה מהיום.</strong> הבדיקה <span class="en">test-cc-version-floor.sh</span>
+    קיימת כדי לתפוס סטייה של מספר הגרסה המינימלית בין קבצים. היא חיפשה מחרוזת
+    שמעולם לא היתה קיימת בקובץ, וכשלא מצאה אותה היא רשמה <span class="en">PASS</span>.
+    כלומר: סימן ירוק, בלי שנקרא ולו מספר גרסה אחד. במצב הזה היא עברה מעבר לשינוי
+    מ־<span class="en">2.1.220</span> ל־<span class="en">2.1.251</span>, והשאירה טבלה
+    שאומרת למשתמשים שגרסה לא נתמכת היא בסדר.
+  </p>
+  <p style="margin:12px 0 0">
+    <strong>המבחן הזול.</strong> להריץ כל בדיקה גם על קלט שבור בכוונה. אם היא לא
+    מסוגלת לצאת אדומה, היא לא מדדה כלום. חשוב באותה מידה להריץ גם את הזרוע התקינה,
+    כי בדיקה שנכשלת על הכול נראית זהה לבדיקה שעובדת.
+  </p>
+</div>
+
+<h2>🔥 מנה ראשונה · שלושה באגים, פול־ריקווסט אחד</h2>
+<p>שלושתם באותה משפחה, שלושתם קטנים, שלושתם בשכבת ה־hooks והבדיקות.</p>
+
+<div class="card hot">
+  <h3>⚡ הרדקטור בולע מזהי טאבים <span class="id">#3894</span></h3>
+  <p>
+    <span class="en">mcp-output-transform</span> מזהה מזהי טאבים של הדפדפן כמספרי
+    טלפון ומצנזר אותם. זה שובר אוטומציית דפדפן בזמן אמת, וכנראה מדובר בביטוי רגולרי
+    אחד רעב מדי.
+  </p>
+</div>
+<div class="card hot">
+  <h3>🧪 בדיקה מהבהבת עם סף זמן קשיח <span class="id">#3522</span></h3>
+  <p>
+    טסט שדורש פחות מ־200 מילישניות, ונמדד ב־158, 710 ו־312 על ענף ראשי נקי. כלומר
+    כל פול־ריקווסט יורש הטלת מטבע אדומה. הנזק האמיתי הוא חינוכי: אנשים לומדים
+    להתעלם מאדום.
+  </p>
+</div>
+<div class="card hot">
+  <h3>🚨 הכלי מציע פקודה שהוא עצמו חוסם <span class="id">#3493</span></h3>
+  <p>
+    <span class="en">git-validator</span> מדפיס תיקון עם <span class="en">-C</span>,
+    ואז שומר הענפים שרץ אחריו מסרב לו. ההנחיה לא רק לא עוזרת, אי אפשר לבצע אותה.
+  </p>
+</div>
+
+<h2>🟡 מנה שנייה · אמיתי, אבל לא באותה חבילה</h2>
+<table>
+  <thead><tr><th>נושא</th><th>למה בנפרד</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>🟡 <span class="en">#2528</span> · סקילים נשמרים פעמיים־שלוש</td>
+      <td>מסומן <span class="en">priority:high</span> ומבני. הבנייה חסומה בשער סטייה. מגיע לו מסלול משלו, לא סעיף בחבילה.</td>
+    </tr>
+    <tr>
+      <td>🟡 <span class="en">#3822</span> · <span class="en">${CLAUDE_PLUGIN_ROOT}</span> נשאר כטקסט</td>
+      <td>פוגע רק בלקוחות שאינם Claude Code. שייך לחוט של Codex ו־pi, לא לחבילת הבאגים.</td>
+    </tr>
+    <tr>
+      <td>🟡 <span class="en">#3448</span> · מחקר של סוכן אובד</td>
+      <td>אובדן מידע אמיתי כשקריאת Bash ארוכה עוברת לרקע. דורש שחזור לפני תיקון.</td>
+    </tr>
+    <tr>
+      <td>🟡 <span class="en">#3780</span> · סקילים לא פותרים כינוי גוף</td>
+      <td>חוויית שימוש, מוגדר באופן רופף. צריך חידוד לפני שאפשר לעבוד עליו.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>🟢 מנה שלישית · נמוך, או מוקפא</h2>
+<table>
+  <tbody>
+    <tr><td>🟢 <span class="en">#3684</span></td><td>בדיקת כתובת לפי תת־מחרוזת, ושני תאומי markdown</td></tr>
+    <tr><td>🟢 <span class="en">#3667</span></td><td>תיאור המאגר נושא ספירות שאף אחד לא מעדכן</td></tr>
+    <tr><td>🟢 <span class="en">#3190</span></td><td>קיפאון של here-string ב־bash 5.3 על macOS · מוקפא</td></tr>
+    <tr><td>🟢 <span class="en">#3101</span></td><td>דיאגרמות mermaid נשברות בלשוניות לא פעילות · משימה טובה למתחילים</td></tr>
+  </tbody>
+</table>
+
+<h2>🛤️ הסדר המומלץ</h2>
+<div class="rail">
+  <div class="step">
+    <div class="node"><div class="bullet">🔥</div><div class="line"></div></div>
+    <div class="body">
+      <strong>סחיפת גרסאות <span class="en">#3537</span></strong>
+      <span>
+        הפריט היחיד עם התראה אוטומטית שדולקת כל לילה.
+        <span class="en">emulate</span> מ־0.10 ל־0.11, ובנוסף
+        <span class="en">motion</span> ו־<span class="en">react-i18next</span>
+        מפגרים בגרסה ראשית שלמה. הפעולה היא הפעלה ידנית של
+        <span class="en">Upstream Version Watch</span>.
+      </span>
+    </div>
+  </div>
+  <div class="step">
+    <div class="node"><div class="bullet">2</div><div class="line"></div></div>
+    <div class="body">
+      <strong>חבילת שלושת הבאגים</strong>
+      <span>עץ עבודה חדש מ־<span class="en">origin/main</span>, ומתחילים ב־<span class="en">#3894</span>, כי הוא היחיד שנוגע בכלים שאנחנו משתמשים בהם עכשיו.</span>
+    </div>
+  </div>
+  <div class="step">
+    <div class="node"><div class="bullet">3</div><div class="line"></div></div>
+    <div class="body">
+      <strong>אי־התאמת החוזה של Codex</strong>
+      <span>
+        <span class="en">manifests/codex/ork-codex.json</span> הפסיק להתעדכן ותקוע על
+        <span class="en">9.5.4</span>, בדיוק מה שה־<span class="en">pinned_ref</span> מצהיר,
+        בזמן שהמותקן הוא <span class="en">10.0.0-alpha.80</span>. הראיה הסטטית מנבאת
+        כישלון של אימות מקור.
+      </span>
+    </div>
+  </div>
+  <div class="step">
+    <div class="node"><div class="bullet">4</div></div>
+    <div class="body">
+      <strong>אבני דרך <span class="en">165</span> עד <span class="en">168</span></strong>
+      <span>תשע משימות: סוכני מסחר, הגשת עמוד לאדם, עמוד לכל סקיל, ותוכן מכירות. אף אחת לא נגעה מאז ה־2 בספטמבר, וכולן צריכות הגדרה לפני שאפשר לעבוד עליהן.</span>
+    </div>
+  </div>
+</div>
+
+<h2>⚠️ מה לא נבדק</h2>
+<p>
+  אף אחד מאחד עשר הבאגים לא שוחזר בפועל. הדירוג נקרא מהכותרות, מהתוויות ומהתאריכים
+  בלבד. <span class="en">#3522</span> הוא זה שהכי סביר שאטעה לגביו, כי טענות על
+  בדיקה מהבהבת מתיישנות מהר והוא נגע לאחרונה ב־21 באוגוסט. גם סריקת
+  <span class="en">npm test</span> המלאה לא רצה בשום שלב היום; מה שהסתמכתי עליו זה
+  51 הבדיקות הירוקות של המערכת האוטומטית.
+</p>
+
+<footer>
+  נבנה מתוך רשימת הסוגיות הפתוחות של <span class="en">yonatangross/orchestkit</span>,
+  ממצב הענפים המקומי, ומהיסטוריית ה־git, כפי שנקראו ב־6 בספטמבר 2026.
+  צבע וסימן מציינים דחיפות בלבד, לא גודל.
+</footer>
+
+</main>
+</body>
+</html>


### PR DESCRIPTION
## What

Files three read-only artifacts from the 2026-09-06 session under `docs/audits/` and `docs/playgrounds/`. No code, no configuration.

| file | what it is |
|---|---|
| `docs/audits/epic-c-close-state-2026-09-06.md` | The measured per-mechanism table behind closing EPIC C (#3308). Carries the retraction of a "silently-dead hook" claim about `network-egress-guard` (`validate-registry.mjs`: 183 of 183 reachable, PASS) and states mechanisms 05/07/08 as INFERRED closed, not verified by name. |
| `docs/audits/codex-alignment-readonly-2026-09-06.md` | Read-only Codex host audit. Section 5 rewritten to the single contract mismatch: `manifests/codex/ork-codex.json` stopped being stamped at `9.5.4`, and `ork-bridge.json`'s provenance check compares that to the installed `10.0.0-alpha.80`. |
| `docs/playgrounds/roadmap-he-2026-09-06.html` | Hebrew RTL roadmap page, served this session at `https://ork-playgrounds.localhost/playgrounds/roadmap-he-2026-09-06.html`. CSS boxes rather than ASCII frames, because Hebrew inside box-drawing scrambles under bidi. |

## Why `docs/audits/`

Both markdown files were first written at `docs/` root. The PR playground gate's INERT list covers `docs/audits/.*` and `docs/playgrounds/.*` but not `docs/*.md`, so at root they would have demanded a playground for a doc-only change.

## Verification

- Every claim in both audits is tagged MEASURED or CLAIMED.
- Docs-only diff, so the playground check should skip. If it does not, that is a gate bug worth its own issue rather than a playground for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4wMb1zHnT3jCf8zfph9NS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added audit documentation covering Codex alignment, installed artifacts, configuration, version provenance, and advisory recommendations.
  - Added an EPIC C status audit detailing completed and remaining validation work, retention decisions, and follow-up recommendations.
  - Added a Hebrew, right-to-left roadmap page with responsive styling, completed work, issue categories, execution order, and verification status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->