### PR TITLE
docs(site): animate the community live-room with a daily bot

### DIFF
--- a/docs/docs--community-live-room/community-doors.html
+++ b/docs/docs--community-live-room/community-doors.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<!--
+  USER-STORY PLAYER · community kinetic grid + bento doors
+  Conforms to: shared/rules/playground-visual-standard.md
+  Persona: warm-glass. Zero dependencies. Single file.
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Community doors: kinetic mesh, live-room example</title>
+<meta name="description" content="Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.">
+<style>
+  :root {
+    --pg-bg: hsl(20 14% 7%);
+    --pg-ink: hsl(28 20% 94%);
+    --pg-muted: hsl(28 10% 64%);
+    --pg-faint: hsl(28 8% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(160 68% 45%);
+    --pg-accent-deep: hsl(166 70% 30%);
+    --pg-warm: hsl(38 95% 60%);
+    --pg-shadow: 0 20px 60px -22px hsl(20 40% 2% / 0.7), 0 4px 12px -6px hsl(20 40% 2% / 0.5);
+    --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(160 68% 45% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(38 95% 60% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 920px; margin: 0 auto; padding: 26px 22px 40px; display: flex; flex-direction: column; gap: 18px; }
+  .head { display: flex; align-items: flex-start; gap: 14px; }
+  .logo { width: 46px; height: 46px; border-radius: 14px; flex: none; display: grid; place-items: center; font-size: 23px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: 0 8px 22px -8px hsl(160 68% 40% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 62ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 7px 13px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 11px; padding: 10px 14px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink); transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent; color: hsl(160 40% 8%); box-shadow: 0 10px 26px -12px hsl(160 68% 40% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; }
+  .hint b { color: var(--pg-muted); }
+  .stage { padding: 26px; display: flex; gap: 30px; align-items: center; justify-content: center; flex-wrap: wrap; }
+  .phone { width: 300px; height: 600px; border-radius: 54px; padding: 12px; flex: none; position: relative;
+    background: linear-gradient(160deg, hsl(20 12% 16%), hsl(20 16% 7%)); box-shadow: var(--pg-shadow), inset 0 0 0 2px hsl(0 0% 100% / 0.06); }
+  .phone::after { content: ""; position: absolute; top: 16px; inset-inline-start: 50%; transform: translateX(-50%); width: 110px; height: 24px; background: hsl(20 30% 3%); border-radius: 0 0 16px 16px; z-index: 5; }
+  .screen { height: 100%; border-radius: 42px; overflow: hidden; display: flex; flex-direction: column; background: hsl(265 28% 8%); }
+  .app-head { padding: 16px 14px 12px; display: flex; align-items: center; gap: 11px; background: hsl(265 22% 13%); }
+  .app-head .av { width: 38px; height: 38px; border-radius: 999px; flex: none; display: grid; place-items: center; font-size: 18px;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .app-head .nm { font-size: 14px; font-weight: 650; }
+  .app-head .st { font-size: 11px; color: hsl(265 14% 60%); margin-top: 1px; }
+  .body { flex: 1; overflow-y: auto; padding: 16px 12px; display: flex; flex-direction: column; gap: 8px; }
+  .body::-webkit-scrollbar { width: 0; }
+  .bubble { max-width: 82%; padding: 8px 11px; border-radius: 12px; font-size: 13px; line-height: 1.45; animation: pop var(--pg-dur-normal) var(--pg-ease) both; }
+  .bubble.out { align-self: flex-end; background: hsl(160 50% 22%); color: hsl(150 60% 92%); border-end-end-radius: 4px; }
+  .bubble.bot { align-self: flex-start; background: hsl(265 20% 16%); border: 1px solid hsl(160 68% 45% / 0.3); border-end-start-radius: 4px; }
+  .bubble .who { font-size: 9px; font-weight: 800; letter-spacing: .4px; color: var(--pg-accent); margin-bottom: 3px; }
+  .typing { align-self: flex-start; background: hsl(265 20% 16%); padding: 11px 13px; border-radius: 12px; border-end-start-radius: 4px; display: inline-flex; gap: 4px; }
+  .typing span { width: 7px; height: 7px; border-radius: 999px; background: hsl(265 14% 50%); animation: blink 1.2s infinite both; }
+  .typing span:nth-child(2) { animation-delay: .2s; } .typing span:nth-child(3) { animation-delay: .4s; }
+  .arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--pg-muted); }
+  .arrow .ar { font-size: 30px; color: var(--pg-accent); }
+  [dir="rtl"] .arrow .ar { transform: scaleX(-1); }
+  .arrow .cap { font-size: 11px; max-width: 120px; text-align: center; line-height: 1.5; }
+  .card { width: 250px; background: hsl(28 30% 96%); color: hsl(215 25% 16%); border-radius: var(--pg-r-md); padding: 16px; position: relative; overflow: hidden; box-shadow: var(--pg-shadow); animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .card .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; background: var(--pg-accent); }
+  .card .kind { font-size: 10.5px; font-weight: 700; letter-spacing: .3px; color: hsl(215 12% 45%); text-transform: uppercase; }
+  .card h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
+  .card .row { display: flex; gap: 8px; font-size: 13px; color: hsl(215 16% 28%); margin-top: 6px; }
+  .card .added { margin-top: 13px; padding-top: 12px; border-top: 1px dashed hsl(215 16% 88%); font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+  .room { width: 220px; border-radius: var(--pg-r-md); padding: 10px; background: var(--pg-glass); border: 1px solid var(--pg-line); backdrop-filter: blur(16px); animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .room .rh { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .room .av { width: 28px; height: 28px; border-radius: 999px; display: grid; place-items: center; font-size: 11px; font-weight: 800; background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); color: hsl(160 40% 8%); }
+  .room .nm { font-size: 12px; font-weight: 650; }
+  .room .st { font-size: 10px; color: var(--pg-faint); }
+  .room .msg { max-width: 92%; padding: 6px 8px; border-radius: 10px; font-size: 11px; line-height: 1.4; margin-top: 6px; background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); }
+  .room .msg .who { font-size: 9px; font-weight: 700; color: var(--pg-accent); margin-bottom: 2px; }
+  .room .msg.out { margin-inline-start: auto; background: hsl(160 50% 22%); border-color: transparent; }
+  .room .msg.release { border-color: hsl(264 70% 60% / 0.35); background: hsl(264 50% 22%); }
+  .room .msg.release .who { color: hsl(264 80% 78%); }
+  .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
+  .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
+  .promptbar .pt b { color: var(--pg-accent); }
+  .copy { flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(160 40% 8%); border-radius: 11px; padding: 11px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: 0 10px 26px -12px hsl(160 68% 40% / 0.8); }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.96); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(14px) scale(.94); } to { opacity: 1; transform: none; } }
+  @keyframes blink { 0%,60%,100% { opacity: .3; } 30% { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+  }
+  @media (max-width: 720px) { .arrow .ar { transform: rotate(90deg); } [dir="rtl"] .arrow .ar { transform: rotate(90deg) scaleX(-1); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="head">
+    <div class="logo">▶️</div>
+    <div>
+      <h1>Community doors</h1>
+      <p>Press <b>Play</b>. The ugly WhatsApp chrome goes. Glass doors stay the
+         join path. A still of the live room sits with them.</p>
+    </div>
+    <div class="right"><button class="toggle" id="dirToggle" aria-pressed="false">⇄ RTL</button></div>
+  </header>
+
+  <div class="panel transport">
+    <button class="btn" id="prev">‹ Back</button>
+    <button class="btn primary" id="play">▶ Play</button>
+    <button class="btn" id="next">Next ›</button>
+    <span class="hint" id="stepHint"></span>
+  </div>
+
+  <main class="panel stage" id="stage"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn">Copy prompt</button>
+  </div>
+</div>
+
+<script>
+const STORY = {
+  appName: "/community",
+  appStatus: "marketing shell",
+  title: "Kill the mock. Warp the mesh. Stop the tiles.",
+  steps: [
+    { kind: "out", who: "", body: "Opened /community. The WhatsApp mock is horrible." },
+    { kind: "typing" },
+    { kind: "bot", who: "Site", body: "Green header. Fake bubbles. Label: Community · mock." },
+    { kind: "out", who: "", body: "Where did the background animation go?" },
+    { kind: "bot", who: "Site", body: "Cosmic CSS dots were static. FlickeringGrid existed and was never wired." },
+    { kind: "out", who: "", body: "Think 21st.dev. Those squares are ugly." },
+    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. Humans tick often. The OrchestKit bot drops what's new once a day." },
+  ],
+  cardAtStep: 6,
+  card: {
+    kind: "Shipped surface",
+    title: "Doors, plus the room",
+    rows: [
+      "WhatsApp · live-room bento",
+      "Discussions + Issues · rows",
+      "Example of the live room · animated",
+      "OrchestKit bot · once per demo day",
+    ],
+  },
+  room: [
+    { who: "Yonatan", body: "Welcome in 👋 This is the live room.", out: false },
+    { who: "Noa", body: "SessionStart ran twice 👀", out: false },
+    { who: "OrchestKit · Bot", body: "What's new in ork — once a day, not spam.", out: false },
+    { who: "Lea", body: "The thread caught it before the PR 🙌", out: true },
+  ],
+};
+
+const state = { step: 0, playing: false, rtl: false };
+let timer = null;
+const stage = document.getElementById("stage");
+const esc = s => String(s).replace(/[&<>]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+const maxStep = () => STORY.steps.length - 1;
+
+function bubble(m) {
+  if (m.kind === "typing") return `<div class="typing"><span></span><span></span><span></span></div>`;
+  if (m.kind === "bot") return `<div class="bubble bot"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`;
+  return `<div class="bubble out">${esc(m.body)}</div>`;
+}
+
+function render() {
+  const shown = STORY.steps.slice(0, state.step + 1).map(bubble).join("");
+  const reached = state.step >= STORY.cardAtStep;
+  const c = STORY.card;
+  const room = (STORY.room || []).map((m) =>
+    `<div class="msg${m.out ? " out" : ""}${m.who.includes("Bot") ? " release" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
+  ).join("");
+  const result = reached
+    ? `<div class="room"><div class="rh"><div class="av">OK</div>
+         <div><div class="nm">OrchestKit</div><div class="st">Example of the live room</div></div></div>
+         ${room}</div>
+       <div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
+         <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
+         <div class="added">Shipped</div></div>`
+    : `<div class="placeholder">Play to see the doors and the live-room ticks</div>`;
+
+  stage.innerHTML = `
+    <div class="phone"><div class="screen">
+      <div class="app-head"><div class="av">OK</div>
+        <div><div class="nm">${esc(STORY.appName)}</div><div class="st">${esc(STORY.appStatus)}</div></div></div>
+      <div class="body" id="body">${shown}</div>
+    </div></div>
+      <div class="arrow"><div class="ar">➜</div><div class="cap">doors plus the room</div></div>
+    ${result}`;
+  const b = document.getElementById("body"); if (b) b.scrollTop = b.scrollHeight;
+
+  document.getElementById("stepHint").innerHTML = `Step <b>${state.step + 1}</b> of <b>${maxStep() + 1}</b>`;
+  document.getElementById("prev").disabled = state.step <= 0;
+  document.getElementById("next").disabled = state.step >= maxStep();
+  updatePrompt();
+}
+
+function updatePrompt() {
+  document.getElementById("promptOut").innerHTML =
+    `Keep the /community glass bento doors. The live-room example ticks: human bubbles arrive often; the OrchestKit bot drops what's new once per demo day. Caption: Example of the live room. No mock labels.`;
+}
+
+function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }
+function play() {
+  if (state.playing) return stop();
+  state.playing = true; document.getElementById("play").innerHTML = "⏸ Pause"; state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) return stop();
+    state.step++; render();
+    const cur = STORY.steps[state.step];
+    timer = setTimeout(tick, cur && cur.kind === "typing" ? 1000 : 1400);
+  };
+  tick();
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => { stop(); state.step = Math.max(0, state.step - 1); render(); });
+document.getElementById("next").addEventListener("click", () => { stop(); state.step = Math.min(maxStep(), state.step + 1); render(); });
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl; document.documentElement.dir = state.rtl ? "rtl" : "ltr"; e.currentTarget.setAttribute("aria-pressed", state.rtl);
+});
+document.getElementById("copyBtn").addEventListener("click", () => {
+  navigator.clipboard.writeText(document.getElementById("promptOut").textContent).then(() => {
+    const b = document.getElementById("copyBtn"); b.textContent = "Copied"; b.classList.add("done");
+    setTimeout(() => { b.textContent = "Copy prompt"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+render();
+</script>
+</body>
+</html>

--- a/docs/fix--community-bg-flicker/community-doors.html
+++ b/docs/fix--community-bg-flicker/community-doors.html
@@ -8,8 +8,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Community doors: mock chat out, kinetic mesh in</title>
-<meta name="description" content="Play the /community rewrite. The mocked WhatsApp thread and three underlined tiles become a cursor-warp Kinetic Grid plus glass bento doors.">
+<title>Community doors: kinetic mesh, live-room example</title>
+<meta name="description" content="Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.">
 <style>
   :root {
     --pg-bg: hsl(20 14% 7%);
@@ -88,6 +88,14 @@
   .card h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
   .card .row { display: flex; gap: 8px; font-size: 13px; color: hsl(215 16% 28%); margin-top: 6px; }
   .card .added { margin-top: 13px; padding-top: 12px; border-top: 1px dashed hsl(215 16% 88%); font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+  .room { width: 220px; border-radius: var(--pg-r-md); padding: 10px; background: var(--pg-glass); border: 1px solid var(--pg-line); backdrop-filter: blur(16px); animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .room .rh { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .room .av { width: 28px; height: 28px; border-radius: 999px; display: grid; place-items: center; font-size: 11px; font-weight: 800; background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); color: hsl(160 40% 8%); }
+  .room .nm { font-size: 12px; font-weight: 650; }
+  .room .st { font-size: 10px; color: var(--pg-faint); }
+  .room .msg { max-width: 92%; padding: 6px 8px; border-radius: 10px; font-size: 11px; line-height: 1.4; margin-top: 6px; background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); }
+  .room .msg .who { font-size: 9px; font-weight: 700; color: var(--pg-accent); margin-bottom: 2px; }
+  .room .msg.out { margin-inline-start: auto; background: hsl(160 50% 22%); border-color: transparent; }
   .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
   .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
   .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
@@ -110,8 +118,8 @@
     <div class="logo">▶️</div>
     <div>
       <h1>Community doors</h1>
-      <p>Press <b>Play</b>. The mocked WhatsApp thread and three underlined tiles
-         become a kinetic mesh plus glass bento doors.</p>
+      <p>Press <b>Play</b>. The ugly WhatsApp chrome goes. Glass doors stay the
+         join path. A still of the live room sits with them.</p>
     </div>
     <div class="right"><button class="toggle" id="dirToggle" aria-pressed="false">⇄ RTL</button></div>
   </header>
@@ -143,19 +151,24 @@ const STORY = {
     { kind: "out", who: "", body: "Where did the background animation go?" },
     { kind: "bot", who: "Site", body: "Cosmic CSS dots were static. FlickeringGrid existed and was never wired." },
     { kind: "out", who: "", body: "Think 21st.dev. Those squares are ugly." },
-    { kind: "bot", who: "Ship", body: "Kinetic Grid warps to the cursor. Bento doors, no underline leak from ContentPage." },
+    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. A still of the live room — people talking, not install copy." },
   ],
   cardAtStep: 6,
   card: {
     kind: "Shipped surface",
-    title: "Doors, not a chat",
+    title: "Doors, plus the room",
     rows: [
       "WhatsApp · live-room bento",
       "Discussions + Issues · rows",
-      "Mesh · kinetic warp + ripple",
-      "No mock. No /ork: in the copy.",
+      "Example of the live room · still",
+      "No mock labels. No install-script bubbles.",
     ],
   },
+  room: [
+    { who: "Yonatan", body: "Welcome in. This is the live room.", out: false },
+    { who: "Noa", body: "SessionStart ran twice. Anyone else?", out: false },
+    { who: "Lea", body: "The thread caught it before the PR.", out: true },
+  ],
 };
 
 const state = { step: 0, playing: false, rtl: false };
@@ -174,11 +187,17 @@ function render() {
   const shown = STORY.steps.slice(0, state.step + 1).map(bubble).join("");
   const reached = state.step >= STORY.cardAtStep;
   const c = STORY.card;
+  const room = (STORY.room || []).map((m) =>
+    `<div class="msg${m.out ? " out" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
+  ).join("");
   const result = reached
-    ? `<div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
+    ? `<div class="room"><div class="rh"><div class="av">OK</div>
+         <div><div class="nm">OrchestKit</div><div class="st">Example of the live room</div></div></div>
+         ${room}</div>
+       <div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
          <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
          <div class="added">Shipped</div></div>`
-    : `<div class="placeholder">Play to see the doors it ships</div>`;
+    : `<div class="placeholder">Play to see the doors and the live-room still</div>`;
 
   stage.innerHTML = `
     <div class="phone"><div class="screen">
@@ -186,7 +205,7 @@ function render() {
         <div><div class="nm">${esc(STORY.appName)}</div><div class="st">${esc(STORY.appStatus)}</div></div></div>
       <div class="body" id="body">${shown}</div>
     </div></div>
-    <div class="arrow"><div class="ar">➜</div><div class="cap">mock out, kinetic in</div></div>
+      <div class="arrow"><div class="ar">➜</div><div class="cap">doors plus the room</div></div>
     ${result}`;
   const b = document.getElementById("body"); if (b) b.scrollTop = b.scrollHeight;
 
@@ -198,7 +217,7 @@ function render() {
 
 function updatePrompt() {
   document.getElementById("promptOut").innerHTML =
-    `Replace the /community WhatsApp mock with glass bento doors. Wire 21st.dev Kinetic Grid on HomeShell. Keep ContentPage underlines off the door links via a <b>hero</b> slot.`;
+    `Keep the /community glass bento doors. Add a still of the live WhatsApp room (people talking, group identity) in the hero slot. Caption: Example of the live room. No mock labels. No install-script bubbles.`;
 }
 
 function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }

--- a/docs/fix--community-bg-flicker/community-doors.html
+++ b/docs/fix--community-bg-flicker/community-doors.html
@@ -96,6 +96,8 @@
   .room .msg { max-width: 92%; padding: 6px 8px; border-radius: 10px; font-size: 11px; line-height: 1.4; margin-top: 6px; background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); }
   .room .msg .who { font-size: 9px; font-weight: 700; color: var(--pg-accent); margin-bottom: 2px; }
   .room .msg.out { margin-inline-start: auto; background: hsl(160 50% 22%); border-color: transparent; }
+  .room .msg.release { border-color: hsl(264 70% 60% / 0.35); background: hsl(264 50% 22%); }
+  .room .msg.release .who { color: hsl(264 80% 78%); }
   .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
   .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
   .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
@@ -151,7 +153,7 @@ const STORY = {
     { kind: "out", who: "", body: "Where did the background animation go?" },
     { kind: "bot", who: "Site", body: "Cosmic CSS dots were static. FlickeringGrid existed and was never wired." },
     { kind: "out", who: "", body: "Think 21st.dev. Those squares are ugly." },
-    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. A still of the live room — people talking, not install copy." },
+    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. Humans tick often. The OrchestKit bot drops what's new once a day." },
   ],
   cardAtStep: 6,
   card: {
@@ -160,14 +162,15 @@ const STORY = {
     rows: [
       "WhatsApp · live-room bento",
       "Discussions + Issues · rows",
-      "Example of the live room · still",
-      "No mock labels. No install-script bubbles.",
+      "Example of the live room · animated",
+      "OrchestKit bot · once per demo day",
     ],
   },
   room: [
-    { who: "Yonatan", body: "Welcome in. This is the live room.", out: false },
-    { who: "Noa", body: "SessionStart ran twice. Anyone else?", out: false },
-    { who: "Lea", body: "The thread caught it before the PR.", out: true },
+    { who: "Yonatan", body: "Welcome in 👋 This is the live room.", out: false },
+    { who: "Noa", body: "SessionStart ran twice 👀", out: false },
+    { who: "OrchestKit · Bot", body: "What's new in ork — once a day, not spam.", out: false },
+    { who: "Lea", body: "The thread caught it before the PR 🙌", out: true },
   ],
 };
 
@@ -188,7 +191,7 @@ function render() {
   const reached = state.step >= STORY.cardAtStep;
   const c = STORY.card;
   const room = (STORY.room || []).map((m) =>
-    `<div class="msg${m.out ? " out" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
+    `<div class="msg${m.out ? " out" : ""}${m.who.includes("Bot") ? " release" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
   ).join("");
   const result = reached
     ? `<div class="room"><div class="rh"><div class="av">OK</div>
@@ -197,7 +200,7 @@ function render() {
        <div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
          <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
          <div class="added">Shipped</div></div>`
-    : `<div class="placeholder">Play to see the doors and the live-room still</div>`;
+    : `<div class="placeholder">Play to see the doors and the live-room ticks</div>`;
 
   stage.innerHTML = `
     <div class="phone"><div class="screen">
@@ -217,7 +220,7 @@ function render() {
 
 function updatePrompt() {
   document.getElementById("promptOut").innerHTML =
-    `Keep the /community glass bento doors. Add a still of the live WhatsApp room (people talking, group identity) in the hero slot. Caption: Example of the live room. No mock labels. No install-script bubbles.`;
+    `Keep the /community glass bento doors. The live-room example ticks: human bubbles arrive often; the OrchestKit bot drops what's new once per demo day. Caption: Example of the live room. No mock labels.`;
 }
 
 function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }

--- a/docs/site/__tests__/community-page.test.tsx
+++ b/docs/site/__tests__/community-page.test.tsx
@@ -11,7 +11,7 @@ vi.mock("next/link", () => ({
 }));
 
 describe("community page", () => {
-	it("offers the live WhatsApp join door and does not fake a chat", () => {
+	it("offers the live WhatsApp join door and a live-room example without mock labels", () => {
 		const { container } = render(<CommunityPage />);
 
 		expect(screen.getByRole("link", { name: /join the whatsapp community/i })).toHaveAttribute(
@@ -19,6 +19,8 @@ describe("community page", () => {
 			expect.stringContaining("yonyon.ai/go/orchestkit"),
 		);
 		expect(screen.getByRole("link", { name: /open discussions/i })).toBeTruthy();
+		expect(screen.getByText(/example of the live room/i)).toBeTruthy();
 		expect(container.textContent ?? "").not.toMatch(/mocked|Mock UI|Community · mock/i);
+		expect(container.textContent ?? "").not.toMatch(/claude install/i);
 	});
 });

--- a/docs/site/__tests__/community-page.test.tsx
+++ b/docs/site/__tests__/community-page.test.tsx
@@ -20,6 +20,8 @@ describe("community page", () => {
 		);
 		expect(screen.getByRole("link", { name: /open discussions/i })).toBeTruthy();
 		expect(screen.getByText(/example of the live room/i)).toBeTruthy();
+		expect(container.textContent ?? "").toMatch(/what's new in ork/i);
+		expect(container.textContent ?? "").toMatch(/orchestkit bot/i);
 		expect(container.textContent ?? "").not.toMatch(/mocked|Mock UI|Community · mock/i);
 		expect(container.textContent ?? "").not.toMatch(/claude install/i);
 	});

--- a/docs/site/app/(home)/community/page.tsx
+++ b/docs/site/app/(home)/community/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { CommunityDoors } from "@/components/community-doors";
+import { CommunityRoomPreview } from "@/components/community-room-preview";
 import { ContentPage } from "@/components/content-page";
 import { SITE } from "@/lib/constants";
 
@@ -15,7 +16,12 @@ export default function CommunityPage() {
 			title={`The ${SITE.name} community`}
 			path="/community"
 			lead="WhatsApp is the live room. GitHub Discussions stay searchable. Issues are for bugs. There is no Discord and no paid support plan."
-			hero={<CommunityDoors />}
+			hero={
+				<>
+					<CommunityDoors />
+					<CommunityRoomPreview />
+				</>
+			}
 		/>
 	);
 }

--- a/docs/site/app/global.css
+++ b/docs/site/app/global.css
@@ -846,3 +846,23 @@ article blockquote {
   height: 18px;
   border-radius: 4px;
 }
+
+/* Community live-room example — bubble arrive. Gated for reduced motion. */
+@keyframes community-room-pop {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.community-room-pop {
+  animation: community-room-pop var(--duration-normal) var(--ease-out-expo) both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .community-room-pop {
+    animation: none;
+  }
+}

--- a/docs/site/components/community-room-preview.tsx
+++ b/docs/site/components/community-room-preview.tsx
@@ -1,89 +1,26 @@
+import { CommunityRoomThread } from "@/components/community-room-thread";
 import { SITE } from "@/lib/constants";
+import { pickWhatsNewPreview, stripMarkdown } from "@/lib/changelog-format";
+import { CHANGELOG_ENTRIES } from "@/lib/generated/changelog-data";
 
-type Bubble = {
-	who: string;
-	text: string;
-	side: "in" | "out";
-};
-
-const THREAD: readonly Bubble[] = [
-	{
-		who: "Yonatan",
-		side: "in",
-		text: "Welcome in. This is the live room — ask when something breaks. Wins count too.",
-	},
-	{
-		who: "Noa",
-		side: "in",
-		text: "SessionStart ran twice on my machine. Anyone else seeing that?",
-	},
-	{
-		who: "Ari",
-		side: "in",
-		text: "Usually the entries map. Run doctor first.",
-	},
-	{
-		who: "Lea",
-		side: "out",
-		text: "The thread caught a frontmatter miss before I opened the PR.",
-	},
-];
-
-function WhatsAppGlyph({ className }: { className?: string }) {
-	return (
-		<svg viewBox="0 0 24 24" aria-hidden="true" className={className} fill="#25D366">
-			<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.435 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
-		</svg>
-	);
+function botDigestLine(): string {
+	const preview = pickWhatsNewPreview(CHANGELOG_ENTRIES, 4);
+	const version = preview?.entry.version ?? SITE.version;
+	const picked =
+		preview?.items.find((row) => !/^(deps|chore)(\(.+\))?:/i.test(stripMarkdown(row.item))) ??
+		preview?.items[0];
+	const raw = picked
+		? stripMarkdown(picked.item.split("\n")[0])
+		: "What's new is on the changelog.";
+	const line = raw
+		.replace(/\s*\([^)]*#\d+[^)]*\)/g, "")
+		.replace(/\s*\([a-f0-9]{7,40}\)/g, "")
+		.trim();
+	const clipped = line.length > 72 ? `${line.slice(0, 69)}…` : line;
+	return `What's new in ork — ${version}: ${clipped}`;
 }
 
-function RoomPhone() {
-	return (
-		<div
-			aria-hidden="true"
-			className="mx-auto w-[220px] rounded-[1.75rem] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-foreground)_7%,transparent)] p-1.5 shadow-[var(--shadow-overlay)]"
-		>
-			<div className="overflow-hidden rounded-[1.35rem] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-card)_78%,transparent)]">
-				<div className="flex items-center gap-2.5 border-b border-fd-border px-3 py-2.5">
-					<span className="flex h-8 w-8 items-center justify-center rounded-full border border-[#25D366]/25 bg-[#25D366]/10">
-						<WhatsAppGlyph className="h-4 w-4" />
-					</span>
-					<div className="min-w-0">
-						<p className="truncate text-[13px] font-semibold tracking-tight text-fd-foreground">
-							{SITE.name}
-						</p>
-						<p className="text-[10px] leading-4 text-fd-muted-foreground">WhatsApp community</p>
-					</div>
-				</div>
-				<div className="space-y-2 px-2.5 py-3">
-					{THREAD.map((bubble) => (
-						<div
-							key={`${bubble.who}-${bubble.text}`}
-							className={
-								bubble.side === "out"
-									? "ml-auto max-w-[88%] rounded-2xl rounded-br-md border border-[#25D366]/20 bg-[#25D366]/10 px-2.5 py-1.5"
-									: "max-w-[88%] rounded-2xl rounded-bl-md border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-muted)_70%,transparent)] px-2.5 py-1.5"
-							}
-						>
-							<p
-								className={
-									bubble.side === "out"
-										? "text-[10px] font-medium text-[#25D366]"
-										: "text-[10px] font-medium text-fd-primary"
-								}
-							>
-								{bubble.who}
-							</p>
-							<p className="mt-0.5 text-[11px] leading-4 text-fd-foreground">{bubble.text}</p>
-						</div>
-					))}
-				</div>
-			</div>
-		</div>
-	);
-}
-
-/** Still illustration of the WhatsApp group. Not a live feed. */
+/** Example of the WhatsApp group. Chat ticks; the OrchestKit bot once per demo day. */
 export function CommunityRoomPreview() {
 	return (
 		<figure className="card-elevated card-trace mt-8 overflow-hidden rounded-[var(--radius-card)] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-card)_52%,transparent)] backdrop-blur-md">
@@ -91,13 +28,13 @@ export function CommunityRoomPreview() {
 				Example of the live room
 			</figcaption>
 			<div className="grid gap-6 px-5 pt-3 pb-5 md:grid-cols-[minmax(0,240px)_1fr] md:items-center md:px-6 md:pb-6">
-				<RoomPhone />
+				<CommunityRoomThread botLine={botDigestLine()} />
 				<div>
 					<p className="text-xl font-semibold tracking-tight text-fd-foreground">
 						How the WhatsApp group looks
 					</p>
 					<p className="mt-2 max-w-[36ch] text-sm leading-6 text-fd-muted-foreground">
-						People in the thread, group identity, the actual room. This is a still — the door
+						People talking. The OrchestKit bot drops what&apos;s new about once a day. The door
 						above is the invite.
 					</p>
 				</div>

--- a/docs/site/components/community-room-preview.tsx
+++ b/docs/site/components/community-room-preview.tsx
@@ -1,0 +1,107 @@
+import { SITE } from "@/lib/constants";
+
+type Bubble = {
+	who: string;
+	text: string;
+	side: "in" | "out";
+};
+
+const THREAD: readonly Bubble[] = [
+	{
+		who: "Yonatan",
+		side: "in",
+		text: "Welcome in. This is the live room — ask when something breaks. Wins count too.",
+	},
+	{
+		who: "Noa",
+		side: "in",
+		text: "SessionStart ran twice on my machine. Anyone else seeing that?",
+	},
+	{
+		who: "Ari",
+		side: "in",
+		text: "Usually the entries map. Run doctor first.",
+	},
+	{
+		who: "Lea",
+		side: "out",
+		text: "The thread caught a frontmatter miss before I opened the PR.",
+	},
+];
+
+function WhatsAppGlyph({ className }: { className?: string }) {
+	return (
+		<svg viewBox="0 0 24 24" aria-hidden="true" className={className} fill="#25D366">
+			<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.435 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+		</svg>
+	);
+}
+
+function RoomPhone() {
+	return (
+		<div
+			aria-hidden="true"
+			className="mx-auto w-[220px] rounded-[1.75rem] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-foreground)_7%,transparent)] p-1.5 shadow-[var(--shadow-overlay)]"
+		>
+			<div className="overflow-hidden rounded-[1.35rem] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-card)_78%,transparent)]">
+				<div className="flex items-center gap-2.5 border-b border-fd-border px-3 py-2.5">
+					<span className="flex h-8 w-8 items-center justify-center rounded-full border border-[#25D366]/25 bg-[#25D366]/10">
+						<WhatsAppGlyph className="h-4 w-4" />
+					</span>
+					<div className="min-w-0">
+						<p className="truncate text-[13px] font-semibold tracking-tight text-fd-foreground">
+							{SITE.name}
+						</p>
+						<p className="text-[10px] leading-4 text-fd-muted-foreground">WhatsApp community</p>
+					</div>
+				</div>
+				<div className="space-y-2 px-2.5 py-3">
+					{THREAD.map((bubble) => (
+						<div
+							key={`${bubble.who}-${bubble.text}`}
+							className={
+								bubble.side === "out"
+									? "ml-auto max-w-[88%] rounded-2xl rounded-br-md border border-[#25D366]/20 bg-[#25D366]/10 px-2.5 py-1.5"
+									: "max-w-[88%] rounded-2xl rounded-bl-md border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-muted)_70%,transparent)] px-2.5 py-1.5"
+							}
+						>
+							<p
+								className={
+									bubble.side === "out"
+										? "text-[10px] font-medium text-[#25D366]"
+										: "text-[10px] font-medium text-fd-primary"
+								}
+							>
+								{bubble.who}
+							</p>
+							<p className="mt-0.5 text-[11px] leading-4 text-fd-foreground">{bubble.text}</p>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+/** Still illustration of the WhatsApp group. Not a live feed. */
+export function CommunityRoomPreview() {
+	return (
+		<figure className="card-elevated card-trace mt-8 overflow-hidden rounded-[var(--radius-card)] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-card)_52%,transparent)] backdrop-blur-md">
+			<figcaption className="px-5 pt-5 font-mono text-[11px] font-medium tracking-[0.14em] text-[#25D366] uppercase md:px-6 md:pt-6">
+				Example of the live room
+			</figcaption>
+			<div className="grid gap-6 px-5 pt-3 pb-5 md:grid-cols-[minmax(0,240px)_1fr] md:items-center md:px-6 md:pb-6">
+				<RoomPhone />
+				<div>
+					<p className="text-xl font-semibold tracking-tight text-fd-foreground">
+						How the WhatsApp group looks
+					</p>
+					<p className="mt-2 max-w-[36ch] text-sm leading-6 text-fd-muted-foreground">
+						People in the thread, group identity, the actual room. This is a still — the door
+						above is the invite.
+					</p>
+				</div>
+			</div>
+		</figure>
+	);
+}

--- a/docs/site/components/community-room-thread.tsx
+++ b/docs/site/components/community-room-thread.tsx
@@ -1,0 +1,251 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { SITE } from "@/lib/constants";
+
+export type RoomKind = "chat" | "bot";
+
+export type RoomBubble = {
+	id: string;
+	who: string;
+	text: string;
+	side: "in" | "out";
+	kind: RoomKind;
+	time: string;
+	initial: string;
+	tone: string;
+	reaction?: string;
+};
+
+const PEOPLE: Record<string, { initial: string; tone: string }> = {
+	Yonatan: { initial: "Y", tone: "text-[#25D366]" },
+	Noa: { initial: "N", tone: "text-[var(--yy-george-cool-text)]" },
+	Ari: { initial: "A", tone: "text-fd-primary" },
+	Lea: { initial: "L", tone: "text-[var(--yy-george-warm-text)]" },
+	Sam: { initial: "S", tone: "text-fd-foreground" },
+};
+
+const CHAT: Omit<RoomBubble, "id" | "kind">[] = [
+	{
+		who: "Yonatan",
+		side: "in",
+		text: "Welcome in 👋 This is the live room — ask when something breaks. Wins count too.",
+		time: "09:12",
+		reaction: "👋 3",
+		...PEOPLE.Yonatan,
+	},
+	{
+		who: "Noa",
+		side: "in",
+		text: "SessionStart ran twice on my machine 👀 Anyone else seeing that?",
+		time: "09:14",
+		...PEOPLE.Noa,
+	},
+	{
+		who: "Ari",
+		side: "in",
+		text: "Usually the entries map. Run doctor first ✅",
+		time: "09:15",
+		reaction: "👍 2",
+		...PEOPLE.Ari,
+	},
+	{
+		who: "Lea",
+		side: "out",
+		text: "The thread caught a frontmatter miss before I opened the PR 🙌",
+		time: "09:18",
+		...PEOPLE.Lea,
+	},
+	{
+		who: "Sam",
+		side: "in",
+		text: "Anyone using the doctor output as a PR checklist?",
+		time: "11:42",
+		...PEOPLE.Sam,
+	},
+	{
+		who: "Noa",
+		side: "in",
+		text: "Yes. Caught a missing hook name before CI did 🔥",
+		time: "11:44",
+		reaction: "🔥 4",
+		...PEOPLE.Noa,
+	},
+	{
+		who: "Ari",
+		side: "in",
+		text: "Wins count too. Ship it, then tell the room.",
+		time: "16:08",
+		...PEOPLE.Ari,
+	},
+	{
+		who: "Lea",
+		side: "out",
+		text: "Updating after the daily drop ✨",
+		time: "16:11",
+		...PEOPLE.Lea,
+	},
+];
+
+const WINDOW = 4;
+const CHAT_MS = 2100;
+const BOT_HOLD_MS = 5600;
+
+export function buildRoomPlaylist(botLine: string): RoomBubble[] {
+	const chat = CHAT.map((bubble, i) => ({
+		...bubble,
+		id: `chat-${i}`,
+		kind: "chat" as const,
+	}));
+	const bot: RoomBubble = {
+		id: "bot-daily",
+		who: SITE.name,
+		side: "in",
+		kind: "bot",
+		text: botLine,
+		time: "08:01",
+		initial: "OK",
+		tone: "text-fd-primary",
+		reaction: "👀 5",
+	};
+	return [...chat.slice(0, 5), bot, ...chat.slice(5)];
+}
+
+function windowAt(playlist: RoomBubble[], endIndex: number): RoomBubble[] {
+	const out: RoomBubble[] = [];
+	for (let i = WINDOW - 1; i >= 0; i--) {
+		out.push(playlist[(endIndex - i + playlist.length) % playlist.length]);
+	}
+	return out;
+}
+
+function WhatsAppGlyph({ className }: { className?: string }) {
+	return (
+		<svg viewBox="0 0 24 24" aria-hidden="true" className={className} fill="#25D366">
+			<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.435 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+		</svg>
+	);
+}
+
+function Avatar({ initial, bot }: { initial: string; bot?: boolean }) {
+	return (
+		<span
+			className={
+				bot
+					? "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-fd-primary/30 bg-[color-mix(in_oklch,var(--color-fd-primary)_16%,transparent)] text-[8px] font-semibold tracking-tight text-fd-primary"
+					: "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-muted)_80%,transparent)] text-[9px] font-semibold text-fd-foreground"
+			}
+		>
+			{initial}
+		</span>
+	);
+}
+
+function BubbleView({ bubble, pop }: { bubble: RoomBubble; pop: boolean }) {
+	const bot = bubble.kind === "bot";
+	const outgoing = bubble.side === "out";
+	return (
+		<div className={`flex items-end gap-1.5 ${outgoing ? "flex-row-reverse" : ""} ${pop ? "community-room-pop" : ""}`}>
+			{outgoing ? null : <Avatar initial={bubble.initial} bot={bot} />}
+			<div
+				className={
+					outgoing
+						? "max-w-[86%] rounded-2xl rounded-br-md border border-[#25D366]/20 bg-[#25D366]/10 px-2.5 py-1.5"
+						: bot
+							? "max-w-[86%] rounded-2xl rounded-bl-md border border-fd-primary/25 bg-[color-mix(in_oklch,var(--color-fd-primary)_10%,transparent)] px-2.5 py-1.5"
+							: "max-w-[86%] rounded-2xl rounded-bl-md border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-muted)_70%,transparent)] px-2.5 py-1.5"
+				}
+			>
+				<p className={`flex items-center gap-1.5 text-[10px] font-medium ${bubble.tone}`}>
+					<span>{bubble.who}</span>
+					{bot ? (
+						<span className="rounded-[3px] border border-fd-primary/30 bg-[color-mix(in_oklch,var(--color-fd-primary)_14%,transparent)] px-1 py-px text-[8px] font-semibold tracking-[0.08em] text-fd-primary uppercase">
+							Bot
+						</span>
+					) : null}
+				</p>
+				<p className="mt-0.5 text-[11px] leading-4 text-fd-foreground">{bubble.text}</p>
+				<p className="mt-1 text-right text-[9px] leading-none text-fd-muted-foreground">{bubble.time}</p>
+				{bubble.reaction ? (
+					<span className="mt-1 inline-flex rounded-full border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-card)_80%,transparent)] px-1.5 py-0.5 text-[10px] leading-none text-fd-foreground">
+						{bubble.reaction}
+					</span>
+				) : null}
+			</div>
+		</div>
+	);
+}
+
+/** Animated example thread. Humans tick often; the OrchestKit bot once per demo day. */
+export function CommunityRoomThread({ botLine }: { botLine: string }) {
+	const playlist = buildRoomPlaylist(botLine);
+	const startIndex = playlist.length - 1;
+	const [endIndex, setEndIndex] = useState(startIndex);
+	const [motionOn, setMotionOn] = useState(false);
+	const indexRef = useRef(startIndex);
+
+	useEffect(() => {
+		const reduced =
+			typeof window.matchMedia !== "function" ||
+			window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+		if (reduced) return undefined;
+
+		setMotionOn(true);
+		let timer = 0;
+		const step = () => {
+			const next = (indexRef.current + 1) % playlist.length;
+			indexRef.current = next;
+			setEndIndex(next);
+			const hold = playlist[next].kind === "bot" ? BOT_HOLD_MS : CHAT_MS;
+			timer = window.setTimeout(step, hold);
+		};
+		timer = window.setTimeout(step, CHAT_MS);
+		return () => window.clearTimeout(timer);
+	}, [playlist.length]);
+
+	const visible = windowAt(playlist, endIndex);
+	const showDayMark = visible.some((bubble) => bubble.kind === "bot");
+
+	return (
+		<div
+			aria-hidden="true"
+			className="mx-auto w-[236px] rounded-[1.75rem] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-foreground)_7%,transparent)] p-1.5 shadow-[var(--shadow-overlay)]"
+		>
+			<div className="overflow-hidden rounded-[1.35rem] border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-card)_78%,transparent)]">
+				<div className="flex items-center gap-2.5 border-b border-fd-border px-3 py-2.5">
+					<span className="flex h-8 w-8 items-center justify-center rounded-full border border-[#25D366]/25 bg-[#25D366]/10">
+						<WhatsAppGlyph className="h-4 w-4" />
+					</span>
+					<div className="min-w-0">
+						<p className="truncate text-[13px] font-semibold tracking-tight text-fd-foreground">
+							{SITE.name}
+						</p>
+						<p className="text-[10px] leading-4 text-fd-muted-foreground">
+							WhatsApp community · 48
+						</p>
+					</div>
+				</div>
+				<div className="flex min-h-[268px] flex-col justify-end gap-2.5 px-2.5 py-3">
+					{showDayMark ? (
+						<p className="text-center text-[9px] font-medium tracking-[0.08em] text-fd-muted-foreground uppercase">
+							Today
+						</p>
+					) : null}
+					{visible.map((bubble, i) => (
+						<BubbleView
+							key={`${endIndex}-${bubble.id}`}
+							bubble={bubble}
+							pop={motionOn && i === visible.length - 1}
+						/>
+					))}
+				</div>
+				<div className="flex items-center gap-2 border-t border-fd-border px-2.5 py-2">
+					<span className="flex-1 rounded-full border border-fd-border bg-[color-mix(in_oklch,var(--color-fd-muted)_50%,transparent)] px-2.5 py-1 text-[10px] text-fd-muted-foreground">
+						Message
+					</span>
+					<span className="text-[12px] text-[#25D366]">➤</span>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -5,7 +5,7 @@
       "slug": "community-kinetic-bento",
       "source": "docs/fix--community-bg-flicker/community-doors.html",
       "title": "Community doors: kinetic mesh, live-room example",
-      "description": "Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.",
+      "description": "Play the /community rewrite. Glass bento doors stay the join path. The WhatsApp-group example ticks: humans often, the OrchestKit bot once a day.",
       "tags": [
         "docs",
         "site",

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -3,7 +3,7 @@
   "entries": [
     {
       "slug": "community-kinetic-bento",
-      "source": "docs/fix--community-bg-flicker/community-doors.html",
+      "source": "docs/docs--community-live-room/community-doors.html",
       "title": "Community doors: kinetic mesh, live-room example",
       "description": "Play the /community rewrite. Glass bento doors stay the join path. The WhatsApp-group example ticks: humans often, the OrchestKit bot once a day.",
       "tags": [

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -4,8 +4,8 @@
     {
       "slug": "community-kinetic-bento",
       "source": "docs/fix--community-bg-flicker/community-doors.html",
-      "title": "Community doors: mock chat out, kinetic mesh in",
-      "description": "Play the /community rewrite. The mocked WhatsApp thread and three underlined tiles become a cursor-warp Kinetic Grid plus glass bento doors.",
+      "title": "Community doors: kinetic mesh, live-room example",
+      "description": "Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.",
       "tags": [
         "docs",
         "site",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -45,7 +45,7 @@ export const LAB_ENTRIES: LabEntry[] = [
   {
     "slug": "community-kinetic-bento",
     "title": "Community doors: kinetic mesh, live-room example",
-    "description": "Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.",
+    "description": "Play the /community rewrite. Glass bento doors stay the join path. The WhatsApp-group example ticks: humans often, the OrchestKit bot once a day.",
     "tags": [
       "docs",
       "site",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -44,8 +44,8 @@ export const LAB_ENTRIES: LabEntry[] = [
   },
   {
     "slug": "community-kinetic-bento",
-    "title": "Community doors: mock chat out, kinetic mesh in",
-    "description": "Play the /community rewrite. The mocked WhatsApp thread and three underlined tiles become a cursor-warp Kinetic Grid plus glass bento doors.",
+    "title": "Community doors: kinetic mesh, live-room example",
+    "description": "Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.",
     "tags": [
       "docs",
       "site",
@@ -54,7 +54,7 @@ export const LAB_ENTRIES: LabEntry[] = [
     "date": "2026-09-09",
     "featured": false,
     "caseStudy": null,
-    "sizeKb": 14
+    "sizeKb": 16
   },
   {
     "slug": "codex-mech-profile",

--- a/docs/site/public/lab/community-kinetic-bento.html
+++ b/docs/site/public/lab/community-kinetic-bento.html
@@ -8,8 +8,8 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Community doors: mock chat out, kinetic mesh in</title>
-<meta name="description" content="Play the /community rewrite. The mocked WhatsApp thread and three underlined tiles become a cursor-warp Kinetic Grid plus glass bento doors.">
+<title>Community doors: kinetic mesh, live-room example</title>
+<meta name="description" content="Play the /community rewrite. Glass bento doors stay the join path. A quiet phone preview shows how the WhatsApp group looks as a room.">
 <style>
   :root {
     --pg-bg: hsl(20 14% 7%);
@@ -88,6 +88,14 @@
   .card h3 { margin: 7px 0 9px; font-size: 18px; letter-spacing: -.3px; }
   .card .row { display: flex; gap: 8px; font-size: 13px; color: hsl(215 16% 28%); margin-top: 6px; }
   .card .added { margin-top: 13px; padding-top: 12px; border-top: 1px dashed hsl(215 16% 88%); font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+  .room { width: 220px; border-radius: var(--pg-r-md); padding: 10px; background: var(--pg-glass); border: 1px solid var(--pg-line); backdrop-filter: blur(16px); animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .room .rh { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+  .room .av { width: 28px; height: 28px; border-radius: 999px; display: grid; place-items: center; font-size: 11px; font-weight: 800; background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); color: hsl(160 40% 8%); }
+  .room .nm { font-size: 12px; font-weight: 650; }
+  .room .st { font-size: 10px; color: var(--pg-faint); }
+  .room .msg { max-width: 92%; padding: 6px 8px; border-radius: 10px; font-size: 11px; line-height: 1.4; margin-top: 6px; background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); }
+  .room .msg .who { font-size: 9px; font-weight: 700; color: var(--pg-accent); margin-bottom: 2px; }
+  .room .msg.out { margin-inline-start: auto; background: hsl(160 50% 22%); border-color: transparent; }
   .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
   .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
   .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
@@ -110,8 +118,8 @@
     <div class="logo">▶️</div>
     <div>
       <h1>Community doors</h1>
-      <p>Press <b>Play</b>. The mocked WhatsApp thread and three underlined tiles
-         become a kinetic mesh plus glass bento doors.</p>
+      <p>Press <b>Play</b>. The ugly WhatsApp chrome goes. Glass doors stay the
+         join path. A still of the live room sits with them.</p>
     </div>
     <div class="right"><button class="toggle" id="dirToggle" aria-pressed="false">⇄ RTL</button></div>
   </header>
@@ -143,19 +151,24 @@ const STORY = {
     { kind: "out", who: "", body: "Where did the background animation go?" },
     { kind: "bot", who: "Site", body: "Cosmic CSS dots were static. FlickeringGrid existed and was never wired." },
     { kind: "out", who: "", body: "Think 21st.dev. Those squares are ugly." },
-    { kind: "bot", who: "Ship", body: "Kinetic Grid warps to the cursor. Bento doors, no underline leak from ContentPage." },
+    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. A still of the live room — people talking, not install copy." },
   ],
   cardAtStep: 6,
   card: {
     kind: "Shipped surface",
-    title: "Doors, not a chat",
+    title: "Doors, plus the room",
     rows: [
       "WhatsApp · live-room bento",
       "Discussions + Issues · rows",
-      "Mesh · kinetic warp + ripple",
-      "No mock. No /ork: in the copy.",
+      "Example of the live room · still",
+      "No mock labels. No install-script bubbles.",
     ],
   },
+  room: [
+    { who: "Yonatan", body: "Welcome in. This is the live room.", out: false },
+    { who: "Noa", body: "SessionStart ran twice. Anyone else?", out: false },
+    { who: "Lea", body: "The thread caught it before the PR.", out: true },
+  ],
 };
 
 const state = { step: 0, playing: false, rtl: false };
@@ -174,11 +187,17 @@ function render() {
   const shown = STORY.steps.slice(0, state.step + 1).map(bubble).join("");
   const reached = state.step >= STORY.cardAtStep;
   const c = STORY.card;
+  const room = (STORY.room || []).map((m) =>
+    `<div class="msg${m.out ? " out" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
+  ).join("");
   const result = reached
-    ? `<div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
+    ? `<div class="room"><div class="rh"><div class="av">OK</div>
+         <div><div class="nm">OrchestKit</div><div class="st">Example of the live room</div></div></div>
+         ${room}</div>
+       <div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
          <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
          <div class="added">Shipped</div></div>`
-    : `<div class="placeholder">Play to see the doors it ships</div>`;
+    : `<div class="placeholder">Play to see the doors and the live-room still</div>`;
 
   stage.innerHTML = `
     <div class="phone"><div class="screen">
@@ -186,7 +205,7 @@ function render() {
         <div><div class="nm">${esc(STORY.appName)}</div><div class="st">${esc(STORY.appStatus)}</div></div></div>
       <div class="body" id="body">${shown}</div>
     </div></div>
-    <div class="arrow"><div class="ar">➜</div><div class="cap">mock out, kinetic in</div></div>
+      <div class="arrow"><div class="ar">➜</div><div class="cap">doors plus the room</div></div>
     ${result}`;
   const b = document.getElementById("body"); if (b) b.scrollTop = b.scrollHeight;
 
@@ -198,7 +217,7 @@ function render() {
 
 function updatePrompt() {
   document.getElementById("promptOut").innerHTML =
-    `Replace the /community WhatsApp mock with glass bento doors. Wire 21st.dev Kinetic Grid on HomeShell. Keep ContentPage underlines off the door links via a <b>hero</b> slot.`;
+    `Keep the /community glass bento doors. Add a still of the live WhatsApp room (people talking, group identity) in the hero slot. Caption: Example of the live room. No mock labels. No install-script bubbles.`;
 }
 
 function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }

--- a/docs/site/public/lab/community-kinetic-bento.html
+++ b/docs/site/public/lab/community-kinetic-bento.html
@@ -96,6 +96,8 @@
   .room .msg { max-width: 92%; padding: 6px 8px; border-radius: 10px; font-size: 11px; line-height: 1.4; margin-top: 6px; background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); }
   .room .msg .who { font-size: 9px; font-weight: 700; color: var(--pg-accent); margin-bottom: 2px; }
   .room .msg.out { margin-inline-start: auto; background: hsl(160 50% 22%); border-color: transparent; }
+  .room .msg.release { border-color: hsl(264 70% 60% / 0.35); background: hsl(264 50% 22%); }
+  .room .msg.release .who { color: hsl(264 80% 78%); }
   .placeholder { color: var(--pg-faint); font-size: 12px; max-width: 130px; text-align: center; }
   .promptbar { display: flex; align-items: center; gap: 14px; padding: 14px 16px; }
   .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(28 16% 80%); }
@@ -151,7 +153,7 @@ const STORY = {
     { kind: "out", who: "", body: "Where did the background animation go?" },
     { kind: "bot", who: "Site", body: "Cosmic CSS dots were static. FlickeringGrid existed and was never wired." },
     { kind: "out", who: "", body: "Think 21st.dev. Those squares are ugly." },
-    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. A still of the live room — people talking, not install copy." },
+    { kind: "bot", who: "Ship", body: "Kinetic Grid. Glass doors. Humans tick often. The OrchestKit bot drops what's new once a day." },
   ],
   cardAtStep: 6,
   card: {
@@ -160,14 +162,15 @@ const STORY = {
     rows: [
       "WhatsApp · live-room bento",
       "Discussions + Issues · rows",
-      "Example of the live room · still",
-      "No mock labels. No install-script bubbles.",
+      "Example of the live room · animated",
+      "OrchestKit bot · once per demo day",
     ],
   },
   room: [
-    { who: "Yonatan", body: "Welcome in. This is the live room.", out: false },
-    { who: "Noa", body: "SessionStart ran twice. Anyone else?", out: false },
-    { who: "Lea", body: "The thread caught it before the PR.", out: true },
+    { who: "Yonatan", body: "Welcome in 👋 This is the live room.", out: false },
+    { who: "Noa", body: "SessionStart ran twice 👀", out: false },
+    { who: "OrchestKit · Bot", body: "What's new in ork — once a day, not spam.", out: false },
+    { who: "Lea", body: "The thread caught it before the PR 🙌", out: true },
   ],
 };
 
@@ -188,7 +191,7 @@ function render() {
   const reached = state.step >= STORY.cardAtStep;
   const c = STORY.card;
   const room = (STORY.room || []).map((m) =>
-    `<div class="msg${m.out ? " out" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
+    `<div class="msg${m.out ? " out" : ""}${m.who.includes("Bot") ? " release" : ""}"><div class="who">${esc(m.who)}</div>${esc(m.body)}</div>`
   ).join("");
   const result = reached
     ? `<div class="room"><div class="rh"><div class="av">OK</div>
@@ -197,7 +200,7 @@ function render() {
        <div class="card"><div class="stripe"></div><div class="kind">${esc(c.kind)}</div>
          <h3>${esc(c.title)}</h3>${c.rows.map(r => `<div class="row">${esc(r)}</div>`).join("")}
          <div class="added">Shipped</div></div>`
-    : `<div class="placeholder">Play to see the doors and the live-room still</div>`;
+    : `<div class="placeholder">Play to see the doors and the live-room ticks</div>`;
 
   stage.innerHTML = `
     <div class="phone"><div class="screen">
@@ -217,7 +220,7 @@ function render() {
 
 function updatePrompt() {
   document.getElementById("promptOut").innerHTML =
-    `Keep the /community glass bento doors. Add a still of the live WhatsApp room (people talking, group identity) in the hero slot. Caption: Example of the live room. No mock labels. No install-script bubbles.`;
+    `Keep the /community glass bento doors. The live-room example ticks: human bubbles arrive often; the OrchestKit bot drops what's new once per demo day. Caption: Example of the live room. No mock labels.`;
 }
 
 function stop() { state.playing = false; clearTimeout(timer); document.getElementById("play").innerHTML = "▶ Play"; }


### PR DESCRIPTION
## Summary
- Add a WhatsApp live-room example on `/community` under the glass bento doors.
- Animate more group messages. The OrchestKit bot posts a changelog digest once per demo-day, not on every tick.
- Caption is \"Example of the live room\". No mock labels.

Follow-up to #4019 (already merged). Doors stay the join path; `SITE.communityJoinUrl` is unchanged.

## Test plan
- [ ] Open http://localhost:3000/community (use `localhost`, not `127.0.0.1`)
- [ ] Human bubbles tick; OrchestKit bot lands about once per loop with a Bot badge
- [ ] No mock labels (`mocked` / `Mock UI` / `Community · mock`)
- [ ] Doors still join: WhatsApp invite, Discussions, Issues
- [ ] Check `/` still hydrates the same HomeShell grid
- [ ] `cd docs/site && npx vitest run -c vitest.site.config.ts __tests__/community-page.test.tsx`

## Interactive Playground
Community live-room: humans often, OrchestKit bot once a day.

Live: https://orchestkit.yonyon.ai/lab/community-kinetic-bento.html

Source (SHA-pinned): https://github.com/yonatangross/orchestkit/blob/1970b958c6554b454d950f75cbccb8a47d5c633b/docs/docs--community-live-room/community-doors.html