### PR TITLE
fix(ci): report an unreadable version as SKIP, not DRIFT

### DIFF
--- a/scripts/validate-fn-hooks-canary.sh
+++ b/scripts/validate-fn-hooks-canary.sh
@@ -33,7 +33,16 @@ fi
 # pass.
 MIN_CC="2.1.259"
 CC_RAW="$(claude --version 2>&1)"
+
+# Capture rc around the parse. `grep` exits 1 on no match, and under
+# `set -euo pipefail` a failing pipeline inside a command substitution kills the
+# script: measured, a non-semver banner exited 1 with EMPTY output, which the CI
+# step then reports as DRIFT. A version we could not read is its own outcome and
+# must never be indistinguishable from a contract change.
+set +e
 CC_VER="$(printf '%s' "$CC_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+set -e
+
 if [ -z "$CC_VER" ]; then
   echo "SKIP: could not parse a version out of: $CC_RAW"
   exit 0


### PR DESCRIPTION
## Rescoped, because I made a branching mistake and the rest of this PR already merged

This PR now contains **one commit, nine lines, one file**. Everything else it used to
carry is already on `main`, and that was not intentional.

### What went wrong

I created `chore/depersonalize-public-docs-hq-refs` (PR #3990) **off this branch
instead of off `main`**. So #3990 silently carried the canary commit
`16423895274c`, and merging #3990 put the whole Function Hooks canary on `main`.

Two consequences, and the first is the serious one:

1. **The `modules`-key rule question was settled by accident.** I flagged, in this
   PR, that `.claude/rules/hooks-development.md` says unqualified *do not add a
   `modules` key to `hooks.json`*, and said explicitly that resolving it was the
   operator's call and that merging first would settle it by fait accompli. Then my
   branching error did exactly that. The fixture is on `main` and the rule question
   is still genuinely open. It should be decided on its merits, and the rule amended
   or the fixture reverted, rather than left as "well, it shipped".
2. **`main` currently carries a bug this PR fixes.** The version-parse fix was
   committed here after I parked it off #3990, so `main` has the unfixed script.

Rebasing onto `main` dropped the canary commit as "patch contents already upstream",
which is the confirmation.

### The remaining nine lines

`grep` exits 1 on no match. Under `set -euo pipefail` a failing pipeline inside a
command substitution kills the script, so the `[ -z "$CC_VER" ]` SKIP branch below it
was unreachable. Measured against `main`'s current copy with a stub CLI printing a
non-semver banner:

```
main today:  rc=1, EMPTY output
this PR:     rc=0, "SKIP: could not parse a version out of: ..."
```

The empty output is what matters. `cc-contract-probe.yml` maps a non-zero rc to
`DRIFT: the upstream contract moved`, so an unreadable version would report an
upstream contract change with nothing in the log to contradict it. A canary that
cannot distinguish "I could not look" from "the thing I watch changed" is worse than
no canary. Fixed by capturing rc around the parse rather than `|| true`, so the
could-not-observe case stays named.

That workflow runs on a daily 07:00 UTC schedule, so this is not urgent, but it is
live on `main` until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tFBz1xmrTpEYmv27Qozjb
