### PR TITLE
docs(site): wire Chrono Board into What's new and changelog

### DIFF
--- a/docs/feat--docs-chrono-board-release/chrono-board.html
+++ b/docs/feat--docs-chrono-board-release/chrono-board.html
@@ -1,0 +1,425 @@
+<!doctype html>
+<!--
+  RELEASE-NOTES PLAYER · Chrono Board on the OrchestKit docs site
+  Archetype: user-story-player (release-notes-player recipe)
+  Persona: cool-glass. Conforms to shared/rules/playground-visual-standard.md
+  21st.dev dhileepkumargm/chrono-board (demo 9216), wired to real ork data.
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Chrono Board: What's new becomes a release timeline</title>
+<meta name="description" content="Play the 21st.dev Chrono Board on the docs site. What's new is a live catalog card plus product bullets. Changelog gets a five-release activity rail. Notes jumps to the version; Diff opens compare. Reduced-motion keeps the actions usable.">
+<style>
+  :root {
+    --pg-bg: hsl(232 26% 7%);
+    --pg-ink: hsl(220 18% 93%);
+    --pg-muted: hsl(222 12% 64%);
+    --pg-faint: hsl(222 10% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(264 72% 62%);
+    --pg-accent-deep: hsl(264 70% 46%);
+    --pg-teal: hsl(220 40% 62%);
+    --pg-shadow: 0 20px 60px -22px hsl(264 60% 2% / 0.7), 0 4px 12px -6px hsl(264 60% 2% / 0.5);
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(264 72% 62% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(248 70% 58% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 24px 16px 48px; display: flex; flex-direction: column; gap: 16px; }
+  .head { display: flex; align-items: flex-start; gap: 16px; }
+  .logo { width: 48px; height: 48px; border-radius: 16px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 24px -8px hsl(264 70% 50% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .logo svg { width: 22px; height: 22px; }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head h1 .v { color: var(--pg-accent); font-variant-numeric: tabular-nums; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 8px 16px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); border-color: hsl(264 72% 62% / 0.45); }
+
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 12px; padding: 8px 16px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink);
+    transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent;
+    color: hsl(264 40% 96%); box-shadow: 0 10px 26px -12px hsl(264 70% 50% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; font-variant-numeric: tabular-nums; }
+  .hint b { color: var(--pg-muted); }
+
+  .stage { padding: 24px; display: flex; gap: 24px; align-items: center; justify-content: center; flex-wrap: wrap; }
+
+  .phone { width: 320px; height: 600px; border-radius: 54px; padding: 12px; flex: none; position: relative;
+    background: linear-gradient(160deg, hsl(232 14% 17%), hsl(232 22% 7%));
+    box-shadow: var(--pg-shadow), inset 0 0 0 2px hsl(0 0% 100% / 0.06); }
+  .phone::after { content: ""; position: absolute; top: 16px; left: 50%; transform: translateX(-50%);
+    width: 112px; height: 24px; background: hsl(232 30% 3%); border-radius: 0 0 16px 16px; z-index: 5; }
+  .screen { height: 100%; border-radius: 42px; overflow: hidden; display: flex; flex-direction: column; background: hsl(232 24% 9%); }
+  .app-head { padding: 24px 16px 12px; display: flex; align-items: center; gap: 12px; background: hsl(232 22% 13%); }
+  .app-head .av { width: 40px; height: 40px; border-radius: 12px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .app-head .av svg { width: 18px; height: 18px; }
+  .app-head .nm { font-size: 14px; font-weight: 700; }
+  .app-head .st { font-size: 11px; color: var(--pg-muted); margin-top: 1px; }
+  .app-head .vpill { margin-inline-start: auto; font-family: var(--pg-mono); font-size: 11px; font-weight: 700;
+    color: var(--pg-accent); background: hsl(264 72% 62% / 0.14); border: 1px solid hsl(264 72% 62% / 0.3);
+    border-radius: 999px; padding: 4px 12px; font-variant-numeric: tabular-nums; }
+  .feed { flex: 1; overflow-y: auto; padding: 12px 12px 16px; scroll-behavior: smooth; }
+  .feed::-webkit-scrollbar { width: 0; }
+
+  .board { position: relative; display: flex; flex-direction: column; gap: 16px; }
+  .card-row { position: relative; display: flex; align-items: flex-start; gap: 12px; }
+  .card-row .rail { position: absolute; inset-inline-start: 11px; top: 24px; bottom: -16px; width: 1px; background: hsl(0 0% 100% / 0.12); }
+  .card-row:last-child .rail { display: none; }
+  .node { position: relative; z-index: 1; flex: none; width: 24px; height: 24px; border-radius: 999px;
+    display: grid; place-items: center; background: hsl(264 72% 62% / 0.20); color: var(--pg-accent); }
+  .node.changed, .node.fixed { background: hsl(0 0% 100% / 0.08); color: var(--pg-teal); }
+  .node svg { width: 12px; height: 12px; }
+  .event { flex: 1; min-width: 0; padding: 12px; border-radius: var(--pg-r-md); border: 1px solid transparent;
+    animation: pop var(--pg-dur-normal) var(--pg-ease) both; }
+  .event.past { opacity: .5; }
+  .event.current { background: var(--pg-glass-2); border-color: hsl(264 72% 62% / 0.40);
+    box-shadow: 0 0 0 4px hsl(264 72% 62% / 0.16); }
+  .event .top { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+  .event h3 { margin: 0; font-size: 13.5px; font-weight: 700; letter-spacing: -.2px; }
+  .event time { font-family: var(--pg-mono); font-size: 10px; color: var(--pg-faint); flex: none; }
+  .event p { margin: 4px 0 0; font-size: 11.5px; line-height: 1.5; color: var(--pg-muted); }
+  .event .foot { margin-top: 12px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .pill { font-size: 9.5px; font-weight: 800; letter-spacing: .4px; text-transform: uppercase;
+    border-radius: 999px; padding: 4px 8px; background: hsl(264 72% 62% / 0.18); color: hsl(264 90% 86%); }
+  .pill.changed { background: hsl(0 0% 100% / 0.08); color: var(--pg-ink); }
+  .pill.shipped { background: hsl(264 72% 62% / 0.14); color: var(--pg-accent); }
+  .acts { display: flex; gap: 8px; opacity: 0; transition: opacity var(--pg-dur-fast); }
+  .event.current .acts, .event:hover .acts, .event:focus-within .acts { opacity: 1; }
+  .act { font: inherit; font-size: 11px; color: var(--pg-ink); text-decoration: none;
+    background: hsl(0 0% 100% / 0.08); border-radius: 8px; padding: 4px 8px; }
+  .act:hover, .act:focus-visible { color: var(--pg-accent); outline: none; }
+  .act.flash { box-shadow: 0 0 0 2px hsl(264 72% 62% / 0.55); }
+
+  .arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--pg-muted); }
+  .arrow .ar { font-size: 30px; color: var(--pg-accent); }
+  [dir="rtl"] .arrow .ar { transform: scaleX(-1); }
+  .arrow .cap { font-size: 11px; max-width: 132px; text-align: center; line-height: 1.5; }
+
+  .impact { width: 280px; background: hsl(220 18% 96%); color: hsl(232 25% 16%); border-radius: var(--pg-r-md);
+    padding: 16px; position: relative; overflow: hidden; box-shadow: var(--pg-shadow);
+    animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .impact .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; background: var(--pg-accent); }
+  .impact .kind { font-size: 10.5px; font-weight: 800; letter-spacing: .3px; color: hsl(232 12% 45%); text-transform: uppercase; }
+  .impact h3 { margin: 8px 0 12px; font-size: 18px; letter-spacing: -.3px; }
+  .impact .row { display: flex; gap: 8px; font-size: 13px; color: hsl(232 16% 28%); margin-top: 8px; line-height: 1.45; }
+  .impact .tick { color: var(--pg-accent-deep); font-weight: 800; flex: none; }
+  .impact .added { margin-top: 12px; padding-top: 12px; border-top: 1px dashed hsl(232 16% 88%);
+    font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+
+  .promptbar { display: flex; align-items: center; gap: 16px; padding: 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(220 16% 80%); }
+  .promptbar .pt b { color: var(--pg-accent); }
+  .copy { flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(264 40% 96%);
+    border-radius: 12px; padding: 12px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 10px 26px -12px hsl(264 70% 50% / 0.8); }
+  .copy:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.97); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(16px) scale(.94); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    .feed { scroll-behavior: auto; }
+    .acts { opacity: 1; }
+  }
+  html.reduce *, html.reduce *::before, html.reduce *::after {
+    animation-duration: .01ms !important; transition-duration: .01ms !important;
+  }
+  html.reduce .acts { opacity: 1; }
+  @media (max-width: 760px) { .arrow .ar { transform: rotate(90deg); } [dir="rtl"] .arrow .ar { transform: rotate(90deg) scaleX(-1); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="head">
+    <div class="logo" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="hsl(264 40% 96%)" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+    </div>
+    <div>
+      <h1>Chrono Board on <span class="v">What's new</span></h1>
+      <p>Press <b>Play</b>. The 21st.dev timeline becomes the OrchestKit release surface:
+         live catalog counts, product bullets, then the five-release changelog rail.
+         <b>Notes</b> jumps to the version. <b>Diff</b> opens compare. Reduced-motion keeps both actions visible.</p>
+    </div>
+    <div class="right">
+      <button class="toggle" id="reduceToggle" aria-pressed="false">Reduced motion</button>
+      <button class="toggle" id="dirToggle" aria-pressed="false">RTL</button>
+    </div>
+  </header>
+
+  <div class="panel transport">
+    <button class="btn" id="prev" type="button">Back</button>
+    <button class="btn primary" id="play" type="button">Play</button>
+    <button class="btn" id="next" type="button">Next</button>
+    <span class="hint" id="stepHint"></span>
+  </div>
+
+  <main class="panel stage" id="stage"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn" type="button">Copy prompt</button>
+  </div>
+</div>
+
+<script>
+const STEPS = [
+  {
+    surface: "whats-new",
+    current: 0,
+    flash: null,
+    title: "Live catalog card",
+    kind: "What's new",
+    lines: [
+      "OrchestKit 10.0.0-beta.12 is the first card, not a fake system status.",
+      "107 skills, 36 agents, 171 hooks come from COUNTS + SITE.version."
+    ]
+  },
+  {
+    surface: "whats-new",
+    current: 1,
+    flash: null,
+    title: "Product bullet on the rail",
+    kind: "What's new",
+    lines: [
+      "Plumbing prefixes stay off the board. Product bullets stay on it.",
+      "Generic floor Lab is a real 10.0.0-beta.12 changelog line."
+    ]
+  },
+  {
+    surface: "whats-new",
+    current: 2,
+    flash: null,
+    title: "Host-first install ships",
+    kind: "What's new",
+    lines: [
+      "The third card is the host-first wizard, still the same timeline.",
+      "Notes still points at /changelog#10.0.0-beta.12."
+    ]
+  },
+  {
+    surface: "changelog",
+    current: 0,
+    flash: null,
+    title: "Five-release activity rail",
+    kind: "Changelog",
+    lines: [
+      "/changelog now opens with a Chrono Board of the last five versions.",
+      "The latest card is current. Older cards keep the rail and status pills."
+    ]
+  },
+  {
+    surface: "changelog",
+    current: 1,
+    flash: "notes",
+    title: "Notes jumps into the rail",
+    kind: "Action",
+    lines: [
+      "Notes is a real link, not a Dismiss stub.",
+      "On changelog it hashes to #10.0.0-beta.11 and the existing rail scrolls."
+    ]
+  },
+  {
+    surface: "changelog",
+    current: 1,
+    flash: "diff",
+    title: "Diff opens compare",
+    kind: "Action",
+    lines: [
+      "Diff uses the release compareUrl on GitHub.",
+      "Reduced-motion keeps Notes and Diff at full opacity, not hover-only."
+    ]
+  }
+];
+
+const SURFACES = {
+  "whats-new": {
+    name: "What's new",
+    sub: "Release · live catalog",
+    version: "10.0.0-beta.12",
+    cards: [
+      { title: "OrchestKit 10.0.0-beta.12 live", date: "Sep 9, 2026",
+        desc: "107 skills · 36 agents · 171 hooks", status: "Latest", tone: "live",
+        notes: "/changelog#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.11...v10.0.0-beta.12" },
+      { title: "generic floor Lab and portable skill invoke", date: "Sep 9, 2026",
+        desc: "A skill you invoke with /ork: changed. Re-read that skill page if you use it.",
+        status: "Changed", tone: "changed", notes: "/changelog#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/issues/4018" },
+      { title: "host-first install wizard and multi-host getting started", date: "Sep 9, 2026",
+        desc: "Shipped in this release. Open the linked PR if you need the full rationale.",
+        status: "Changed", tone: "changed", notes: "/changelog#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/issues/4016" }
+    ]
+  },
+  changelog: {
+    name: "Changelog",
+    sub: "Release activity · last 5",
+    version: "5 releases",
+    cards: [
+      { title: "10.0.0-beta.12", date: "Sep 9, 2026",
+        desc: "deps: bump hono in /src/mcp-server", status: "Latest", tone: "live",
+        notes: "#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.11...v10.0.0-beta.12" },
+      { title: "10.0.0-beta.11", date: "Sep 8, 2026",
+        desc: "codex: ship the ork-mech profile", status: "Shipped", tone: "added",
+        notes: "#10.0.0-beta.11",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.10...v10.0.0-beta.11" },
+      { title: "10.0.0-beta.10", date: "Sep 8, 2026",
+        desc: "cursor: export rules to .cursor-plugin", status: "Shipped", tone: "added",
+        notes: "#10.0.0-beta.10",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.9...v10.0.0-beta.10" }
+    ]
+  }
+};
+
+const ICONS = {
+  live: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>',
+  added: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
+  changed: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>'
+};
+
+const state = { step: 0, playing: false, rtl: false, reduce: false };
+let timer = null;
+const stage = document.getElementById("stage");
+const esc = s => String(s).replace(/[&<>]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+const maxStep = () => STEPS.length - 1;
+
+function cardHtml(card, i, current, flash) {
+  const cls = i === current ? "current" : (i < current ? "past" : "");
+  const notesFlash = flash === "notes" && i === current ? " flash" : "";
+  const diffFlash = flash === "diff" && i === current ? " flash" : "";
+  return `<div class="card-row">
+    <div class="rail" aria-hidden="true"></div>
+    <span class="node ${esc(card.tone)}" aria-hidden="true">${ICONS[card.tone] || ICONS.changed}</span>
+    <article class="event ${cls}"${i === current ? ' aria-current="true"' : ""}>
+      <div class="top"><h3>${esc(card.title)}</h3><time>${esc(card.date)}</time></div>
+      <p>${esc(card.desc)}</p>
+      <div class="foot">
+        <span class="pill ${card.tone === "live" ? "" : card.tone === "added" ? "shipped" : "changed"}">${esc(card.status)}</span>
+        <div class="acts">
+          <a class="act${notesFlash}" href="${esc(card.notes)}" aria-label="Release notes for ${esc(card.title)}">Notes</a>
+          <a class="act${diffFlash}" href="${esc(card.diff)}" target="_blank" rel="noopener noreferrer" aria-label="Diff for ${esc(card.title)}">Diff</a>
+        </div>
+      </div>
+    </article>
+  </div>`;
+}
+
+function render() {
+  const step = STEPS[state.step];
+  const surface = SURFACES[step.surface];
+  const rows = surface.cards.map((card, i) => cardHtml(card, i, step.current, step.flash)).join("");
+  const impact = `<div class="impact"><div class="stripe"></div>
+    <div class="kind">${esc(step.kind)}</div>
+    <h3>${esc(step.title)}</h3>
+    ${step.lines.map(l => `<div class="row"><span class="tick">+</span><span>${esc(l)}</span></div>`).join("")}
+    <div class="added">${esc(surface.name)} · ${esc(surface.version)}</div></div>`;
+
+  stage.innerHTML = `
+    <div class="phone"><div class="screen">
+      <div class="app-head">
+        <div class="av">${ICONS.live}</div>
+        <div><div class="nm">OrchestKit · ${esc(surface.name)}</div><div class="st">${esc(surface.sub)}</div></div>
+        <div class="vpill">${esc(surface.version)}</div>
+      </div>
+      <div class="feed" id="feed"><div class="board">${rows}</div></div>
+    </div></div>
+    <div class="arrow"><div class="ar">-&gt;</div><div class="cap">this card → what it changes for a visitor</div></div>
+    ${impact}`;
+
+  const feed = document.getElementById("feed");
+  if (feed) {
+    const c = feed.querySelector(".event.current");
+    if (c) c.scrollIntoView({ block: "nearest" });
+  }
+  document.getElementById("stepHint").innerHTML = `Step <b>${state.step + 1}</b> of <b>${maxStep() + 1}</b> · ${esc(step.title)}`;
+  document.getElementById("prev").disabled = state.step <= 0;
+  document.getElementById("next").disabled = state.step >= maxStep();
+  updatePrompt();
+}
+
+function updatePrompt() {
+  document.getElementById("promptOut").innerHTML =
+    `Build a <b>release-notes player</b> for OrchestKit <b>10.0.0-beta.12</b>: cool-glass Chrono Board `
+    + `on What's new and /changelog, fed by CHANGELOG_ENTRIES plus skill/agent/hook counts. `
+    + `Notes hashes to the version. Diff opens compare. Reduced-motion keeps both actions usable.`;
+}
+
+function stop() {
+  state.playing = false;
+  clearTimeout(timer);
+  document.getElementById("play").textContent = "Play";
+}
+function play() {
+  if (state.playing) return stop();
+  state.playing = true;
+  document.getElementById("play").textContent = "Pause";
+  state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) return stop();
+    state.step++;
+    render();
+    timer = setTimeout(tick, 1600);
+  };
+  tick();
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => { stop(); state.step = Math.max(0, state.step - 1); render(); });
+document.getElementById("next").addEventListener("click", () => { stop(); state.step = Math.min(maxStep(), state.step + 1); render(); });
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl;
+  document.documentElement.dir = state.rtl ? "rtl" : "ltr";
+  e.currentTarget.setAttribute("aria-pressed", String(state.rtl));
+});
+document.getElementById("reduceToggle").addEventListener("click", e => {
+  state.reduce = !state.reduce;
+  document.documentElement.classList.toggle("reduce", state.reduce);
+  e.currentTarget.setAttribute("aria-pressed", String(state.reduce));
+});
+document.getElementById("copyBtn").addEventListener("click", () => {
+  navigator.clipboard.writeText(document.getElementById("promptOut").textContent).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "Copied";
+    b.classList.add("done");
+    setTimeout(() => { b.textContent = "Copy prompt"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+render();
+</script>
+</body>
+</html>

--- a/docs/site/__tests__/chrono-board-release.test.ts
+++ b/docs/site/__tests__/chrono-board-release.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { ChangelogEntry } from "@/lib/generated/changelog-data";
+import {
+  buildReleaseChronoCards,
+  buildVersionChronoCards,
+} from "@/lib/chrono-board-release";
+
+const ENTRIES: ChangelogEntry[] = [
+  {
+    version: "10.0.0-beta.12",
+    date: "2026-09-09",
+    compareUrl: "https://github.com/yonatangross/orchestkit/compare/a...b",
+    sections: [
+      {
+        type: "changed",
+        heading: "Miscellaneous",
+        items: ["**build:** stamp manifests"],
+      },
+    ],
+  },
+  {
+    version: "10.0.0-beta.11",
+    date: "2026-09-08",
+    compareUrl: "https://github.com/yonatangross/orchestkit/compare/c...d",
+    sections: [
+      {
+        type: "added",
+        heading: "Features",
+        items: [
+          "**skills:** relative paths ([#4012](https://github.com/yonatangross/orchestkit/issues/4012))",
+        ],
+      },
+    ],
+  },
+];
+
+describe("buildReleaseChronoCards", () => {
+  it("leads with live catalog counts and follows with product changelog items", () => {
+    const cards = buildReleaseChronoCards({
+      entries: ENTRIES,
+      counts: { skills: 107, agents: 36, hooks: 172 },
+      latestVersion: "10.0.0-beta.12",
+      itemLimit: 3,
+    });
+
+    expect(cards[0]).toMatchObject({
+      title: "OrchestKit 10.0.0-beta.12 live",
+      description: "107 skills · 36 agents · 172 hooks",
+      status: "Latest",
+      tone: "live",
+      active: true,
+      notesHref: "/changelog#10.0.0-beta.12",
+    });
+    expect(cards[1]).toMatchObject({
+      title: "relative paths",
+      status: "Shipped",
+      tone: "added",
+      notesHref: "/changelog#10.0.0-beta.11",
+      diffHref: "https://github.com/yonatangross/orchestkit/issues/4012",
+    });
+    expect(cards.some((card) => /System Status|Phoenix-Next|Server Maintenance/i.test(card.title))).toBe(
+      false,
+    );
+  });
+
+  it("skips plumbing-only bullets when picking product cards", () => {
+    const cards = buildReleaseChronoCards({
+      entries: ENTRIES,
+      counts: { skills: 1, agents: 1, hooks: 1 },
+      latestVersion: "10.0.0-beta.12",
+    });
+    expect(cards.map((card) => card.title)).not.toContain("stamp manifests");
+  });
+});
+
+describe("buildVersionChronoCards", () => {
+  it("maps each recent release to a timeline card", () => {
+    const cards = buildVersionChronoCards(ENTRIES, 2);
+    expect(cards).toHaveLength(2);
+    expect(cards[0]).toMatchObject({
+      id: "10.0.0-beta.12",
+      title: "10.0.0-beta.12",
+      status: "Latest",
+      tone: "live",
+      notesHref: "#10.0.0-beta.12",
+    });
+    expect(cards[1]?.title).toBe("10.0.0-beta.11");
+    expect(cards[1]?.description).toMatch(/relative paths/i);
+  });
+});

--- a/docs/site/__tests__/chrono-board-release.test.ts
+++ b/docs/site/__tests__/chrono-board-release.test.ts
@@ -63,6 +63,17 @@ describe("buildReleaseChronoCards", () => {
     );
   });
 
+  it("returns only the live card when there are no changelog entries", () => {
+    const cards = buildReleaseChronoCards({
+      entries: [],
+      counts: { skills: 1, agents: 1, hooks: 1 },
+      latestVersion: "10.0.0-beta.12",
+    });
+    expect(cards).toHaveLength(1);
+    expect(cards[0]?.tone).toBe("live");
+    expect(cards[0]?.notesHref).toBe("/changelog");
+  });
+
   it("skips plumbing-only bullets when picking product cards", () => {
     const cards = buildReleaseChronoCards({
       entries: ENTRIES,

--- a/docs/site/__tests__/chrono-board.test.tsx
+++ b/docs/site/__tests__/chrono-board.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ChronoBoard } from "@/components/ui/chrono-board";
+import type { ChronoBoardCardModel } from "@/lib/chrono-board-release";
+
+const CARDS: ChronoBoardCardModel[] = [
+  {
+    id: "live",
+    title: "OrchestKit 10.0.0-beta.12 live",
+    description: "107 skills · 36 agents · 172 hooks",
+    date: "Sep 9, 2026",
+    status: "Latest",
+    tone: "live",
+    active: true,
+    notesHref: "/changelog#10.0.0-beta.12",
+    diffHref: "https://github.com/yonatangross/orchestkit/compare/a...b",
+  },
+  {
+    id: "item",
+    title: "relative paths",
+    description: "A skill you invoke with /ork: changed.",
+    date: "Sep 8, 2026",
+    status: "Shipped",
+    tone: "added",
+    notesHref: "/changelog#10.0.0-beta.11",
+  },
+];
+
+describe("ChronoBoard", () => {
+  it("renders release cards with Notes/Diff actions and theme tokens", () => {
+    const { container } = render(
+      <ChronoBoard cards={CARDS} labelledBy="whats-new-heading" />,
+    );
+
+    expect(screen.getByText("OrchestKit 10.0.0-beta.12 live")).toBeTruthy();
+    expect(screen.getByText("107 skills · 36 agents · 172 hooks")).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Release notes for OrchestKit 10.0.0-beta.12 live" }).getAttribute("href"),
+    ).toBe("/changelog#10.0.0-beta.12");
+    expect(
+      screen.getByRole("link", { name: "Diff for OrchestKit 10.0.0-beta.12 live" }).getAttribute("href"),
+    ).toContain("github.com/yonatangross/orchestkit/compare");
+    expect(screen.queryByText("Dismiss")).toBeNull();
+    expect(screen.queryByText("System Status: Nominal")).toBeNull();
+
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/slate-800|bg-green-400|bg-blue-400|bg-amber-400|#0A0A0A/);
+    expect(html).toMatch(/--color-fd-primary|--yy-george/);
+  });
+
+  it("marks the live card as the current item", () => {
+    const { container } = render(<ChronoBoard cards={CARDS} />);
+    const current = container.querySelector("[aria-current='true']");
+    expect(current?.textContent).toMatch(/10\.0\.0-beta\.12 live/);
+  });
+});

--- a/docs/site/app/(home)/changelog/page.tsx
+++ b/docs/site/app/(home)/changelog/page.tsx
@@ -5,8 +5,10 @@ import {
   RecentVersions,
 } from "@/components/changelog-legend";
 import { ChangelogMermaid } from "@/components/changelog-mermaid";
+import { ChronoBoard } from "@/components/ui/chrono-board";
 import { CHANGELOG_ENTRIES } from "@/lib/generated/changelog-data";
 import { howToReadMermaid, recentTimelineMermaid } from "@/lib/changelog-format";
+import { buildVersionChronoCards } from "@/lib/chrono-board-release";
 import { SITE } from "@/lib/constants";
 
 export const metadata: Metadata = {
@@ -63,6 +65,16 @@ export default function ChangelogPage() {
         </p>
         <ChangelogLegend />
         <ChangelogMermaid chart={howToReadMermaid()} />
+        <h2
+          id="release-activity-heading"
+          className="font-mono text-[11px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground"
+        >
+          Release activity
+        </h2>
+        <ChronoBoard
+          cards={buildVersionChronoCards(CHANGELOG_ENTRIES, 5)}
+          labelledBy="release-activity-heading"
+        />
         <p className="font-mono text-[11px] font-medium uppercase tracking-[0.06em] text-fd-muted-foreground">
           Recent versions
         </p>

--- a/docs/site/components/ui/chrono-board.tsx
+++ b/docs/site/components/ui/chrono-board.tsx
@@ -1,0 +1,182 @@
+import type { ReactNode } from "react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  RefreshCw,
+  ShieldAlert,
+  XCircle,
+  Zap,
+} from "lucide-react";
+import type { ChronoBoardCardModel, ChronoTone } from "@/lib/chrono-board-release";
+
+/**
+ * Chrono Board — 21st.dev `dhileepkumargm/chrono-board` (demo 9216), adapted.
+ * Timeline rail, status-cued cards, and two hover/focus actions. Slate/green
+ * demo chrome is replaced with fd-* / George tokens. Wired to OrchestKit
+ * release data by the caller — this file does not invent activity.
+ */
+
+function cn(...inputs: Array<string | false | null | undefined>): string {
+  return inputs.filter(Boolean).join(" ");
+}
+
+const TONE_NODE: Record<ChronoTone, string> = {
+  live: "bg-[var(--color-fd-primary-20)] text-fd-primary",
+  added: "bg-[var(--color-fd-primary-20)] text-fd-primary",
+  fixed: "bg-fd-muted text-[var(--yy-george-cool-text)]",
+  changed: "bg-fd-muted text-fd-foreground",
+  removed: "bg-fd-muted text-fd-error",
+  deprecated: "bg-fd-muted text-[var(--yy-george-warm-text)]",
+  security: "border border-fd-error/40 bg-fd-muted text-fd-error",
+};
+
+const TONE_PILL: Record<ChronoTone, string> = {
+  live: "bg-[var(--color-fd-primary-20)] text-fd-primary",
+  added: "bg-[var(--color-fd-primary-10)] text-fd-primary",
+  fixed: "bg-fd-muted text-[var(--yy-george-cool-text)]",
+  changed: "bg-fd-muted text-fd-foreground",
+  removed: "bg-fd-muted text-fd-error",
+  deprecated: "bg-fd-muted text-[var(--yy-george-warm-text)]",
+  security: "border border-fd-error/40 bg-fd-muted text-fd-error",
+};
+
+const TONE_ICON: Record<ChronoTone, typeof Zap> = {
+  live: CheckCircle2,
+  added: Zap,
+  fixed: CheckCircle2,
+  changed: RefreshCw,
+  removed: XCircle,
+  deprecated: AlertTriangle,
+  security: ShieldAlert,
+};
+
+export function DisplayCard({
+  title,
+  description,
+  date,
+  status,
+  tone,
+  active = false,
+  notesHref,
+  diffHref,
+  showRail,
+}: ChronoBoardCardModel & { showRail: boolean }) {
+  const Icon = TONE_ICON[tone];
+
+  return (
+    <article
+      className="group/card relative flex items-start gap-x-4"
+      aria-current={active ? "true" : undefined}
+    >
+      {showRail ? (
+        <div
+          aria-hidden="true"
+          className="absolute left-[11px] top-6 h-full w-px bg-fd-border"
+        />
+      ) : null}
+
+      <span
+        className={cn(
+          "relative z-10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full",
+          TONE_NODE[tone],
+        )}
+        aria-hidden="true"
+      >
+        <Icon className="h-3 w-3" />
+      </span>
+
+      <div
+        className={cn(
+          "min-w-0 flex-1 rounded-xl border p-4 motion-reduce:transition-none",
+          active
+            ? "border-fd-primary/40 bg-[var(--color-fd-surface-raised)] shadow-[0_0_0_4px_var(--color-fd-glow)]"
+            : "border-transparent group-hover/card:border-fd-border group-hover/card:bg-[var(--color-fd-surface-raised)] group-focus-within/card:border-fd-border",
+        )}
+      >
+        <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+          <h3 className="text-base font-semibold tracking-[-0.01em] text-fd-foreground">
+            {title}
+          </h3>
+          {date ? (
+            <time className="font-mono text-[11px] text-fd-muted-foreground">
+              {date}
+            </time>
+          ) : null}
+        </div>
+        <p className="mt-1 text-[13px] leading-[1.55] text-fd-muted-foreground">
+          {description}
+        </p>
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+          <span
+            className={cn(
+              "rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide",
+              TONE_PILL[tone],
+            )}
+          >
+            {status}
+          </span>
+          <div
+            className={cn(
+              "flex items-center gap-2 opacity-0 transition-opacity duration-200",
+              "group-hover/card:opacity-100 group-focus-within/card:opacity-100",
+              "motion-reduce:opacity-100 motion-reduce:transition-none",
+            )}
+          >
+            <a
+              href={notesHref}
+              aria-label={`Release notes for ${title}`}
+              className="rounded-md bg-fd-muted px-3 py-1 text-[12px] text-fd-foreground transition-colors hover:text-fd-primary"
+            >
+              Notes
+            </a>
+            {diffHref ? (
+              <a
+                href={diffHref}
+                aria-label={`Diff for ${title}`}
+                target={diffHref.startsWith("http") ? "_blank" : undefined}
+                rel={diffHref.startsWith("http") ? "noopener noreferrer" : undefined}
+                className="rounded-md bg-fd-muted px-3 py-1 text-[12px] text-fd-foreground transition-colors hover:text-fd-primary"
+              >
+                Diff
+              </a>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function DisplayCards({ cards }: { cards: ChronoBoardCardModel[] }) {
+  return (
+    <ol className="relative w-full space-y-4">
+      {cards.map((card, index) => (
+        <li key={card.id}>
+          <DisplayCard {...card} showRail={index < cards.length - 1} />
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function ChronoBoard({
+  cards,
+  labelledBy,
+  caption,
+}: {
+  cards: ChronoBoardCardModel[];
+  labelledBy?: string;
+  caption?: ReactNode;
+}) {
+  if (cards.length === 0) return null;
+
+  return (
+    <div
+      className="relative w-full"
+      aria-labelledby={labelledBy}
+    >
+      {caption}
+      <DisplayCards cards={cards} />
+    </div>
+  );
+}

--- a/docs/site/components/whats-new-strip.tsx
+++ b/docs/site/components/whats-new-strip.tsx
@@ -1,18 +1,18 @@
 import Link from "next/link";
 import { ArrowRight } from "lucide-react";
+import { ChronoBoard } from "@/components/ui/chrono-board";
 import { CHANGELOG_ENTRIES } from "@/lib/generated/changelog-data";
-import {
-  TAG_BG,
-  SECTION_LABEL,
-  formatChangelogDate,
-  markdownInline,
-  pickWhatsNewPreview,
-} from "@/lib/changelog-format";
+import { COUNTS, SITE } from "@/lib/constants";
+import { buildReleaseChronoCards } from "@/lib/chrono-board-release";
 
 export function WhatsNewStrip() {
-  const preview = pickWhatsNewPreview(CHANGELOG_ENTRIES, 3);
-  if (!preview) return null;
-  const { entry, items } = preview;
+  const cards = buildReleaseChronoCards({
+    entries: CHANGELOG_ENTRIES,
+    counts: COUNTS,
+    latestVersion: SITE.version,
+    itemLimit: 3,
+  });
+  if (cards.length === 0) return null;
 
   return (
     <section
@@ -42,38 +42,7 @@ export function WhatsNewStrip() {
           </Link>
         </div>
 
-        <div className="rounded-xl border border-fd-border bg-[var(--color-fd-surface-raised)] p-5">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-md bg-[var(--color-fd-primary-20)] px-2 py-0.5 font-mono text-xs font-semibold text-fd-primary">
-              {entry.version}
-            </span>
-            <span className="font-mono text-[11px] text-fd-muted-foreground">
-              {formatChangelogDate(entry.date)}
-            </span>
-            {entry === CHANGELOG_ENTRIES[0] ? (
-              <span className="rounded-sm bg-[var(--color-fd-primary-20)] px-1.5 py-px text-[9px] font-bold uppercase tracking-wider text-fd-primary">
-                Latest
-              </span>
-            ) : null}
-          </div>
-          <ul className="mt-4 space-y-2">
-            {items.map((row, i) => (
-              <li key={i} className="flex items-start gap-2.5">
-                <span
-                  className={`mt-0.5 inline-block shrink-0 rounded-sm px-1.5 py-px text-[10px] font-semibold uppercase tracking-wide ${TAG_BG[row.type]}`}
-                >
-                  {SECTION_LABEL[row.type]}
-                </span>
-                <span
-                  className="text-[13px] leading-[1.55] text-fd-foreground/80"
-                  dangerouslySetInnerHTML={{
-                    __html: markdownInline(row.item.split("\n")[0]),
-                  }}
-                />
-              </li>
-            ))}
-          </ul>
-        </div>
+        <ChronoBoard cards={cards} labelledBy="whats-new-heading" />
       </div>
     </section>
   );

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "chrono-board-release",
+      "source": "docs/feat--docs-chrono-board-release/chrono-board.html",
+      "title": "Chrono Board: What's new becomes a release timeline",
+      "description": "Play the 21st.dev Chrono Board on the docs site. What's new is a live catalog card plus product bullets. Changelog gets a five-release activity rail. Notes jumps to the version; Diff opens compare. Reduced-motion keeps the actions usable.",
+      "tags": [
+        "docs",
+        "site",
+        "release"
+      ],
+      "date": "2026-09-09"
+    },
+    {
       "slug": "community-kinetic-bento",
       "source": "docs/docs--community-live-room/community-doors.html",
       "title": "Community doors: kinetic mesh, live-room example",

--- a/docs/site/lib/chrono-board-release.ts
+++ b/docs/site/lib/chrono-board-release.ts
@@ -58,7 +58,9 @@ export function buildReleaseChronoCards({
     diffHref: latest?.compareUrl || undefined,
   };
 
-  const items = (preview?.items ?? []).map((row, index) => {
+  if (!preview) return [live];
+
+  const items = preview.items.map((row, index) => {
     const parsed = parseChangelogItem(row.item);
     const entry = preview.entry;
     return {

--- a/docs/site/lib/chrono-board-release.ts
+++ b/docs/site/lib/chrono-board-release.ts
@@ -1,0 +1,112 @@
+import { COUNTS, SITE } from "@/lib/constants";
+import type { ChangelogEntry, SectionType } from "@/lib/generated/changelog-data";
+import {
+  entryHeadline,
+  formatChangelogDate,
+  isProductChangelogItem,
+  parseChangelogItem,
+  pickWhatsNewPreview,
+  releaseSectionMix,
+} from "@/lib/changelog-format";
+
+export type ChronoTone = SectionType | "live";
+
+export type ChronoBoardCardModel = {
+  id: string;
+  title: string;
+  description: string;
+  date: string;
+  status: string;
+  tone: ChronoTone;
+  active?: boolean;
+  notesHref: string;
+  diffHref?: string;
+};
+
+export const CHRONO_STATUS_LABEL: Record<ChronoTone, string> = {
+  live: "Latest",
+  added: "Shipped",
+  fixed: "Fixed",
+  changed: "Changed",
+  removed: "Removed",
+  deprecated: "Deprecated",
+  security: "Security",
+};
+
+export function buildReleaseChronoCards({
+  entries,
+  counts = COUNTS,
+  latestVersion = SITE.version,
+  itemLimit = 3,
+}: {
+  entries: ChangelogEntry[];
+  counts?: { skills: number; agents: number; hooks: number };
+  latestVersion?: string;
+  itemLimit?: number;
+}): ChronoBoardCardModel[] {
+  const latest = entries[0];
+  const preview = pickWhatsNewPreview(entries, itemLimit);
+  const live: ChronoBoardCardModel = {
+    id: `live-${latestVersion}`,
+    title: `OrchestKit ${latestVersion} live`,
+    description: `${counts.skills} skills · ${counts.agents} agents · ${counts.hooks} hooks`,
+    date: latest ? formatChangelogDate(latest.date) : "",
+    status: CHRONO_STATUS_LABEL.live,
+    tone: "live",
+    active: true,
+    notesHref: latest ? `/changelog#${latest.version}` : "/changelog",
+    diffHref: latest?.compareUrl || undefined,
+  };
+
+  const items = (preview?.items ?? []).map((row, index) => {
+    const parsed = parseChangelogItem(row.item);
+    const entry = preview.entry;
+    return {
+      id: `${entry.version}-${index}`,
+      title: parsed.title,
+      description: parsed.rationale,
+      date: formatChangelogDate(entry.date),
+      status: CHRONO_STATUS_LABEL[row.type],
+      tone: row.type,
+      notesHref: `/changelog#${entry.version}`,
+      diffHref: parsed.issues[0]?.href ?? entry.compareUrl ?? undefined,
+    } satisfies ChronoBoardCardModel;
+  });
+
+  return [live, ...items];
+}
+
+export function buildVersionChronoCards(
+  entries: ChangelogEntry[],
+  take = 5,
+): ChronoBoardCardModel[] {
+  return entries.slice(0, take).map((entry, index) => {
+    const product = entry.sections.flatMap((section) =>
+      section.items
+        .filter(isProductChangelogItem)
+        .map((item) => ({ type: section.type, item })),
+    );
+    const lead = product[0] ??
+      entry.sections.flatMap((section) =>
+        section.items.map((item) => ({ type: section.type, item })),
+      )[0];
+    const mix = releaseSectionMix(entry);
+    const tone: ChronoTone = index === 0 ? "live" : (lead?.type ?? "changed");
+    const description = lead
+      ? entryHeadline([lead.item])
+      : mix.map((item) => `${item.count} ${item.heading}`).join(" · ") ||
+        "Release notes";
+
+    return {
+      id: entry.version,
+      title: entry.version,
+      description,
+      date: formatChangelogDate(entry.date),
+      status: index === 0 ? CHRONO_STATUS_LABEL.live : CHRONO_STATUS_LABEL[tone],
+      tone,
+      active: index === 0,
+      notesHref: `#${entry.version}`,
+      diffHref: entry.compareUrl || undefined,
+    };
+  });
+}

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -57,6 +57,20 @@ export const LAB_ENTRIES: LabEntry[] = [
     "sizeKb": 16
   },
   {
+    "slug": "chrono-board-release",
+    "title": "Chrono Board: What's new becomes a release timeline",
+    "description": "Play the 21st.dev Chrono Board on the docs site. What's new is a live catalog card plus product bullets. Changelog gets a five-release activity rail. Notes jumps to the version; Diff opens compare. Reduced-motion keeps the actions usable.",
+    "tags": [
+      "docs",
+      "site",
+      "release"
+    ],
+    "date": "2026-09-09",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 22
+  },
+  {
     "slug": "codex-mech-profile",
     "title": "The Codex mech profile: which file codex actually reads",
     "description": "Put the ork-mech profile in three places and read codex 0.153.4's own answer: a hard config-load error for the legacy [profiles.*] table, a silent base-config run for a name that does not exist, and the measured header for the shipped file. Plus the worktree writable-roots line with and without --add-dir.",

--- a/docs/site/public/lab/chrono-board-release.html
+++ b/docs/site/public/lab/chrono-board-release.html
@@ -1,0 +1,425 @@
+<!doctype html>
+<!--
+  RELEASE-NOTES PLAYER · Chrono Board on the OrchestKit docs site
+  Archetype: user-story-player (release-notes-player recipe)
+  Persona: cool-glass. Conforms to shared/rules/playground-visual-standard.md
+  21st.dev dhileepkumargm/chrono-board (demo 9216), wired to real ork data.
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Chrono Board: What's new becomes a release timeline</title>
+<meta name="description" content="Play the 21st.dev Chrono Board on the docs site. What's new is a live catalog card plus product bullets. Changelog gets a five-release activity rail. Notes jumps to the version; Diff opens compare. Reduced-motion keeps the actions usable.">
+<style>
+  :root {
+    --pg-bg: hsl(232 26% 7%);
+    --pg-ink: hsl(220 18% 93%);
+    --pg-muted: hsl(222 12% 64%);
+    --pg-faint: hsl(222 10% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(264 72% 62%);
+    --pg-accent-deep: hsl(264 70% 46%);
+    --pg-teal: hsl(220 40% 62%);
+    --pg-shadow: 0 20px 60px -22px hsl(264 60% 2% / 0.7), 0 4px 12px -6px hsl(264 60% 2% / 0.5);
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(264 72% 62% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(248 70% 58% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 24px 16px 48px; display: flex; flex-direction: column; gap: 16px; }
+  .head { display: flex; align-items: flex-start; gap: 16px; }
+  .logo { width: 48px; height: 48px; border-radius: 16px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 24px -8px hsl(264 70% 50% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .logo svg { width: 22px; height: 22px; }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head h1 .v { color: var(--pg-accent); font-variant-numeric: tabular-nums; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 8px 16px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); border-color: hsl(264 72% 62% / 0.45); }
+
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 12px; padding: 8px 16px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink);
+    transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent;
+    color: hsl(264 40% 96%); box-shadow: 0 10px 26px -12px hsl(264 70% 50% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; font-variant-numeric: tabular-nums; }
+  .hint b { color: var(--pg-muted); }
+
+  .stage { padding: 24px; display: flex; gap: 24px; align-items: center; justify-content: center; flex-wrap: wrap; }
+
+  .phone { width: 320px; height: 600px; border-radius: 54px; padding: 12px; flex: none; position: relative;
+    background: linear-gradient(160deg, hsl(232 14% 17%), hsl(232 22% 7%));
+    box-shadow: var(--pg-shadow), inset 0 0 0 2px hsl(0 0% 100% / 0.06); }
+  .phone::after { content: ""; position: absolute; top: 16px; left: 50%; transform: translateX(-50%);
+    width: 112px; height: 24px; background: hsl(232 30% 3%); border-radius: 0 0 16px 16px; z-index: 5; }
+  .screen { height: 100%; border-radius: 42px; overflow: hidden; display: flex; flex-direction: column; background: hsl(232 24% 9%); }
+  .app-head { padding: 24px 16px 12px; display: flex; align-items: center; gap: 12px; background: hsl(232 22% 13%); }
+  .app-head .av { width: 40px; height: 40px; border-radius: 12px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); box-shadow: inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .app-head .av svg { width: 18px; height: 18px; }
+  .app-head .nm { font-size: 14px; font-weight: 700; }
+  .app-head .st { font-size: 11px; color: var(--pg-muted); margin-top: 1px; }
+  .app-head .vpill { margin-inline-start: auto; font-family: var(--pg-mono); font-size: 11px; font-weight: 700;
+    color: var(--pg-accent); background: hsl(264 72% 62% / 0.14); border: 1px solid hsl(264 72% 62% / 0.3);
+    border-radius: 999px; padding: 4px 12px; font-variant-numeric: tabular-nums; }
+  .feed { flex: 1; overflow-y: auto; padding: 12px 12px 16px; scroll-behavior: smooth; }
+  .feed::-webkit-scrollbar { width: 0; }
+
+  .board { position: relative; display: flex; flex-direction: column; gap: 16px; }
+  .card-row { position: relative; display: flex; align-items: flex-start; gap: 12px; }
+  .card-row .rail { position: absolute; inset-inline-start: 11px; top: 24px; bottom: -16px; width: 1px; background: hsl(0 0% 100% / 0.12); }
+  .card-row:last-child .rail { display: none; }
+  .node { position: relative; z-index: 1; flex: none; width: 24px; height: 24px; border-radius: 999px;
+    display: grid; place-items: center; background: hsl(264 72% 62% / 0.20); color: var(--pg-accent); }
+  .node.changed, .node.fixed { background: hsl(0 0% 100% / 0.08); color: var(--pg-teal); }
+  .node svg { width: 12px; height: 12px; }
+  .event { flex: 1; min-width: 0; padding: 12px; border-radius: var(--pg-r-md); border: 1px solid transparent;
+    animation: pop var(--pg-dur-normal) var(--pg-ease) both; }
+  .event.past { opacity: .5; }
+  .event.current { background: var(--pg-glass-2); border-color: hsl(264 72% 62% / 0.40);
+    box-shadow: 0 0 0 4px hsl(264 72% 62% / 0.16); }
+  .event .top { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+  .event h3 { margin: 0; font-size: 13.5px; font-weight: 700; letter-spacing: -.2px; }
+  .event time { font-family: var(--pg-mono); font-size: 10px; color: var(--pg-faint); flex: none; }
+  .event p { margin: 4px 0 0; font-size: 11.5px; line-height: 1.5; color: var(--pg-muted); }
+  .event .foot { margin-top: 12px; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .pill { font-size: 9.5px; font-weight: 800; letter-spacing: .4px; text-transform: uppercase;
+    border-radius: 999px; padding: 4px 8px; background: hsl(264 72% 62% / 0.18); color: hsl(264 90% 86%); }
+  .pill.changed { background: hsl(0 0% 100% / 0.08); color: var(--pg-ink); }
+  .pill.shipped { background: hsl(264 72% 62% / 0.14); color: var(--pg-accent); }
+  .acts { display: flex; gap: 8px; opacity: 0; transition: opacity var(--pg-dur-fast); }
+  .event.current .acts, .event:hover .acts, .event:focus-within .acts { opacity: 1; }
+  .act { font: inherit; font-size: 11px; color: var(--pg-ink); text-decoration: none;
+    background: hsl(0 0% 100% / 0.08); border-radius: 8px; padding: 4px 8px; }
+  .act:hover, .act:focus-visible { color: var(--pg-accent); outline: none; }
+  .act.flash { box-shadow: 0 0 0 2px hsl(264 72% 62% / 0.55); }
+
+  .arrow { display: flex; flex-direction: column; align-items: center; gap: 8px; color: var(--pg-muted); }
+  .arrow .ar { font-size: 30px; color: var(--pg-accent); }
+  [dir="rtl"] .arrow .ar { transform: scaleX(-1); }
+  .arrow .cap { font-size: 11px; max-width: 132px; text-align: center; line-height: 1.5; }
+
+  .impact { width: 280px; background: hsl(220 18% 96%); color: hsl(232 25% 16%); border-radius: var(--pg-r-md);
+    padding: 16px; position: relative; overflow: hidden; box-shadow: var(--pg-shadow);
+    animation: cardin var(--pg-dur-slow) var(--pg-ease) both; }
+  .impact .stripe { position: absolute; inset-inline-start: 0; top: 0; bottom: 0; width: 5px; background: var(--pg-accent); }
+  .impact .kind { font-size: 10.5px; font-weight: 800; letter-spacing: .3px; color: hsl(232 12% 45%); text-transform: uppercase; }
+  .impact h3 { margin: 8px 0 12px; font-size: 18px; letter-spacing: -.3px; }
+  .impact .row { display: flex; gap: 8px; font-size: 13px; color: hsl(232 16% 28%); margin-top: 8px; line-height: 1.45; }
+  .impact .tick { color: var(--pg-accent-deep); font-weight: 800; flex: none; }
+  .impact .added { margin-top: 12px; padding-top: 12px; border-top: 1px dashed hsl(232 16% 88%);
+    font-size: 11px; color: var(--pg-accent-deep); font-weight: 700; }
+
+  .promptbar { display: flex; align-items: center; gap: 16px; padding: 16px; }
+  .promptbar .pt { flex: 1; font-family: var(--pg-mono); font-size: 12px; line-height: 1.6; color: hsl(220 16% 80%); }
+  .promptbar .pt b { color: var(--pg-accent); }
+  .copy { flex: none; cursor: pointer; font: inherit; font-weight: 650; font-size: 12.5px; color: hsl(264 40% 96%);
+    border-radius: 12px; padding: 12px 16px; border: 1px solid transparent;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 10px 26px -12px hsl(264 70% 50% / 0.8); }
+  .copy:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .copy.done { background: var(--pg-glass-2); color: var(--pg-ink); box-shadow: none; border-color: var(--pg-line); }
+
+  @keyframes pop { from { opacity: 0; transform: translateY(8px) scale(.97); } to { opacity: 1; transform: none; } }
+  @keyframes cardin { from { opacity: 0; transform: translateY(16px) scale(.94); } to { opacity: 1; transform: none; } }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; }
+    .feed { scroll-behavior: auto; }
+    .acts { opacity: 1; }
+  }
+  html.reduce *, html.reduce *::before, html.reduce *::after {
+    animation-duration: .01ms !important; transition-duration: .01ms !important;
+  }
+  html.reduce .acts { opacity: 1; }
+  @media (max-width: 760px) { .arrow .ar { transform: rotate(90deg); } [dir="rtl"] .arrow .ar { transform: rotate(90deg) scaleX(-1); } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header class="head">
+    <div class="logo" aria-hidden="true">
+      <svg viewBox="0 0 24 24" fill="none" stroke="hsl(264 40% 96%)" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+    </div>
+    <div>
+      <h1>Chrono Board on <span class="v">What's new</span></h1>
+      <p>Press <b>Play</b>. The 21st.dev timeline becomes the OrchestKit release surface:
+         live catalog counts, product bullets, then the five-release changelog rail.
+         <b>Notes</b> jumps to the version. <b>Diff</b> opens compare. Reduced-motion keeps both actions visible.</p>
+    </div>
+    <div class="right">
+      <button class="toggle" id="reduceToggle" aria-pressed="false">Reduced motion</button>
+      <button class="toggle" id="dirToggle" aria-pressed="false">RTL</button>
+    </div>
+  </header>
+
+  <div class="panel transport">
+    <button class="btn" id="prev" type="button">Back</button>
+    <button class="btn primary" id="play" type="button">Play</button>
+    <button class="btn" id="next" type="button">Next</button>
+    <span class="hint" id="stepHint"></span>
+  </div>
+
+  <main class="panel stage" id="stage"></main>
+
+  <div class="panel promptbar">
+    <div class="pt" id="promptOut"></div>
+    <button class="copy" id="copyBtn" type="button">Copy prompt</button>
+  </div>
+</div>
+
+<script>
+const STEPS = [
+  {
+    surface: "whats-new",
+    current: 0,
+    flash: null,
+    title: "Live catalog card",
+    kind: "What's new",
+    lines: [
+      "OrchestKit 10.0.0-beta.12 is the first card, not a fake system status.",
+      "107 skills, 36 agents, 171 hooks come from COUNTS + SITE.version."
+    ]
+  },
+  {
+    surface: "whats-new",
+    current: 1,
+    flash: null,
+    title: "Product bullet on the rail",
+    kind: "What's new",
+    lines: [
+      "Plumbing prefixes stay off the board. Product bullets stay on it.",
+      "Generic floor Lab is a real 10.0.0-beta.12 changelog line."
+    ]
+  },
+  {
+    surface: "whats-new",
+    current: 2,
+    flash: null,
+    title: "Host-first install ships",
+    kind: "What's new",
+    lines: [
+      "The third card is the host-first wizard, still the same timeline.",
+      "Notes still points at /changelog#10.0.0-beta.12."
+    ]
+  },
+  {
+    surface: "changelog",
+    current: 0,
+    flash: null,
+    title: "Five-release activity rail",
+    kind: "Changelog",
+    lines: [
+      "/changelog now opens with a Chrono Board of the last five versions.",
+      "The latest card is current. Older cards keep the rail and status pills."
+    ]
+  },
+  {
+    surface: "changelog",
+    current: 1,
+    flash: "notes",
+    title: "Notes jumps into the rail",
+    kind: "Action",
+    lines: [
+      "Notes is a real link, not a Dismiss stub.",
+      "On changelog it hashes to #10.0.0-beta.11 and the existing rail scrolls."
+    ]
+  },
+  {
+    surface: "changelog",
+    current: 1,
+    flash: "diff",
+    title: "Diff opens compare",
+    kind: "Action",
+    lines: [
+      "Diff uses the release compareUrl on GitHub.",
+      "Reduced-motion keeps Notes and Diff at full opacity, not hover-only."
+    ]
+  }
+];
+
+const SURFACES = {
+  "whats-new": {
+    name: "What's new",
+    sub: "Release · live catalog",
+    version: "10.0.0-beta.12",
+    cards: [
+      { title: "OrchestKit 10.0.0-beta.12 live", date: "Sep 9, 2026",
+        desc: "107 skills · 36 agents · 171 hooks", status: "Latest", tone: "live",
+        notes: "/changelog#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.11...v10.0.0-beta.12" },
+      { title: "generic floor Lab and portable skill invoke", date: "Sep 9, 2026",
+        desc: "A skill you invoke with /ork: changed. Re-read that skill page if you use it.",
+        status: "Changed", tone: "changed", notes: "/changelog#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/issues/4018" },
+      { title: "host-first install wizard and multi-host getting started", date: "Sep 9, 2026",
+        desc: "Shipped in this release. Open the linked PR if you need the full rationale.",
+        status: "Changed", tone: "changed", notes: "/changelog#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/issues/4016" }
+    ]
+  },
+  changelog: {
+    name: "Changelog",
+    sub: "Release activity · last 5",
+    version: "5 releases",
+    cards: [
+      { title: "10.0.0-beta.12", date: "Sep 9, 2026",
+        desc: "deps: bump hono in /src/mcp-server", status: "Latest", tone: "live",
+        notes: "#10.0.0-beta.12",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.11...v10.0.0-beta.12" },
+      { title: "10.0.0-beta.11", date: "Sep 8, 2026",
+        desc: "codex: ship the ork-mech profile", status: "Shipped", tone: "added",
+        notes: "#10.0.0-beta.11",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.10...v10.0.0-beta.11" },
+      { title: "10.0.0-beta.10", date: "Sep 8, 2026",
+        desc: "cursor: export rules to .cursor-plugin", status: "Shipped", tone: "added",
+        notes: "#10.0.0-beta.10",
+        diff: "https://github.com/yonatangross/orchestkit/compare/v10.0.0-beta.9...v10.0.0-beta.10" }
+    ]
+  }
+};
+
+const ICONS = {
+  live: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>',
+  added: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>',
+  changed: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>'
+};
+
+const state = { step: 0, playing: false, rtl: false, reduce: false };
+let timer = null;
+const stage = document.getElementById("stage");
+const esc = s => String(s).replace(/[&<>]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" }[c]));
+const maxStep = () => STEPS.length - 1;
+
+function cardHtml(card, i, current, flash) {
+  const cls = i === current ? "current" : (i < current ? "past" : "");
+  const notesFlash = flash === "notes" && i === current ? " flash" : "";
+  const diffFlash = flash === "diff" && i === current ? " flash" : "";
+  return `<div class="card-row">
+    <div class="rail" aria-hidden="true"></div>
+    <span class="node ${esc(card.tone)}" aria-hidden="true">${ICONS[card.tone] || ICONS.changed}</span>
+    <article class="event ${cls}"${i === current ? ' aria-current="true"' : ""}>
+      <div class="top"><h3>${esc(card.title)}</h3><time>${esc(card.date)}</time></div>
+      <p>${esc(card.desc)}</p>
+      <div class="foot">
+        <span class="pill ${card.tone === "live" ? "" : card.tone === "added" ? "shipped" : "changed"}">${esc(card.status)}</span>
+        <div class="acts">
+          <a class="act${notesFlash}" href="${esc(card.notes)}" aria-label="Release notes for ${esc(card.title)}">Notes</a>
+          <a class="act${diffFlash}" href="${esc(card.diff)}" target="_blank" rel="noopener noreferrer" aria-label="Diff for ${esc(card.title)}">Diff</a>
+        </div>
+      </div>
+    </article>
+  </div>`;
+}
+
+function render() {
+  const step = STEPS[state.step];
+  const surface = SURFACES[step.surface];
+  const rows = surface.cards.map((card, i) => cardHtml(card, i, step.current, step.flash)).join("");
+  const impact = `<div class="impact"><div class="stripe"></div>
+    <div class="kind">${esc(step.kind)}</div>
+    <h3>${esc(step.title)}</h3>
+    ${step.lines.map(l => `<div class="row"><span class="tick">+</span><span>${esc(l)}</span></div>`).join("")}
+    <div class="added">${esc(surface.name)} · ${esc(surface.version)}</div></div>`;
+
+  stage.innerHTML = `
+    <div class="phone"><div class="screen">
+      <div class="app-head">
+        <div class="av">${ICONS.live}</div>
+        <div><div class="nm">OrchestKit · ${esc(surface.name)}</div><div class="st">${esc(surface.sub)}</div></div>
+        <div class="vpill">${esc(surface.version)}</div>
+      </div>
+      <div class="feed" id="feed"><div class="board">${rows}</div></div>
+    </div></div>
+    <div class="arrow"><div class="ar">-&gt;</div><div class="cap">this card → what it changes for a visitor</div></div>
+    ${impact}`;
+
+  const feed = document.getElementById("feed");
+  if (feed) {
+    const c = feed.querySelector(".event.current");
+    if (c) c.scrollIntoView({ block: "nearest" });
+  }
+  document.getElementById("stepHint").innerHTML = `Step <b>${state.step + 1}</b> of <b>${maxStep() + 1}</b> · ${esc(step.title)}`;
+  document.getElementById("prev").disabled = state.step <= 0;
+  document.getElementById("next").disabled = state.step >= maxStep();
+  updatePrompt();
+}
+
+function updatePrompt() {
+  document.getElementById("promptOut").innerHTML =
+    `Build a <b>release-notes player</b> for OrchestKit <b>10.0.0-beta.12</b>: cool-glass Chrono Board `
+    + `on What's new and /changelog, fed by CHANGELOG_ENTRIES plus skill/agent/hook counts. `
+    + `Notes hashes to the version. Diff opens compare. Reduced-motion keeps both actions usable.`;
+}
+
+function stop() {
+  state.playing = false;
+  clearTimeout(timer);
+  document.getElementById("play").textContent = "Play";
+}
+function play() {
+  if (state.playing) return stop();
+  state.playing = true;
+  document.getElementById("play").textContent = "Pause";
+  state.step = -1;
+  const tick = () => {
+    if (!state.playing) return;
+    if (state.step >= maxStep()) return stop();
+    state.step++;
+    render();
+    timer = setTimeout(tick, 1600);
+  };
+  tick();
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => { stop(); state.step = Math.max(0, state.step - 1); render(); });
+document.getElementById("next").addEventListener("click", () => { stop(); state.step = Math.min(maxStep(), state.step + 1); render(); });
+document.getElementById("dirToggle").addEventListener("click", e => {
+  state.rtl = !state.rtl;
+  document.documentElement.dir = state.rtl ? "rtl" : "ltr";
+  e.currentTarget.setAttribute("aria-pressed", String(state.rtl));
+});
+document.getElementById("reduceToggle").addEventListener("click", e => {
+  state.reduce = !state.reduce;
+  document.documentElement.classList.toggle("reduce", state.reduce);
+  e.currentTarget.setAttribute("aria-pressed", String(state.reduce));
+});
+document.getElementById("copyBtn").addEventListener("click", () => {
+  navigator.clipboard.writeText(document.getElementById("promptOut").textContent).then(() => {
+    const b = document.getElementById("copyBtn");
+    b.textContent = "Copied";
+    b.classList.add("done");
+    setTimeout(() => { b.textContent = "Copy prompt"; b.classList.remove("done"); }, 1500);
+  });
+});
+
+render();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Pull the real 21st.dev Chrono Board (`dhileepkumargm/chrono-board`, demo 9216) via Pro `get_component` and adapt it to docs-site tokens (fd-* / George, reduced-motion, no slate/green demo chrome).
- Wire it to real OrchestKit release data: homepage What's new uses `CHANGELOG_ENTRIES` + `SITE.version` + skill/agent/hook counts; `/changelog` adds a five-release activity board with Notes/Diff actions into the existing rail.
- `feat/web-client-command-center` does not exist. No skill parking, no community/WhatsApp changes.

## Interactive Playground
Play the Chrono Board release-notes player (What's new live card, product rail, five-release changelog, Notes/Diff, reduced-motion):

- Lab (rendered): https://orchestkit.yonyon.ai/lab/chrono-board-release.html
- Source: docs/feat--docs-chrono-board-release/chrono-board.html
- SHA-pinned blob: https://github.com/yonatangross/orchestkit/blob/1a814e817a30bbae1709264efb87ae86a06a5263/docs/feat--docs-chrono-board-release/chrono-board.html

## Test plan
- [x] `docs/site` vitest: chrono-board-release, chrono-board, changelog-format, landing-page, community-page
- [x] Browser on `http://localhost:3000/`: What's new renders live version + catalog counts; Notes/Diff are real changelog/compare links
- [x] Browser on `http://localhost:3000/changelog`: Release activity board + hash jump (`#10.0.0-beta.11`)
- [x] Browser on `http://localhost:3000/lab/chrono-board-release.html`: Play/Next through six steps, reduced-motion toggle, copy prompt
- [x] `/community` still loads the live room; no mocked WhatsApp UI added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a release activity timeline to the changelog page, showing recent releases with statuses, dates, descriptions, and Notes/Diff links.
  - Updated the “What’s New” area to use the timeline format and highlight the latest release alongside recent updates.
  - Added a Chrono Board playground for exploring release timeline presentations.

- **Documentation**
  - Improved release information visibility with consistent activity cards and navigation links across the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->