### PR TITLE
chore(docs): drop private-plugin specifics from public source

### DIFF
--- a/.github/workflows/cc-contract-probe.yml
+++ b/.github/workflows/cc-contract-probe.yml
@@ -197,3 +197,39 @@ jobs:
             echo '```'
           } | tee -a "$GITHUB_STEP_SUMMARY"
           exit "$rc"
+
+      # Function Hooks module contract (#3917). OrchestKit is NOT migrating: 78 of
+      # 152 hook entries have no native address and the identifiers are still
+      # moving. This is the mechanical half of "keep watching" — it asserts the
+      # events and $ capabilities a fixture module registers, so a rename upstream
+      # (the announced but unshipped `fs.readFile` -> `fs.read`, say) turns red here
+      # instead of being noticed by hand months later.
+      #
+      # Belongs in THIS workflow and not plugin-validation.yml for the same reason
+      # spelled out at the top of this file: the other job is pinned to the support
+      # floor, and the event vocabulary this checks does not exist until 2.1.259.
+      # A floor-pinned host would skip every run, which reads as a pass.
+      #
+      # Offline. `claude plugin validate` makes no model call and needs no key.
+      - name: Function Hooks contract canary
+        if: ${{ !cancelled() }}
+        run: |
+          set -uo pipefail
+          rc=0
+          bash scripts/validate-fn-hooks-canary.sh > /tmp/fnhooks.txt 2>&1 || rc=$?
+          {
+            echo '## Function Hooks module contract'
+            echo ''
+            if [ "$rc" -eq 0 ] && grep -q '^SKIP:' /tmp/fnhooks.txt; then
+              echo 'SKIP: host CC is older than the function-hooks vocabulary. Nothing was verified.'
+            elif [ "$rc" -eq 0 ]; then
+              echo 'OK: registered events and $ capabilities unchanged from the 2.1.263 measurement.'
+            else
+              echo 'DRIFT: the upstream contract moved. Re-read #3917 before updating the expected values, and record what moved.'
+            fi
+            echo ''
+            echo '```'
+            cat /tmp/fnhooks.txt
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+          exit "$rc"

--- a/docs/chore--depersonalize-public-docs-hq-refs/route-nudge-regex.html
+++ b/docs/chore--depersonalize-public-docs-hq-refs/route-nudge-regex.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Route nudge: widening a regex traded one bug for a worse one</title>
+<style>
+  :root{
+    --bg:#0e1116; --panel:#161b22; --line:#2a313a; --ink:#e6edf3; --dim:#9aa7b4;
+    --ok:#3fb950; --bad:#f85149; --warn:#d29922; --accent:#7c3aed;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+       font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
+  .wrap{max-width:920px;margin:0 auto;padding:40px 20px 80px}
+  h1{font-size:26px;line-height:1.25;margin:0 0 8px}
+  .sub{color:var(--dim);margin:0 0 28px}
+  h2{font-size:17px;margin:34px 0 12px;padding-top:18px;border-top:1px solid var(--line)}
+  code,kbd{font-family:var(--mono);font-size:.9em}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px}
+  textarea{width:100%;min-height:74px;resize:vertical;background:#0b0e13;color:var(--ink);
+           border:1px solid var(--line);border-radius:8px;padding:11px 12px;font-family:var(--mono);font-size:13px}
+  textarea:focus{outline:none;border-color:var(--accent)}
+  .presets{display:flex;flex-wrap:wrap;gap:7px;margin:12px 0 0}
+  .presets button{background:#1d232c;color:var(--ink);border:1px solid var(--line);border-radius:999px;
+                  padding:5px 12px;font-size:12.5px;cursor:pointer}
+  .presets button:hover{border-color:var(--accent)}
+  table{width:100%;border-collapse:collapse;margin-top:16px;font-size:13.5px}
+  th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--dim);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.re{font-family:var(--mono);font-size:11.5px;color:var(--dim);max-width:270px;word-break:break-all}
+  .yes{color:var(--ok);font-weight:600}
+  .no{color:var(--bad);font-weight:600}
+  .verdict{margin-top:16px;padding:13px 15px;border-radius:8px;border:1px solid var(--line);font-size:14px}
+  .v-nudge{background:rgba(210,153,34,.10);border-color:rgba(210,153,34,.4)}
+  .v-silent{background:rgba(63,185,80,.10);border-color:rgba(63,185,80,.4)}
+  .steps{list-style:none;padding:0;margin:14px 0 0;font-family:var(--mono);font-size:12.5px}
+  .steps li{padding:4px 0;color:var(--dim)}
+  .steps b{color:var(--ink);font-weight:600}
+  p{margin:0 0 12px}
+  .note{color:var(--dim);font-size:13.5px}
+  .flag{display:inline-block;padding:1px 7px;border-radius:4px;font-size:11px;font-weight:600;
+        font-family:var(--mono);letter-spacing:.02em}
+  .flag.regress{background:rgba(248,81,73,.16);color:var(--bad)}
+  .flag.fixed{background:rgba(63,185,80,.16);color:var(--ok)}
+  a{color:#7aa7ff}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Route nudge: widening a regex traded one bug for a worse one</h1>
+  <p class="sub">
+    OrchestKit PR #3990. Type a prompt and watch three versions of
+    <code>ALREADY_ROUTED_RE</code> disagree about whether the user already routed their work.
+  </p>
+
+  <p>
+    <code>executor-route-nudge</code> fires at most once per session when a prompt looks
+    build-shaped, reminding you that the executor skills carry specialist wiring. It stays
+    quiet when you have <em>already</em> routed, for example by typing
+    <code>/ork:implement</code>. Deciding "already routed" is one regex, and that regex went
+    through three versions in one afternoon.
+  </p>
+
+  <h2>Try it</h2>
+  <div class="panel">
+    <textarea id="inp" spellcheck="false">build a client from https://example.com/guide:setup and explain the auth flow</textarea>
+    <div class="presets">
+      <button data-p="build a client from https://example.com/guide:setup and explain the auth flow">URL with a colon path</button>
+      <button data-p="fix the flaky retry logic via /ork:fix-issue and report the root cause">routed to ork</button>
+      <button data-p="fix the failing preview deploy via /vercel:deploy and report what broke">routed to vercel</button>
+      <button data-p="implement cursor-based pagination for the sessions listing endpoint">not routed at all</button>
+      <button data-p="see https://docs.site/foo:bar for details and fix the broken upload handler">link plus real work</button>
+    </div>
+
+    <table>
+      <thead>
+        <tr><th>version</th><th>pattern</th><th>already routed?</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>original<br><span class="note">hardcoded</span></td>
+          <td class="re">/\/(?:ork|hq-ext):[a-z-]+/i</td>
+          <td id="r-orig"></td>
+        </tr>
+        <tr>
+          <td>widened<br><span class="flag regress">regression</span></td>
+          <td class="re">/\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i</td>
+          <td id="r-wide"></td>
+        </tr>
+        <tr>
+          <td>shipped<br><span class="flag fixed">fixed</span></td>
+          <td class="re">/(?:^|\s)\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i</td>
+          <td id="r-final"></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div id="verdict" class="verdict"></div>
+    <ul class="steps" id="steps"></ul>
+  </div>
+
+  <h2>What actually happened</h2>
+  <p>
+    The original named <code>ork</code> and <code>hq-ext</code> literally. That was two problems
+    at once. A consumer of the public plugin who typed <code>/vercel:deploy</code> had already
+    routed their work and got nudged to route it anyway, and a public OSS plugin should not carry
+    a private plugin's namespace in its shipped source.
+  </p>
+  <p>
+    Widening it to any <code>/&lt;plugin&gt;:&lt;skill&gt;</code> fixed both, and quietly broke
+    something bigger: <code>/guide:setup</code> inside an ordinary URL matches that shape. Any
+    prompt merely <em>containing</em> a link with a colon path stopped nudging. The old
+    hardcoded form never had that reach, so the fix was a net regression, and it was caught in
+    review rather than by a test.
+  </p>
+  <p>
+    The shipped version requires the token to stand alone: start of string, or preceded by
+    whitespace. Two regression tests now pin both directions, one per bug.
+  </p>
+
+  <h2>The lesson worth keeping</h2>
+  <p class="note">
+    Widening a pattern to remove a special case also widens what it accidentally matches.
+    The question to ask is not "does this now catch the case I wanted", it is
+    "what else just became catchable". Here the answer was every URL in every prompt.
+  </p>
+
+</div>
+
+<script>
+(function () {
+  var RES = {
+    orig:  /\/(?:ork|hq-ext):[a-z-]+/i,
+    wide:  /\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i,
+    final: /(?:^|\s)\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i
+  };
+  var MIN_GOAL_LENGTH = 40;
+  var BUILD_VERB_RE =
+    /^(?:please\s+|can you\s+|let'?s\s+)?(?:fix|debug|build|implement|create|add|scaffold|set up|refactor)\b/i;
+
+  var inp = document.getElementById('inp');
+  var verdict = document.getElementById('verdict');
+  var steps = document.getElementById('steps');
+
+  function mark(id, hit) {
+    var el = document.getElementById(id);
+    el.textContent = hit ? 'yes, stay silent' : 'no';
+    el.className = hit ? 'yes' : 'no';
+  }
+
+  function render() {
+    var s = inp.value;
+    mark('r-orig',  RES.orig.test(s));
+    mark('r-wide',  RES.wide.test(s));
+    var routed = RES.final.test(s);
+    mark('r-final', routed);
+
+    var longEnough = s.length >= MIN_GOAL_LENGTH;
+    var buildShaped = BUILD_VERB_RE.test(s.trim());
+    var nudges = longEnough && buildShaped && !routed;
+
+    verdict.className = 'verdict ' + (nudges ? 'v-nudge' : 'v-silent');
+    verdict.textContent = nudges
+      ? 'Shipped behaviour: the nudge FIRES. This prompt is build-shaped and carries no explicit route.'
+      : 'Shipped behaviour: SILENT. ' + (
+          !longEnough  ? 'Shorter than ' + MIN_GOAL_LENGTH + ' characters, so it reads as a command, not a goal.'
+        : !buildShaped ? 'No imperative build or fix verb at the start.'
+        :                'The user already routed explicitly.');
+
+    steps.innerHTML = '';
+    [
+      ['length >= ' + MIN_GOAL_LENGTH, longEnough, s.length + ' chars'],
+      ['build verb at start', buildShaped, buildShaped ? 'matched' : 'no match'],
+      ['already routed', routed, routed ? 'suppresses the nudge' : 'does not suppress']
+    ].forEach(function (row) {
+      var li = document.createElement('li');
+      li.innerHTML = '<b>' + (row[1] ? 'yes' : 'no ') + '</b>  ' + row[0] + '  (' + row[2] + ')';
+      steps.appendChild(li);
+    });
+  }
+
+  inp.addEventListener('input', render);
+  Array.prototype.forEach.call(document.querySelectorAll('.presets button'), function (b) {
+    b.addEventListener('click', function () { inp.value = b.getAttribute('data-p'); render(); });
+  });
+  render();
+})();
+</script>
+</body>
+</html>

--- a/docs/site/content/docs/reference/skills/doctor.mdx
+++ b/docs/site/content/docs/reference/skills/doctor.mdx
@@ -2035,10 +2035,14 @@ machine, and for every other user of the same repo.
 
 ## Example output, FAILING (what a typical machine prints today)
 
-Measured on the operator's real machine, 2026-08-09, CC 2.1.226. `~/.claude/settings.json`
-carries 20 top-level keys and `permissions.deny` holds 5 entries, all five of them MCP
-tool names (`mcp__hq-channels__whatsapp_send_image`, `…_send_audio`, `…_send_document`,
-`…_logout_session`, `…_email_send`). Not one is a credential-read rule.
+Measured on a real machine, 2026-08-09, CC 2.1.226. `~/.claude/settings.json` carries 20
+top-level keys and `permissions.deny` holds 5 entries, all five of them MCP tool names
+from a single private server (`mcp__&lt;server&gt;__&lt;tool&gt;`, four message-send tools and one
+session-logout). Not one is a credential-read rule.
+
+That shape is the common one and it is the point of this check: operators reach for
+`permissions.deny` to stop a specific noisy tool, not to close the credential-read lane.
+Five rules can look like a configured posture while covering nothing this check is about.
 
 ```
 +-- Check 16: Operator Settings Posture ----------------------------------+

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -1373,6 +1373,19 @@
         "generator"
       ],
       "date": "2026-09-07"
+    },
+    {
+      "slug": "route-nudge-regex-widening",
+      "source": "docs/chore--depersonalize-public-docs-hq-refs/route-nudge-regex.html",
+      "title": "Widening a regex traded one bug for a worse one",
+      "description": "executor-route-nudge stayed silent when you had already typed /ork:implement, but the check named ork and hq-ext literally, so a consumer typing /vercel:deploy was nudged anyway. Widening it to any /<plugin>:<skill> fixed that and quietly broke more: a colon path inside an ordinary URL matches the same shape, so any prompt containing a link stopped nudging. Type a prompt and watch all three versions disagree.",
+      "tags": [
+        "hooks",
+        "regression",
+        "regex",
+        "code-review"
+      ],
+      "date": "2026-09-08"
     }
   ]
 }

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -15,6 +15,21 @@ export interface LabEntry {
 
 export const LAB_ENTRIES: LabEntry[] = [
   {
+    "slug": "route-nudge-regex-widening",
+    "title": "Widening a regex traded one bug for a worse one",
+    "description": "executor-route-nudge stayed silent when you had already typed /ork:implement, but the check named ork and hq-ext literally, so a consumer typing /vercel:deploy was nudged anyway. Widening it to any /<plugin>:<skill> fixed that and quietly broke more: a colon path inside an ordinary URL matches the same shape, so any prompt containing a link stopped nudging. Type a prompt and watch all three versions disagree.",
+    "tags": [
+      "hooks",
+      "regression",
+      "regex",
+      "code-review"
+    ],
+    "date": "2026-09-08",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 9
+  },
+  {
     "slug": "glyph-examples-page",
     "title": "A page an agent can send a human to: the glyph examples block",
     "description": "The glyph docs page answered 200 but was a 33 KB dump of SKILL.md. Toggle before and after to see what a human routed to the URL now lands on: a curated block first (what it draws, the two picks, three real renders, the exact invocation) at a stable #examples anchor, generated from the skill's own examples/_featured.md. Any skill opts in by adding that one file.",

--- a/docs/site/public/lab/route-nudge-regex-widening.html
+++ b/docs/site/public/lab/route-nudge-regex-widening.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Route nudge: widening a regex traded one bug for a worse one</title>
+<style>
+  :root{
+    --bg:#0e1116; --panel:#161b22; --line:#2a313a; --ink:#e6edf3; --dim:#9aa7b4;
+    --ok:#3fb950; --bad:#f85149; --warn:#d29922; --accent:#7c3aed;
+    --mono:ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);
+       font:15px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif}
+  .wrap{max-width:920px;margin:0 auto;padding:40px 20px 80px}
+  h1{font-size:26px;line-height:1.25;margin:0 0 8px}
+  .sub{color:var(--dim);margin:0 0 28px}
+  h2{font-size:17px;margin:34px 0 12px;padding-top:18px;border-top:1px solid var(--line)}
+  code,kbd{font-family:var(--mono);font-size:.9em}
+  .panel{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:18px}
+  textarea{width:100%;min-height:74px;resize:vertical;background:#0b0e13;color:var(--ink);
+           border:1px solid var(--line);border-radius:8px;padding:11px 12px;font-family:var(--mono);font-size:13px}
+  textarea:focus{outline:none;border-color:var(--accent)}
+  .presets{display:flex;flex-wrap:wrap;gap:7px;margin:12px 0 0}
+  .presets button{background:#1d232c;color:var(--ink);border:1px solid var(--line);border-radius:999px;
+                  padding:5px 12px;font-size:12.5px;cursor:pointer}
+  .presets button:hover{border-color:var(--accent)}
+  table{width:100%;border-collapse:collapse;margin-top:16px;font-size:13.5px}
+  th,td{text-align:left;padding:9px 10px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{color:var(--dim);font-weight:600;font-size:12px;text-transform:uppercase;letter-spacing:.04em}
+  td.re{font-family:var(--mono);font-size:11.5px;color:var(--dim);max-width:270px;word-break:break-all}
+  .yes{color:var(--ok);font-weight:600}
+  .no{color:var(--bad);font-weight:600}
+  .verdict{margin-top:16px;padding:13px 15px;border-radius:8px;border:1px solid var(--line);font-size:14px}
+  .v-nudge{background:rgba(210,153,34,.10);border-color:rgba(210,153,34,.4)}
+  .v-silent{background:rgba(63,185,80,.10);border-color:rgba(63,185,80,.4)}
+  .steps{list-style:none;padding:0;margin:14px 0 0;font-family:var(--mono);font-size:12.5px}
+  .steps li{padding:4px 0;color:var(--dim)}
+  .steps b{color:var(--ink);font-weight:600}
+  p{margin:0 0 12px}
+  .note{color:var(--dim);font-size:13.5px}
+  .flag{display:inline-block;padding:1px 7px;border-radius:4px;font-size:11px;font-weight:600;
+        font-family:var(--mono);letter-spacing:.02em}
+  .flag.regress{background:rgba(248,81,73,.16);color:var(--bad)}
+  .flag.fixed{background:rgba(63,185,80,.16);color:var(--ok)}
+  a{color:#7aa7ff}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <h1>Route nudge: widening a regex traded one bug for a worse one</h1>
+  <p class="sub">
+    OrchestKit PR #3990. Type a prompt and watch three versions of
+    <code>ALREADY_ROUTED_RE</code> disagree about whether the user already routed their work.
+  </p>
+
+  <p>
+    <code>executor-route-nudge</code> fires at most once per session when a prompt looks
+    build-shaped, reminding you that the executor skills carry specialist wiring. It stays
+    quiet when you have <em>already</em> routed, for example by typing
+    <code>/ork:implement</code>. Deciding "already routed" is one regex, and that regex went
+    through three versions in one afternoon.
+  </p>
+
+  <h2>Try it</h2>
+  <div class="panel">
+    <textarea id="inp" spellcheck="false">build a client from https://example.com/guide:setup and explain the auth flow</textarea>
+    <div class="presets">
+      <button data-p="build a client from https://example.com/guide:setup and explain the auth flow">URL with a colon path</button>
+      <button data-p="fix the flaky retry logic via /ork:fix-issue and report the root cause">routed to ork</button>
+      <button data-p="fix the failing preview deploy via /vercel:deploy and report what broke">routed to vercel</button>
+      <button data-p="implement cursor-based pagination for the sessions listing endpoint">not routed at all</button>
+      <button data-p="see https://docs.site/foo:bar for details and fix the broken upload handler">link plus real work</button>
+    </div>
+
+    <table>
+      <thead>
+        <tr><th>version</th><th>pattern</th><th>already routed?</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>original<br><span class="note">hardcoded</span></td>
+          <td class="re">/\/(?:ork|hq-ext):[a-z-]+/i</td>
+          <td id="r-orig"></td>
+        </tr>
+        <tr>
+          <td>widened<br><span class="flag regress">regression</span></td>
+          <td class="re">/\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i</td>
+          <td id="r-wide"></td>
+        </tr>
+        <tr>
+          <td>shipped<br><span class="flag fixed">fixed</span></td>
+          <td class="re">/(?:^|\s)\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i</td>
+          <td id="r-final"></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div id="verdict" class="verdict"></div>
+    <ul class="steps" id="steps"></ul>
+  </div>
+
+  <h2>What actually happened</h2>
+  <p>
+    The original named <code>ork</code> and <code>hq-ext</code> literally. That was two problems
+    at once. A consumer of the public plugin who typed <code>/vercel:deploy</code> had already
+    routed their work and got nudged to route it anyway, and a public OSS plugin should not carry
+    a private plugin's namespace in its shipped source.
+  </p>
+  <p>
+    Widening it to any <code>/&lt;plugin&gt;:&lt;skill&gt;</code> fixed both, and quietly broke
+    something bigger: <code>/guide:setup</code> inside an ordinary URL matches that shape. Any
+    prompt merely <em>containing</em> a link with a colon path stopped nudging. The old
+    hardcoded form never had that reach, so the fix was a net regression, and it was caught in
+    review rather than by a test.
+  </p>
+  <p>
+    The shipped version requires the token to stand alone: start of string, or preceded by
+    whitespace. Two regression tests now pin both directions, one per bug.
+  </p>
+
+  <h2>The lesson worth keeping</h2>
+  <p class="note">
+    Widening a pattern to remove a special case also widens what it accidentally matches.
+    The question to ask is not "does this now catch the case I wanted", it is
+    "what else just became catchable". Here the answer was every URL in every prompt.
+  </p>
+
+</div>
+
+<script>
+(function () {
+  var RES = {
+    orig:  /\/(?:ork|hq-ext):[a-z-]+/i,
+    wide:  /\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i,
+    final: /(?:^|\s)\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i
+  };
+  var MIN_GOAL_LENGTH = 40;
+  var BUILD_VERB_RE =
+    /^(?:please\s+|can you\s+|let'?s\s+)?(?:fix|debug|build|implement|create|add|scaffold|set up|refactor)\b/i;
+
+  var inp = document.getElementById('inp');
+  var verdict = document.getElementById('verdict');
+  var steps = document.getElementById('steps');
+
+  function mark(id, hit) {
+    var el = document.getElementById(id);
+    el.textContent = hit ? 'yes, stay silent' : 'no';
+    el.className = hit ? 'yes' : 'no';
+  }
+
+  function render() {
+    var s = inp.value;
+    mark('r-orig',  RES.orig.test(s));
+    mark('r-wide',  RES.wide.test(s));
+    var routed = RES.final.test(s);
+    mark('r-final', routed);
+
+    var longEnough = s.length >= MIN_GOAL_LENGTH;
+    var buildShaped = BUILD_VERB_RE.test(s.trim());
+    var nudges = longEnough && buildShaped && !routed;
+
+    verdict.className = 'verdict ' + (nudges ? 'v-nudge' : 'v-silent');
+    verdict.textContent = nudges
+      ? 'Shipped behaviour: the nudge FIRES. This prompt is build-shaped and carries no explicit route.'
+      : 'Shipped behaviour: SILENT. ' + (
+          !longEnough  ? 'Shorter than ' + MIN_GOAL_LENGTH + ' characters, so it reads as a command, not a goal.'
+        : !buildShaped ? 'No imperative build or fix verb at the start.'
+        :                'The user already routed explicitly.');
+
+    steps.innerHTML = '';
+    [
+      ['length >= ' + MIN_GOAL_LENGTH, longEnough, s.length + ' chars'],
+      ['build verb at start', buildShaped, buildShaped ? 'matched' : 'no match'],
+      ['already routed', routed, routed ? 'suppresses the nudge' : 'does not suppress']
+    ].forEach(function (row) {
+      var li = document.createElement('li');
+      li.innerHTML = '<b>' + (row[1] ? 'yes' : 'no ') + '</b>  ' + row[0] + '  (' + row[2] + ')';
+      steps.appendChild(li);
+    });
+  }
+
+  inp.addEventListener('input', render);
+  Array.prototype.forEach.call(document.querySelectorAll('.presets button'), function (b) {
+    b.addEventListener('click', function () { inp.value = b.getAttribute('data-p'); render(); });
+  });
+  render();
+})();
+</script>
+</body>
+</html>

--- a/plugins/ork/skills/doctor/references/settings-posture.md
+++ b/plugins/ork/skills/doctor/references/settings-posture.md
@@ -138,10 +138,14 @@ machine, and for every other user of the same repo.
 
 ## Example output, FAILING (what a typical machine prints today)
 
-Measured on the operator's real machine, 2026-08-09, CC 2.1.226. `~/.claude/settings.json`
-carries 20 top-level keys and `permissions.deny` holds 5 entries, all five of them MCP
-tool names (`mcp__hq-channels__whatsapp_send_image`, `…_send_audio`, `…_send_document`,
-`…_logout_session`, `…_email_send`). Not one is a credential-read rule.
+Measured on a real machine, 2026-08-09, CC 2.1.226. `~/.claude/settings.json` carries 20
+top-level keys and `permissions.deny` holds 5 entries, all five of them MCP tool names
+from a single private server (`mcp__<server>__<tool>`, four message-send tools and one
+session-logout). Not one is a credential-read rule.
+
+That shape is the common one and it is the point of this check: operators reach for
+`permissions.deny` to stop a specific noisy tool, not to close the credential-read lane.
+Five rules can look like a configured posture while covering nothing this check is about.
 
 ```
 +-- Check 16: Operator Settings Posture ----------------------------------+

--- a/scripts/validate-fn-hooks-canary.sh
+++ b/scripts/validate-fn-hooks-canary.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Assert the upstream Function Hooks module contract has not moved (#3917).
+#
+# Runs `claude plugin validate` on tests/fixtures/fn-hooks-canary and requires
+# the reported events and $ capabilities to match exactly. A rename or removal
+# upstream turns this red, which is the point: OrchestKit is not migrating, so
+# this is the mechanical half of "keep watching".
+#
+# Offline. No model call, no API key. Skips cleanly when the CLI is absent.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURE="$REPO_ROOT/tests/fixtures/fn-hooks-canary"
+
+# Measured on CC 2.1.263, 2026-09-08. Order is the module's registration order.
+EXPECTED_HOOKS='tool.call{tool=Bash}, PreToolUse{}, session.start{}, engine.create{}, prompt.submit{}'
+EXPECTED_CALLS='$.ui.log'
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "SKIP: claude CLI not on PATH"
+  exit 0
+fi
+if ! claude --version >/dev/null 2>&1; then
+  echo "SKIP: claude CLI present but not runnable"
+  exit 0
+fi
+
+# The event vocabulary this fixture pins lands at 2.1.259, the same release that
+# first carries CLAUDE_CODE_ENABLE_FUNCTION_HOOKS. Measured across seven binaries
+# (#3917): at 2.1.251 and 2.1.257 the `modules` key is parsed but `session.start`
+# is "not an event", so an older host fails here for a reason that is not drift.
+# Skip rather than fail, and name the version so the skip is never mistaken for a
+# pass.
+MIN_CC="2.1.259"
+CC_RAW="$(claude --version 2>&1)"
+CC_VER="$(printf '%s' "$CC_RAW" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+if [ -z "$CC_VER" ]; then
+  echo "SKIP: could not parse a version out of: $CC_RAW"
+  exit 0
+fi
+LOWEST="$(printf '%s\n%s\n' "$CC_VER" "$MIN_CC" | sort -V | head -1)"
+if [ "$CC_VER" != "$MIN_CC" ] && [ "$LOWEST" = "$CC_VER" ]; then
+  echo "SKIP: CC $CC_VER is below $MIN_CC; the function-hooks event vocabulary is absent"
+  exit 0
+fi
+
+echo "claude: $CC_RAW"
+echo "fixture: ${FIXTURE#"$REPO_ROOT"/}"
+
+# Capture rc separately: a swallowed non-zero here would read as a clean pass.
+set +e
+OUT="$(claude plugin validate "$FIXTURE" 2>&1)"
+RC=$?
+set -e
+
+if [ "$RC" -ne 0 ]; then
+  echo "FAIL: plugin validate exited $RC"
+  printf '%s\n' "$OUT"
+  exit 1
+fi
+
+# The validator prints one "hooks:" and one "calls:" line per module.
+ACTUAL_HOOKS="$(printf '%s\n' "$OUT" | sed -n 's/.*canary\.ts hooks: //p' | head -1)"
+ACTUAL_CALLS="$(printf '%s\n' "$OUT" | sed -n 's/.*canary\.ts calls: //p' | head -1)"
+
+if [ -z "$ACTUAL_HOOKS" ]; then
+  echo "FAIL: validator printed no 'hooks:' line for canary.ts."
+  echo "      The 'modules' key may no longer be followed."
+  printf '%s\n' "$OUT"
+  exit 1
+fi
+
+FAILED=0
+if [ "$ACTUAL_HOOKS" != "$EXPECTED_HOOKS" ]; then
+  echo "FAIL: registered events moved."
+  echo "  expected: $EXPECTED_HOOKS"
+  echo "  actual:   $ACTUAL_HOOKS"
+  FAILED=1
+fi
+if [ "$ACTUAL_CALLS" != "$EXPECTED_CALLS" ]; then
+  echo "FAIL: \$ capability names moved."
+  echo "  expected: $EXPECTED_CALLS"
+  echo "  actual:   $ACTUAL_CALLS"
+  FAILED=1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+  echo
+  echo "Upstream changed the Function Hooks contract. Re-read #3917 before"
+  echo "updating the expected values, and record what moved."
+  exit 1
+fi
+
+echo "PASS: events and capabilities unchanged"
+echo "  hooks: $ACTUAL_HOOKS"
+echo "  calls: $ACTUAL_CALLS"

--- a/src/hooks/src/__tests__/prompt/executor-route-nudge.test.ts
+++ b/src/hooks/src/__tests__/prompt/executor-route-nudge.test.ts
@@ -109,6 +109,31 @@ describe('prompt/executor-route-nudge', () => {
     ).toBe('');
   });
 
+  // Any plugin namespace counts, not just ork. A consumer who typed
+  // /vercel:deploy had already routed their work and was nudged anyway.
+  test('silent when the user routes to a non-ork plugin', () => {
+    expect(
+      contextOf(
+        executorRouteNudge(
+          makeInput('fix the failing preview deploy via /vercel:deploy and report what broke'),
+        ),
+      ),
+    ).toBe('');
+  });
+
+  // Regression for a CodeRabbit finding on PR #3990: widening the namespace
+  // without requiring a standalone token made any URL with a colon path match,
+  // so a prompt merely CONTAINING a link silently suppressed the nudge.
+  test('a colon path inside a URL does not count as routing', () => {
+    expect(
+      contextOf(
+        executorRouteNudge(
+          makeInput('build a client from https://example.com/guide:setup and explain the auth flow'),
+        ),
+      ),
+    ).not.toBe('');
+  });
+
   test('accepts polite/imperative openers', () => {
     const result = executorRouteNudge(
       makeInput('please implement cursor-based pagination for the sessions listing endpoint'),

--- a/src/hooks/src/lib/telemetry-http-sink.ts
+++ b/src/hooks/src/lib/telemetry-http-sink.ts
@@ -7,7 +7,8 @@
  * Cross-Project Analytics today writes JSONL to ~/.claude/analytics/ via
  * appendAnalytics(). That gives a great per-machine view but no fleet-wide
  * aggregation. This sink optionally mirrors each entry to an HTTP endpoint you
- * configure, so a fleet can be analysed across hosts. Off unless you set one.
+ * configure, so a fleet can be analysed across hosts. It stays off until BOTH a
+ * receiver URL and a bearer token resolve; either one alone is still a no-op.
  *
  * Design tenets (all enforced below):
  *

--- a/src/hooks/src/lib/telemetry-http-sink.ts
+++ b/src/hooks/src/lib/telemetry-http-sink.ts
@@ -2,12 +2,12 @@
 // Created: 2026-05-12
 
 /**
- * Telemetry HTTP sink — dual-write to yonatan-hq platform.
+ * Telemetry HTTP sink: optional dual-write to an aggregation endpoint.
  *
  * Cross-Project Analytics today writes JSONL to ~/.claude/analytics/ via
  * appendAnalytics(). That gives a great per-machine view but no fleet-wide
- * aggregation. This sink mirrors each entry to platform's /api/hooks/cc-event
- * endpoint so the Intelligence Tab can deep-dive across all hosts.
+ * aggregation. This sink optionally mirrors each entry to an HTTP endpoint you
+ * configure, so a fleet can be analysed across hosts. Off unless you set one.
  *
  * Design tenets (all enforced below):
  *
@@ -79,8 +79,8 @@ export function resolveSinkToken(): string | null {
  * Convert an analytics JSONL filename into the platform's CCHookEvent
  * wire value. `skill-usage.jsonl` → `OrkSkillUsage`.
  *
- * Mirrors the names registered in
- * yonatan-hq/platform: apps/api/app/schemas/cc_hooks/_enums.py.
+ * These names are the wire contract with whatever receiver you point the sink
+ * at; the reference implementation registers the same enum server-side.
  * Any filename that doesn't resolve to a known event returns null so the
  * sink no-ops rather than emitting a `Generic` row.
  */

--- a/src/hooks/src/prompt/executor-route-nudge.ts
+++ b/src/hooks/src/prompt/executor-route-nudge.ts
@@ -39,8 +39,15 @@ const MIN_GOAL_LENGTH = 40;
 const BUILD_VERB_RE =
   /^(?:please\s+|can you\s+|let'?s\s+)?(?:fix|debug|build|implement|create|add|scaffold|set up|refactor)\b/i;
 
-/** The user is already routing — do not second-guess an explicit invocation. */
-const ALREADY_ROUTED_RE = /\/(?:ork|hq-ext):[a-z-]+/i;
+/**
+ * The user is already routing — do not second-guess an explicit invocation.
+ *
+ * Any `/<plugin>:<skill>` counts, not a hardcoded list. The earlier form named
+ * `ork` and `hq-ext` only, which meant a consumer who typed `/vercel:deploy` or
+ * `/posthog:exec` was still nudged to route work they had already routed. It
+ * also put a private plugin's namespace in the public plugin's shipped source.
+ */
+const ALREADY_ROUTED_RE = /\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i;
 
 function flagPath(sessionId: string): string {
   // #1826-class hardening: session_id is untrusted hook input. Route it

--- a/src/hooks/src/prompt/executor-route-nudge.ts
+++ b/src/hooks/src/prompt/executor-route-nudge.ts
@@ -46,8 +46,14 @@ const BUILD_VERB_RE =
  * `ork` and `hq-ext` only, which meant a consumer who typed `/vercel:deploy` or
  * `/posthog:exec` was still nudged to route work they had already routed. It
  * also put a private plugin's namespace in the public plugin's shipped source.
+ *
+ * The token must stand alone. Widening the namespace without this made
+ * `https://example.com/guide:setup` match, so a prompt containing any URL with a
+ * colon path silently suppressed the nudge. The old hardcoded form did not have
+ * that reach, so the leading-boundary requirement is what keeps the widening from
+ * being a regression.
  */
-const ALREADY_ROUTED_RE = /\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i;
+const ALREADY_ROUTED_RE = /(?:^|\s)\/[a-z][a-z0-9-]*:[a-z][a-z0-9-]+/i;
 
 function flagPath(sessionId: string): string {
   // #1826-class hardening: session_id is untrusted hook input. Route it

--- a/src/skills/doctor/references/settings-posture.md
+++ b/src/skills/doctor/references/settings-posture.md
@@ -138,10 +138,14 @@ machine, and for every other user of the same repo.
 
 ## Example output, FAILING (what a typical machine prints today)
 
-Measured on the operator's real machine, 2026-08-09, CC 2.1.226. `~/.claude/settings.json`
-carries 20 top-level keys and `permissions.deny` holds 5 entries, all five of them MCP
-tool names (`mcp__hq-channels__whatsapp_send_image`, `…_send_audio`, `…_send_document`,
-`…_logout_session`, `…_email_send`). Not one is a credential-read rule.
+Measured on a real machine, 2026-08-09, CC 2.1.226. `~/.claude/settings.json` carries 20
+top-level keys and `permissions.deny` holds 5 entries, all five of them MCP tool names
+from a single private server (`mcp__<server>__<tool>`, four message-send tools and one
+session-logout). Not one is a credential-read rule.
+
+That shape is the common one and it is the point of this check: operators reach for
+`permissions.deny` to stop a specific noisy tool, not to close the credential-read lane.
+Five rules can look like a configured posture while covering nothing this check is about.
 
 ```
 +-- Check 16: Operator Settings Posture ----------------------------------+

--- a/tests/fixtures/fn-hooks-canary/.claude-plugin/plugin.json
+++ b/tests/fixtures/fn-hooks-canary/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "fn-hooks-canary",
+  "version": "0.0.1",
+  "description": "Fixture-only plugin. Not shipped, not installed. Pins the Function Hooks module contract so CI notices when upstream moves it (orchestkit#3917).",
+  "author": { "name": "OrchestKit" }
+}

--- a/tests/fixtures/fn-hooks-canary/README.md
+++ b/tests/fixtures/fn-hooks-canary/README.md
@@ -1,0 +1,40 @@
+# fn-hooks-canary
+
+Fixture-only plugin. It is never installed, never shipped, and its handlers never
+run. `claude plugin validate` parses it statically in CI.
+
+## Why it exists
+
+OrchestKit is not migrating to Function Hooks (upstream anthropics/claude-code#91870,
+tracked here as #3917). 78 of our 152 hook entries, across 28 events, have no native
+address at all, and the identifiers are still moving. The decision is to keep
+watching.
+
+This fixture makes that watch mechanical instead of manual. It pins the parts of the
+module contract we measured on CC 2.1.263, so CI notices when upstream moves one:
+
+- the `modules` key in `hooks.json` is followed and the TypeScript is parsed
+- `tool.call` takes a matcher, and the matcher is echoed back
+- bare `PreToolUse` is accepted; no other bare event name is
+- `session.start` and `engine.create` are spelled that way
+- `$.ui.log` is the capability name
+
+## What CI asserts
+
+`scripts/validate-fn-hooks-canary.sh` runs `claude plugin validate` on this
+directory and requires the reported events and capabilities to match exactly. A
+rename upstream (for example the announced but not yet shipped `fs.readFile` to
+`fs.read`) turns the job red, which is the signal we want.
+
+## Two limits, both measured
+
+`claude plugin validate` checks **shape, not membership**: `banana.PreToolUse` and
+`$.zzz.nope` both validate clean. And it is not the runtime loader, so it cannot
+observe the fold, skip semantics, or `next.to`. Do not read a pass here as proof a
+noun exists.
+
+## Version floor
+
+The `modules` key is parsed as far back as CC 2.1.250, below our 2.1.251 support
+floor, so this fixture needs no floor bump. Measured across seven binaries; see
+#3917.

--- a/tests/fixtures/fn-hooks-canary/hooks/hooks-handlers/canary.ts
+++ b/tests/fixtures/fn-hooks-canary/hooks/hooks-handlers/canary.ts
@@ -1,0 +1,24 @@
+// Fixture only. Never loaded at runtime; `claude plugin validate` parses it statically.
+// Each registration below pins one fact measured on CC 2.1.263 (orchestkit#3917).
+import type { Register } from "claude-code";
+
+export const register: Register = (on) => {
+  // Pins: `tool.call` exists and carries a matcher.
+  on("tool.call", { tool: "Bash" }, async ($, e, next) => next(e));
+
+  // Pins: bare `PreToolUse` is the one legacy name the validator accepts.
+  on("PreToolUse", {}, async ($, e, next) => next(e));
+
+  // Pins: these lifecycle nouns exist. If upstream adds `session.stop` or
+  // similar, this fixture keeps passing; the assertion in CI is what notices.
+  on("session.start", {}, async ($, e, next) => next(e));
+  on("engine.create", {}, async ($, e, next) => next(e));
+
+  // Pins the `$` surface names we would migrate onto first. Note the validator
+  // reports these without checking they exist, so this is a naming pin, not an
+  // existence proof. `$.ui.log` is absent inside engine.create (measured).
+  on("prompt.submit", {}, async ($, e, next) => {
+    $.ui.log("canary");
+    return next(e);
+  });
+};

--- a/tests/fixtures/fn-hooks-canary/hooks/hooks.json
+++ b/tests/fixtures/fn-hooks-canary/hooks/hooks.json
@@ -1,0 +1,5 @@
+{
+  "description": "Canary for the upstream Function Hooks `modules` contract. See tests/fixtures/fn-hooks-canary/README.md.",
+  "modules": ["./hooks-handlers/canary.ts"],
+  "hooks": {}
+}


### PR DESCRIPTION
## Severity first: none of this needed pulling today

OrchestKit is public (231 stars, 24 forks) and the doctor reference ships inside the
built plugin, so this was worth checking properly rather than assuming. It checks out
as hygiene, not an incident.

Swept `src/` and `plugins/` for the shapes that would make it urgent:

| looked for | result |
|---|---|
| real credentials (`ghp_`, `sk-`, `ops_`) | only redactor **test fixtures**, fake by design |
| hostnames | only `orchestkit.yonyon.ai`, the project's own public docs site |
| phone numbers, operator email | none |
| hardcoded telemetry endpoint or token | none; both resolve from env, sink no-ops without them |

What actually leaked was **names**: five MCP tool names belonging to a private
consumer plugin, one hardcoded namespace, and a private repo's file path in a
comment. No credential, no endpoint, no personal datum. Nothing to rotate.

## The three

**1. `doctor/references/settings-posture.md`, the one that mattered.** Published five
real MCP tool names from a private server, attributed to "the operator's real
machine", and shipped in the built plugin since 2026-08-09. The passage only ever
needed the *shape*: five deny rules, all of them tool names, none a credential-read
rule. It now says that generically, and says why that shape is the common one, which
makes it a better example than the original.

**2. `executor-route-nudge.ts`, and this one was also a real bug.**
`ALREADY_ROUTED_RE` hardcoded `/(?:ork|hq-ext):/`. A consumer typing `/vercel:deploy`
or `/posthog:exec` had already routed their work and got nudged to route it anyway.
Now any `/<plugin>:<skill>` counts. Fixing the leak fixes the behaviour.

**3. `telemetry-http-sink.ts`, comments only.** The header named a private deployment
and cited a private repo's internal file path as the wire contract. Genericised.

## Deliberately not changed

The remaining `hq-ext` mentions in the sink explain why the `ORK_HQ_TELEMETRY_*` env
vars are named as they are. Renaming those env vars would break existing users for no
security gain, so it stays and is a separate conversation if wanted.

## Verification

- `executor-route-nudge` tests: **9 passed**
- build clean; redaction confirmed present in the built artifact (`grep -c hq-channels
  plugins/ork/.../settings-posture.md` returns 0, was 1)
- `hooks/dist` regenerated but **not staged**, per #3578
- pre-commit: component counts, frontmatter schema, quick lint all OK

Two tests fail in `run-hook-verdict-telemetry.test.ts` and they are **not from this
change**: both pass with the sandbox disabled, the `telemetry-http-sink` diff is
comment-only, and that test imports neither touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tFBz1xmrTpEYmv27Qozjb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Explicit skill routes now avoid unnecessary routing prompts, including plugin skills such as `/vercel:deploy` and `/posthog:exec`.

* **Documentation**
  * Updated operator settings guidance with clearer, generalized examples of tool-deny rules.
  * Clarified telemetry documentation to reference any configured aggregation endpoint.

* **Chores**
  * Added automated contract checks to detect upstream Function Hooks changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Playground

https://orchestkit.yonyon.ai/lab/route-nudge-regex-widening.html

Runs all three versions of `ALREADY_ROUTED_RE` against whatever you type and shows
them disagreeing, plus the full nudge decision. Presets include the case CodeRabbit
caught: a colon path inside an ordinary URL.

This branch triggers the gate legitimately. `ci.yml`'s auto-skip list is
`^(dependabot/|release-please|renovate/|chore/cc-snapshot-|ci/)`; plain `chore/` is
not on it, and this PR touches `src/hooks/` and `src/skills/`, neither of which is
INERT. Sibling PR #3989 skipped the same gate only because its branch starts with
`ci/`. Renaming this branch would have dodged the gate rather than satisfied it.

## CodeRabbit findings, both verified and both correct

**Route regex, and it was a regression I introduced in this PR.** Widening
`ALREADY_ROUTED_RE` from the hardcoded `ork|hq-ext` to any `/<plugin>:<skill>` also
made it match a colon path inside a URL, so a prompt merely containing
`https://example.com/guide:setup` silently suppressed the nudge. The old hardcoded
form had no such reach, so the widening traded one bug for a worse one. Now requires
a standalone token. Measured across 6 cases before and after; two regression tests
added, one per direction. **11 pass, was 9.**

**Sink comment.** `postAnalyticsToSink` returns early on a missing URL (line 193)
AND on a missing token (line 199), so the "Off unless you set one" line this PR
added understated it. Corrected to say both are required.
