### PR TITLE
ci(deps): ignore vitest major under /src/hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -105,6 +105,30 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # vitest MAJOR is a migration for this manifest, not a bump. Tracked in
+      # #3981, which measured the real API breakage on #3980: `bench` is gone
+      # from the vitest root export (TypeError plus TS2724),
+      # `describe.sequential` is removed (TS2339), and three mock-helper return
+      # types can no longer be named (TS2883). None of that is fixable by
+      # rebasing, and #3980 was reopened weekly on the hope that it was.
+      #
+      # The bump is also structurally unlandable by Dependabot regardless of the
+      # API breakage: the tracked generated mirror plugins/ork/hooks/package.json
+      # sits inside the build-drift roster and Dependabot never runs a build
+      # (#3971). That gate fires BEFORE the suites, so a red here never even
+      # reached the vitest code, which is how the migration went unnoticed.
+      #
+      # Scoped to major only. Minor and patch keep flowing, and keep using the
+      # `vitest` group above so the runner and its coverage provider stay in
+      # lockstep (#3976, ERESOLVE when they split across majors).
+      #
+      # REMOVE THIS when #3981 lands: it is a pause on a known migration, not a
+      # decision to stay on vitest 4.
+      - dependency-name: "vitest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitest/*"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 5
 
   # ── npm: docs/site (Next.js docs site) ──────────────────────────────


### PR DESCRIPTION
## What

One `ignore:` block on the `/src/hooks` npm entry in `.github/dependabot.yml`, scoped to
**major only**, plus the comment explaining it and naming its removal condition.

Closes the loop on #3980, which is now closed pointing at #3981.

## Why

**vitest 5 is a migration for this manifest, not a bump.** #3981 measured the real API
breakage: `bench` is gone from the vitest root export (TypeError plus TS2724),
`describe.sequential` is removed (TS2339), and three mock-helper return types can no longer
be named (TS2883). None of that is fixable by rebasing, which is what #3980 kept getting.

**Two blockers were stacked, and the first hid the second.** Independently of the API
breakage, the bump is structurally unlandable by Dependabot: the tracked generated mirror
`plugins/ork/hooks/package.json` sits inside the build-drift roster and Dependabot never
runs a build (#3971). That gate fires **before** the suites, so on #3980's last head
(`ab028ea0`) `Unit Tests (node 22)` and all four TypeScript shards read MISSING. Every red
that PR ever showed stopped short of executing any vitest code. That is why a real
migration looked like flaky CI for a week.

## Scope

Major only. Minor and patch keep flowing and keep using the `vitest` group, so the runner
and its coverage provider stay in lockstep (#3976: they ERESOLVE when they split across
majors, measured on #3966).

Same shape as the major-ignores this file already carries for `typescript` under
`/orchestkit-demos` and `node` under the docker manifest.

## Verified

Checked with a YAML parse rather than by eye, five assertions:

| assertion | result |
|---|---|
| exactly one `/src/hooks` npm entry | ok |
| its ignore names exactly `vitest` and `@vitest/*` | ok |
| every ignore entry is `version-update:semver-major` only | ok |
| the `vitest` group survives and still has no `update-types` | ok |
| exactly one file changed | ok |

The fourth row is the one that matters: if the group had gained `update-types`, minor and
patch would stop moving in lockstep and reintroduce the #3976 ERESOLVE.

## Not a decision to stay on vitest 4

The comment says so in the file and names **#3981** as the removal condition. #3981 stays
open as the planned migration lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tFBz1xmrTpEYmv27Qozjb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured dependency update management to continue receiving minor and patch updates while excluding major updates for testing packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->