### PR TITLE
ci(deps): group vitest with its coverage provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,7 +53,22 @@ updates:
       - "dependencies"
       - "release-please-override"
     groups:
+      # vitest and its coverage provider must move together. #3976: a MAJOR
+      # matches no `update-types: [minor, patch]` group, so Dependabot opened
+      # `vitest` and `@vitest/coverage-v8` as two PRs per manifest; each one
+      # alone leaves the manifest with a runner and a coverage provider on
+      # different majors and npm refuses to resolve it (ERESOLVE, measured on
+      # #3966). No `update-types` here on purpose: that is what makes this
+      # group cover the major, which is the only case that breaks. Same shape
+      # as the `remotion` group below (#3086).
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       npm-minor-patch:
+        exclude-patterns:
+          - "vitest"
+          - "@vitest/*"
         update-types:
           - "minor"
           - "patch"
@@ -71,7 +86,22 @@ updates:
     labels:
       - "dependencies"
     groups:
+      # vitest and its coverage provider must move together. #3976: a MAJOR
+      # matches no `update-types: [minor, patch]` group, so Dependabot opened
+      # `vitest` and `@vitest/coverage-v8` as two PRs per manifest; each one
+      # alone leaves the manifest with a runner and a coverage provider on
+      # different majors and npm refuses to resolve it (ERESOLVE, measured on
+      # #3966). No `update-types` here on purpose: that is what makes this
+      # group cover the major, which is the only case that breaks. Same shape
+      # as the `remotion` group below (#3086).
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       npm-minor-patch:
+        exclude-patterns:
+          - "vitest"
+          - "@vitest/*"
         update-types:
           - "minor"
           - "patch"
@@ -89,7 +119,22 @@ updates:
     labels:
       - "dependencies"
     groups:
+      # vitest and its coverage provider must move together. #3976: a MAJOR
+      # matches no `update-types: [minor, patch]` group, so Dependabot opened
+      # `vitest` and `@vitest/coverage-v8` as two PRs per manifest; each one
+      # alone leaves the manifest with a runner and a coverage provider on
+      # different majors and npm refuses to resolve it (ERESOLVE, measured on
+      # #3966). No `update-types` here on purpose: that is what makes this
+      # group cover the major, which is the only case that breaks. Same shape
+      # as the `remotion` group below (#3086).
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       npm-minor-patch:
+        exclude-patterns:
+          - "vitest"
+          - "@vitest/*"
         update-types:
           - "minor"
           - "patch"
@@ -140,10 +185,24 @@ updates:
         patterns:
           - "remotion"
           - "@remotion/*"
+      # vitest and its coverage provider must move together. #3976: a MAJOR
+      # matches no `update-types: [minor, patch]` group, so Dependabot opened
+      # `vitest` and `@vitest/coverage-v8` as two PRs per manifest; each one
+      # alone leaves the manifest with a runner and a coverage provider on
+      # different majors and npm refuses to resolve it (ERESOLVE, measured on
+      # #3966). No `update-types` here on purpose: that is what makes this
+      # group cover the major, which is the only case that breaks. Same shape
+      # as the `remotion` group below (#3086).
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
       npm-minor-patch:
         exclude-patterns:
           - "remotion"
           - "@remotion/*"
+          - "vitest"
+          - "@vitest/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Problem

A **major** bump matches no `update-types: [minor, patch]` group, so Dependabot opens
`vitest` and `@vitest/coverage-v8` as two separate PRs per manifest.
`@vitest/coverage-v8` carries a peer constraint on the matching `vitest` major, so a
manifest that has taken one bump and not the other is unresolvable, and **neither PR can
ever go green**. Rebasing does not help; landing the root first does not help, because the
conflict is inside the manifest.

Measured on #3966 after re-running it against vitest 5 at the root (#3960, `104afcfb1`),
`Validate Renderer` failing at "Install demo dependencies":

```
npm error code ERESOLVE
npm error While resolving: @vitest/coverage-v8@4.1.11
npm error Found: vitest@5.0.0
npm error   dev vitest@"^5.0.0" from the root project
```

Four PRs are stuck in this shape right now: #3966 + #3967 (`/orchestkit-demos`) and
#3961 + #3959 (`/src/hooks`). `/` and `/docs/site` landed only because Dependabot happened
to propose `vitest` there without a matching coverage bump in the same window.

## Change

Adds a `vitest` group to every npm ecosystem that carries the family (`/`, `/src/hooks`,
`/docs/site`, `/orchestkit-demos`) and excludes those patterns from `npm-minor-patch`, so
one dependency is never claimed by two groups.

The group deliberately carries **no** `update-types`. That is what makes it cover the
major, which is the only case that actually breaks today.

This is the same shape as the existing `remotion` group added by #3086 for the same class
of problem. That group's own exclusion list is preserved and extended, not replaced.

`/src/mcp-server` has no vitest and is left alone.

## Verification

- `yaml.safe_load` parses the file, 7 update blocks, unchanged count.
- Per-block assertion: all four target directories have `vitest` group with patterns
  `['vitest', '@vitest/*']`, `update-types` unset, and both patterns present in
  `npm-minor-patch.exclude-patterns`. `/src/mcp-server` correctly has none.
- `/orchestkit-demos` `npm-minor-patch.exclude-patterns` reads
  `['remotion', '@remotion/*', 'vitest', '@vitest/*']`.
- Insertions only: 59 added, 0 removed, no existing line modified.

## Follow-up

#3966 and #3967 get closed on this landing, with the verdict recorded on each. #3961 and
#3959 stay open until #3971 (the tracked `plugins/` mirror drift) is also resolved, since
grouping fixes their peer conflict but not their build-drift failure.

Closes #3976.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to group Vitest-related package updates across the project’s configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->