### PR TITLE
ci(playground): treat .claude/rules/ as inert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,7 +362,18 @@ jobs:
           # one audit file plus a one-line upper bound in pyproject.toml (which
           # is already exempt). Requiring a hand-authored interactive page for
           # an evidence record is the tax this list exists to remove.
-          INERT='^(README\.md|CHANGELOG\.md|CONTRIBUTING\.md|SECURITY\.md|CODE_OF_CONDUCT\.md|LICENSE|\.github/.*|vercel\.json|[^/]*\.toml|docs/[^/]*--[^/]*/.*|docs/playgrounds/.*|docs/audits/.*)$'
+          # `.claude/rules/` holds the agent-facing rule texts this repo writes for
+          # itself. They are repo-internal instructions, not product: there is no
+          # user-facing behaviour to demonstrate in an interactive page, and a
+          # playground about a rule amendment is a page about a page. Same
+          # circularity the three widenings above already removed, hit a fourth time
+          # on #3993, a one-file edit to .claude/rules/hooks-development.md that this
+          # gate demanded a hand-authored playground for.
+          #
+          # Scoped to `rules/` deliberately, NOT all of `.claude/`. `.claude/skills/`
+          # and `.claude/hooks/` would be real behaviour a reviewer should be able to
+          # open, and the fail-closed property below is the thing worth keeping.
+          INERT='^(README\.md|CHANGELOG\.md|CONTRIBUTING\.md|SECURITY\.md|CODE_OF_CONDUCT\.md|LICENSE|\.github/.*|vercel\.json|[^/]*\.toml|docs/[^/]*--[^/]*/.*|docs/playgrounds/.*|docs/audits/.*|\.claude/rules/.*)$'
 
           FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || true)
           if [ -z "$FILES" ]; then


### PR DESCRIPTION
## What

One line of the `INERT` regex in `ci.yml`'s playground gate, plus the comment
explaining it. `.claude/rules/**` no longer requires a hand-authored playground.

## Trigger and precedent

**Trigger: #3993**, a one-file edit to `.claude/rules/hooks-development.md`. The gate
failed at "Check playground exists" and demanded an interactive page for a rule-text
change.

That is the fourth time this gate has taxed a diff with nothing to demonstrate, and
this file's own comments record the previous three and the same fix each time:

| PR | diff | outcome |
|---|---|---|
| **#3193** | a one-line `README.md` docs diff | widened INERT |
| **#3495** | a two-line Python example under `src/skills/` | widened INERT |
| **#3845** | a dated audit record plus an already-exempt `pyproject` bound | widened INERT |

`.claude/rules/` holds the agent-facing rule texts this repo writes for itself. They
are repo-internal instructions, not product. There is nothing user-facing to
demonstrate, and a playground about a rule amendment is a page about a page, which is
the exact circularity the `docs/playgrounds/` and `docs/audits/` widenings already
removed.

## Deliberately narrow

Scoped to `rules/`, **not** all of `.claude/`. `.claude/skills/` and `.claude/hooks/`
are real behaviour a reviewer should be able to open, and the fail-closed property of
this list ("a changed file matching nothing here still REQUIRES a playground") is the
thing worth keeping.

## Verified both directions

Run against the workflow's own here-string test, 9 cases, not just the happy one:

| files | verdict |
|---|---|
| `.claude/rules/hooks-development.md` | SKIP (the fix) |
| `.github/workflows/ci.yml` | SKIP (already inert) |
| `.claude/skills/foo/SKILL.md` | **still REQUIRED** |
| `.claude/hooks/thing.ts` | **still REQUIRED** |
| `src/hooks/src/prompt/executor-route-nudge.ts` | **still REQUIRED** |
| `.claude/rules/…` **plus** `src/skills/doctor/SKILL.md` | **still REQUIRED** |
| `docs/audits/`, `docs/playgrounds/`, `README.md` | SKIP, unchanged |

The mixed-diff row is the one that matters: adding a rules file to a real feature PR
does not buy an exemption.

## Note on this PR's own gate

PR Playground will skip here, and not because of the branch name. `.github/.*` has
been on the INERT list since long before this change, so a one-file `ci.yml` diff is
inert by path regardless. The `ci/` branch prefix would also skip it, which is
honest for a CI-only change rather than a way around the gate.

`actionlint` passes (pre-commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tFBz1xmrTpEYmv27Qozjb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated validation so changes limited to designated rule files can pass without requiring an interactive playground.
  - Other configuration areas continue to undergo the existing validation checks.
  - Added documentation clarifying the scope and rationale of this exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->