### PR TITLE
docs(site): host picker, library tabs, and readable hook lists

### DIFF
--- a/docs/feat--docs-library-visual/host-library.html
+++ b/docs/feat--docs-library-visual/host-library.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<!--
+  USER-STORY PLAYER · Homepage install + library motion
+  Archetype: user-story-player. Persona: cool-glass.
+  Conforms to shared/rules/playground-visual-standard.md
+  21st.dev radio cards (10156) + social selector (25137) + animated tabs (24930).
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Pick a host, the command rewrites</title>
+<meta name="description" content="Play the homepage install picker. Host cards keep ?host= links. The command panel blurs to the new payload. Library tabs slide. Hooks group by lifecycle, not a 32-button grid. Reduced-motion keeps every control usable.">
+<style>
+  :root {
+    --pg-bg: hsl(232 26% 7%);
+    --pg-ink: hsl(220 18% 93%);
+    --pg-muted: hsl(222 12% 64%);
+    --pg-faint: hsl(222 10% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(264 72% 62%);
+    --pg-accent-deep: hsl(264 70% 46%);
+    --pg-shadow: 0 20px 60px -22px hsl(264 60% 2% / 0.7), 0 4px 12px -6px hsl(264 60% 2% / 0.5);
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(264 72% 62% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(248 70% 58% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 24px 16px 48px; display: flex; flex-direction: column; gap: 16px; }
+  .head { display: flex; align-items: flex-start; gap: 16px; }
+  .logo { width: 48px; height: 48px; border-radius: 16px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 24px -8px hsl(264 70% 50% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .logo svg { width: 22px; height: 22px; }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 8px 16px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); border-color: hsl(264 72% 62% / 0.45); }
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; flex-wrap: wrap; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 12px; padding: 8px 16px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink);
+    transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent;
+    color: hsl(264 40% 96%); box-shadow: 0 10px 26px -12px hsl(264 70% 50% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; font-variant-numeric: tabular-nums; }
+  .hint b { color: var(--pg-muted); }
+  .stage { padding: 24px; display: flex; flex-direction: column; align-items: stretch; gap: 20px; }
+  .url { font-family: var(--pg-mono); font-size: 12px; color: var(--pg-muted); padding: 8px 12px;
+    border: 1px dashed var(--pg-line); border-radius: var(--pg-r-sm); }
+  .url em { color: var(--pg-accent); font-style: normal; }
+  .hosts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .host { cursor: pointer; text-align: start; font: inherit; color: inherit; background: var(--pg-glass);
+    border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); padding: 12px; display: flex; flex-direction: column; gap: 6px;
+    transition: border-color var(--pg-dur-fast), background var(--pg-dur-fast); }
+  .host-top { display: flex; align-items: center; gap: 8px; }
+  .host-ico { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--pg-line); display: grid; place-items: center; background: hsl(232 30% 9%); color: var(--pg-ink); }
+  .host-ico svg { width: 20px; height: 20px; display: block; }
+  .host:hover { border-color: var(--pg-glass-edge); }
+  .host:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .host[aria-current="true"] { border-color: hsl(264 72% 62% / 0.55); background: hsl(264 72% 62% / 0.12);
+    box-shadow: 0 0 0 2px hsl(264 72% 62% / 0.28); }
+  .host b { font-size: 13px; }
+  .host span { font-size: 11px; color: var(--pg-muted); line-height: 1.35; }
+  .cmd { font-family: var(--pg-mono); font-size: 12.5px; line-height: 1.5; padding: 12px 14px;
+    border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); background: hsl(232 30% 9%);
+    transition: opacity var(--pg-dur-fast), filter var(--pg-dur-fast), transform var(--pg-dur-fast); }
+  .cmd.is-swap { opacity: 0; filter: blur(6px); transform: translateY(6px); }
+  .tabs { display: inline-flex; align-self: flex-start; width: max-content; max-width: 100%; gap: 4px; padding: 4px; border: 1px solid var(--pg-line); border-radius: 12px; position: relative; overflow: visible; }
+  .tab { cursor: pointer; font: inherit; font-size: 13px; font-weight: 600; color: var(--pg-muted);
+    background: transparent; border: 0; border-radius: 8px; padding: 8px 12px; position: relative; z-index: 1;
+    display: inline-flex; align-items: center; gap: 8px; }
+  .tab-ico { width: 22px; height: 22px; border-radius: 7px; display: grid; place-items: center;
+    background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); color: var(--pg-ink); }
+  .tab[aria-selected="true"] .tab-ico { background: hsl(264 72% 62% / 0.32); border-color: hsl(264 72% 62% / 0.45); color: hsl(264 80% 92%); }
+  .tab-ico svg { width: 14px; height: 14px; display: block; }
+  .tab:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .tab[aria-selected="true"] { color: var(--pg-ink); }
+  .tab-ink { position: absolute; top: 4px; bottom: 4px; left: 0; width: 80px; border-radius: 8px;
+    background: hsl(264 72% 62% / 0.22); transition: transform var(--pg-dur-normal) var(--pg-ease), width var(--pg-dur-normal) var(--pg-ease); pointer-events: none; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 600; color: var(--pg-muted);
+    border: 1px solid var(--pg-line); border-radius: 999px; padding: 4px 8px; }
+  .chip svg { width: 12px; height: 12px; display: block; }
+  .panel-copy { font-size: 13px; color: var(--pg-muted); line-height: 1.5; min-height: 3.2em; }
+  .phases { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+  .phase { border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); padding: 10px 12px; }
+  .phase b { display: block; font-size: 12px; margin-bottom: 4px; }
+  .phase span { font-family: var(--pg-mono); font-size: 11px; color: var(--pg-muted); }
+  .flow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; font-size: 12px; color: var(--pg-muted); }
+  .flow i { font-style: normal; padding: 4px 8px; border: 1px solid var(--pg-line); border-radius: 999px; color: var(--pg-ink); }
+  .chips[hidden], .phases[hidden], .flow[hidden] { display: none !important; }
+  .copy { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .copy code { font-family: var(--pg-mono); font-size: 12px; color: var(--pg-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .toast { font-size: 12px; color: var(--pg-accent); min-width: 4ch; }
+  @media (max-width: 720px) {
+    .hosts, .phases { grid-template-columns: 1fr 1fr; }
+    .hint { width: 100%; margin: 0; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+  html.reduce *, html.reduce *::before, html.reduce *::after { transition: none !important; animation: none !important; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="head">
+      <div class="logo" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+      </div>
+      <div>
+        <h1>Pick a host. The command rewrites.</h1>
+        <p>Context7-style cards, not a pill row that remounts the page. <code>?host=</code> stays shareable. Library tabs slide. Hooks group by when they fire.</p>
+      </div>
+      <div class="right">
+        <button class="toggle" type="button" id="reduce" aria-pressed="false">Reduced motion</button>
+      </div>
+    </header>
+
+    <section class="panel" aria-label="Playback">
+      <div class="transport">
+        <button class="btn primary" type="button" id="play">Play</button>
+        <button class="btn" type="button" id="prev">Prev</button>
+        <button class="btn" type="button" id="next">Next</button>
+        <p class="hint"><b id="beat-label">host cards</b></p>
+      </div>
+    </section>
+
+    <section class="panel stage" aria-live="polite">
+      <p class="url" id="url">orchestkit.yonyon.ai<em>/</em></p>
+      <div class="hosts" id="hosts"></div>
+      <pre class="cmd" id="cmd"></pre>
+      <div class="tabs" role="tablist" aria-label="Library primitives">
+        <span class="tab-ink" id="ink" aria-hidden="true"></span>
+        <button class="tab" type="button" role="tab" data-tab="skills" aria-selected="true">
+          <span class="tab-ico" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><rect x="3" y="3.5" width="8.5" height="10" rx="1.2" stroke="currentColor" stroke-width="1.5"/><path d="M6.5 3.5V13.5M4.5 6.5h2M4.5 9h2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M11.5 5.5h1.2c.7 0 1.3.6 1.3 1.3v6.2c0 .7-.6 1.3-1.3 1.3H7" stroke="currentColor" stroke-width="1.5"/></svg></span>
+          Skills 107
+        </button>
+        <button class="tab" type="button" role="tab" data-tab="agents" aria-selected="false">
+          <span class="tab-ico" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="6" cy="6" r="2" stroke="currentColor" stroke-width="1.5"/><path d="M2.5 13c.4-2.2 1.8-3.5 3.5-3.5S9.1 10.8 9.5 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="11.2" cy="6.8" r="1.6" stroke="currentColor" stroke-width="1.5"/><path d="M13.8 13c-.3-1.6-1.3-2.6-2.6-2.6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg></span>
+          Agents 36
+        </button>
+        <button class="tab" type="button" role="tab" data-tab="hooks" aria-selected="false">
+          <span class="tab-ico" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M9 2.5 4.5 9h3.2L7 13.5 12.5 7H9.2L9 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg></span>
+          Hooks 32
+        </button>
+      </div>
+      <div class="chips" id="chips">
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M3 11.5 8 4.5l5 7M5.5 11.5h5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Development</span>
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><ellipse cx="8" cy="4.5" rx="5" ry="2" stroke="currentColor" stroke-width="1.5"/><path d="M3 4.5v7c0 1.1 2.2 2 5 2s5-.9 5-2v-7" stroke="currentColor" stroke-width="1.5"/></svg>Backend</span>
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.5" y="3.5" width="11" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M2.5 6.5h11M5 9h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>Frontend</span>
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 2.5 13 5v3.2c0 3.1-2.1 5.2-5 6.3-2.9-1.1-5-3.2-5-6.3V5l5-2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>Security</span>
+      </div>
+      <p class="panel-copy" id="lib"></p>
+      <div class="flow" id="flow" hidden>
+        <i>Session</i> → <i>Prompt</i> → <i>Tools</i> → <i>Files</i> / <i>Agents</i> / <i>Tasks</i> / <i>Model</i>
+      </div>
+      <div class="phases" id="phases" hidden></div>
+    </section>
+
+    <footer class="panel copy">
+      <button class="btn" type="button" id="copy">Copy prompt</button>
+      <code id="prompt">Build host cards that keep ?host= links, rewrite the install snippet without remounting, slide Skills/Agents/Hooks tabs, and group hooks by lifecycle.</code>
+      <span class="toast" id="toast" hidden>Copied</span>
+    </footer>
+  </div>
+<script>
+const ICO = {
+  claude: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z\"/></svg>",
+  cursor: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23\"/></svg>",
+  codex: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z\"/></svg>",
+  muse: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.832-4.358l-.617-1.028a44.908 44.908 0 0 0-1.255-1.98c.07-.109.141-.224.211-.327 1.12-1.667 2.118-2.602 3.358-2.602zm-10.201.553c1.265 0 2.058.791 2.675 1.446.307.327.737.871 1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.533-1.533a2.264 2.264 0 0 1 1.088-.285z\"/></svg>",
+  pi: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><path d=\"M5 6.5h14\"/><path d=\"M9 6.5v11\"/><path d=\"M15 6.5v8.5a3 3 0 0 0 3 3\"/></svg>",
+  opencode: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"3\" y=\"5\" width=\"18\" height=\"14\" rx=\"2\"/><path d=\"M7 10l3 2-3 2\"/><path d=\"M13 14h4\"/></svg>",
+};
+const HOSTS = [
+  { id: "claude", name: "Claude Code", what: "Full ork plugin.", href: "/", cmd: "claude plugin install yonatangross/orchestkit" },
+  { id: "cursor", name: "Cursor", what: "Same ork plugin. No Claude hooks.", href: "/?host=cursor", cmd: "yonatangross/orchestkit" },
+  { id: "codex", name: "Codex", what: "Portable ork-codex pack.", href: "/?host=codex", cmd: "codex plugin add ork-codex@orchestkit-codex" },
+  { id: "muse", name: "Muse Code", what: "Skills via .agents/skills.", href: "/?host=muse", cmd: "npx skills add yonatangross/orchestkit -s doctor" },
+  { id: "pi", name: "Pi", what: "Shipped pi manifest.", href: "/?host=pi", cmd: "pi install git:github.com/yonatangross/orchestkit" },
+  { id: "opencode", name: "OpenCode", what: "Agent Skills via skills.sh.", href: "/?host=opencode", cmd: "npx skills add yonatangross/orchestkit -s doctor" },
+];
+const TABS = {
+  skills: "Browse 107 skills. Category marks, no All/ork toggle. Search still ranks.",
+  agents: "36 agents. Same category marks. Search by name or role.",
+  hooks: "32 events in 7 phases. Compact flow, then the groups. Not a 32-button grid.",
+};
+const PHASES = [
+  ["Session", "start · cwd · setup · end"],
+  ["Prompt", "submit · expansion"],
+  ["Tools", "pre/post · permission"],
+  ["Files", "changed · directory · worktree"],
+  ["Agents", "subagent · teammate"],
+  ["Tasks", "created · completed"],
+  ["Model", "switch · compact · stop"],
+];
+const BEATS = [
+  { host: "claude", tab: "skills", label: "1 / 4 · host cards" },
+  { host: "cursor", tab: "skills", label: "2 / 4 · command rewrite" },
+  { host: "cursor", tab: "agents", label: "3 / 4 · library tabs" },
+  { host: "cursor", tab: "hooks", label: "4 / 4 · hooks as flow" },
+];
+
+const hostsEl = document.getElementById("hosts");
+const cmdEl = document.getElementById("cmd");
+const urlEl = document.getElementById("url");
+const libEl = document.getElementById("lib");
+const inkEl = document.getElementById("ink");
+const chipsEl = document.getElementById("chips");
+const flowEl = document.getElementById("flow");
+const phasesEl = document.getElementById("phases");
+const beatLabel = document.getElementById("beat-label");
+const reduceBtn = document.getElementById("reduce");
+let hostId = "claude";
+let tabId = "skills";
+let beat = 0;
+let timer = null;
+
+HOSTS.forEach((h) => {
+  const b = document.createElement("button");
+  b.className = "host";
+  b.type = "button";
+  b.dataset.host = h.id;
+  b.innerHTML = `<span class="host-top"><span class="host-ico">${ICO[h.id]}</span><b>${h.name}</b></span><span>${h.what}</span>`;
+  b.addEventListener("click", () => setHost(h.id));
+  hostsEl.appendChild(b);
+});
+PHASES.forEach(([name, bits]) => {
+  const d = document.createElement("div");
+  d.className = "phase";
+  d.innerHTML = `<b>${name}</b><span>${bits}</span>`;
+  phasesEl.appendChild(d);
+});
+document.querySelectorAll(".tab").forEach((btn) => {
+  btn.addEventListener("click", () => setTab(btn.dataset.tab));
+});
+
+function reduced() {
+  return document.documentElement.classList.contains("reduce") || matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+function setHost(id, instant) {
+  hostId = id;
+  const spec = HOSTS.find((h) => h.id === id);
+  hostsEl.querySelectorAll(".host").forEach((el) => {
+    if (el.dataset.host === id) el.setAttribute("aria-current", "true");
+    else el.removeAttribute("aria-current");
+  });
+  urlEl.innerHTML = `orchestkit.yonyon.ai<em>${spec.href}</em>`;
+  const apply = () => { cmdEl.textContent = spec.cmd; cmdEl.classList.remove("is-swap"); };
+  if (instant || reduced()) { apply(); return; }
+  cmdEl.classList.add("is-swap");
+  setTimeout(apply, 180);
+}
+function setTab(id) {
+  tabId = id;
+  const tabs = [...document.querySelectorAll(".tab")];
+  const selected = tabs.find((el) => el.dataset.tab === id);
+  tabs.forEach((el) => {
+    el.setAttribute("aria-selected", el.dataset.tab === id ? "true" : "false");
+  });
+  if (selected) {
+    inkEl.style.width = `${selected.offsetWidth}px`;
+    inkEl.style.transform = `translateX(${selected.offsetLeft}px)`;
+  }
+  libEl.textContent = TABS[id];
+  const hooks = id === "hooks";
+  flowEl.hidden = !hooks;
+  phasesEl.hidden = !hooks;
+  chipsEl.hidden = id !== "skills";
+}
+function applyBeat(i) {
+  beat = i;
+  const b = BEATS[i];
+  beatLabel.textContent = b.label;
+  setHost(b.host, i === 0);
+  setTab(b.tab);
+  document.getElementById("prev").disabled = i === 0;
+  document.getElementById("next").disabled = i === BEATS.length - 1;
+}
+function play() {
+  if (timer) { clearInterval(timer); timer = null; document.getElementById("play").textContent = "Play"; return; }
+  applyBeat(0);
+  document.getElementById("play").textContent = "Pause";
+  timer = setInterval(() => {
+    if (beat >= BEATS.length - 1) { play(); return; }
+    applyBeat(beat + 1);
+  }, reduced() ? 900 : 1600);
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => applyBeat(Math.max(0, beat - 1)));
+document.getElementById("next").addEventListener("click", () => applyBeat(Math.min(BEATS.length - 1, beat + 1)));
+reduceBtn.addEventListener("click", () => {
+  const on = document.documentElement.classList.toggle("reduce");
+  reduceBtn.setAttribute("aria-pressed", String(on));
+});
+document.getElementById("copy").addEventListener("click", async () => {
+  await navigator.clipboard.writeText(document.getElementById("prompt").textContent);
+  const t = document.getElementById("toast");
+  t.hidden = false;
+  setTimeout(() => { t.hidden = true; }, 1600);
+});
+applyBeat(0);
+requestAnimationFrame(() => setTab(tabId));
+</script>
+</body>
+</html>

--- a/docs/site/__tests__/hook-event-table.test.tsx
+++ b/docs/site/__tests__/hook-event-table.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+  DocsTable,
+  HookEventTable,
+  parseHookEventTable,
+  parseHookIndexTable,
+} from "@/components/hook-event-table";
+
+describe("parseHookEventTable", () => {
+  it("reads a four-column hook event table", () => {
+    const rows = parseHookEventTable(
+      <>
+        <thead>
+          <tr>
+            <th>Hook</th>
+            <th>Matcher</th>
+            <th>Behavior</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>session-finalizer</code>
+            </td>
+            <td>
+              <code>*</code>
+            </td>
+            <td>Fire-and-forget</td>
+            <td>Session Finalizer</td>
+          </tr>
+        </tbody>
+      </>,
+    );
+    expect(rows).toEqual([
+      {
+        name: "session-finalizer",
+        matcher: "*",
+        behavior: "Fire-and-forget",
+        description: "Session Finalizer",
+      },
+    ]);
+  });
+
+  it("ignores unrelated tables", () => {
+    expect(
+      parseHookEventTable(
+        <tr>
+          <th>Category</th>
+          <th>Hooks</th>
+          <th>Description</th>
+        </tr>,
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseHookIndexTable", () => {
+  it("keeps the category href", () => {
+    const rows = parseHookIndexTable(
+      <>
+        <tr>
+          <th>Category</th>
+          <th>Hooks</th>
+          <th>Description</th>
+        </tr>
+        <tr>
+          <td>
+            <a href="/docs/reference/hooks/session-end">SessionEnd</a>
+          </td>
+          <td>7</td>
+          <td>Hooks for SessionEnd events</td>
+        </tr>
+      </>,
+    );
+    expect(rows).toEqual([
+      {
+        category: "SessionEnd",
+        href: "/docs/reference/hooks/session-end",
+        count: "7",
+        description: "Hooks for SessionEnd events",
+      },
+    ]);
+  });
+});
+
+describe("HookEventTable", () => {
+  it("puts the hook name, behavior, and matcher on one card", () => {
+    render(
+      <HookEventTable
+        rows={[
+          {
+            name: "session-finalizer",
+            matcher: "*",
+            behavior: "Fire-and-forget",
+            description: "Session Finalizer",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("session-finalizer")).toBeTruthy();
+    expect(screen.getByText("Fire-and-forget")).toBeTruthy();
+    expect(screen.getByText("matcher *")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});
+
+describe("DocsTable", () => {
+  it("renders hook index descriptions on each row", () => {
+    render(
+      <DocsTable>
+        <thead>
+          <tr>
+            <th>Category</th>
+            <th>Hooks</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="/docs/reference/hooks/session-end">SessionEnd</a>
+            </td>
+            <td>7</td>
+            <td>Hooks for SessionEnd events</td>
+          </tr>
+        </tbody>
+      </DocsTable>,
+    );
+    expect(screen.getByText("SessionEnd")).toBeTruthy();
+    expect(screen.getByText("Hooks for SessionEnd events")).toBeTruthy();
+    expect(screen.getByText("7")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("replaces hook event tables with items, not a scrollport", () => {
+    const { container } = render(
+      <DocsTable>
+        <thead>
+          <tr>
+            <th>Hook</th>
+            <th>Matcher</th>
+            <th>Behavior</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>goal-budget-guard</code>
+            </td>
+            <td>
+              <code>*</code>
+            </td>
+            <td>Fire-and-forget</td>
+            <td>Goal Budget Guard</td>
+          </tr>
+        </tbody>
+      </DocsTable>,
+    );
+    expect(container.querySelector(".overflow-auto")).toBeNull();
+    expect(screen.getByText("goal-budget-guard")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});

--- a/docs/site/__tests__/hook-phases.test.ts
+++ b/docs/site/__tests__/hook-phases.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { HOOK_EVENT_PAGES, isHookEventPage } from "@/lib/hook-events";
+import { groupedHookEvents, HOOK_PHASES } from "@/lib/hook-phases";
+
+describe("hook phases", () => {
+  it("covers every hook event page exactly once", () => {
+    const grouped = groupedHookEvents();
+    const slugs = grouped.flatMap((phase) => phase.events.map((e) => e.slug));
+    expect(slugs).toHaveLength(HOOK_EVENT_PAGES.length);
+    expect(new Set(slugs).size).toBe(HOOK_EVENT_PAGES.length);
+    expect(slugs.sort()).toEqual(
+      HOOK_EVENT_PAGES.map((e) => e.slug).sort(),
+    );
+  });
+
+  it("keeps the mermaid at six nodes, not one per hook", () => {
+    const declared = HOOK_PHASES.reduce((n, phase) => n + phase.slugs.length, 0);
+    expect(declared).toBe(HOOK_EVENT_PAGES.length);
+    expect(HOOK_PHASES).toHaveLength(7);
+  });
+});
+
+describe("isHookEventPage", () => {
+  it("matches a four-column event page, not the index or a skill", () => {
+    expect(isHookEventPage(["reference", "hooks", "session-end"])).toBe(true);
+    expect(isHookEventPage(["reference", "hooks"])).toBe(false);
+    expect(isHookEventPage(["reference", "hooks", "spotlights"])).toBe(false);
+    expect(isHookEventPage(["reference", "skills", "tdd"])).toBe(false);
+  });
+});

--- a/docs/site/__tests__/host-install-picker.test.tsx
+++ b/docs/site/__tests__/host-install-picker.test.tsx
@@ -17,6 +17,11 @@ vi.mock("next/link", () => ({
 	),
 }));
 
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ replace, push: vi.fn() }),
+}));
+
 vi.mock("@/lib/search-beacon", () => ({
 	track: vi.fn(),
 }));
@@ -30,8 +35,23 @@ describe("HostInstallPicker", () => {
 	it("Cursor is a host query link, not a dead button", () => {
 		render(<HostInstallPicker />);
 		expect(
-			screen.getByRole("link", { name: "Cursor" }).getAttribute("href"),
-		).toBe("/?host=cursor");
+			screen.getByRole("link", { name: "Cursor" }).querySelector("svg"),
+		).toBeTruthy();
+	});
+
+	it("replaces the URL without a full navigation when a host is clicked", async () => {
+		replace.mockClear();
+		render(<HostInstallPicker />);
+		fireEvent.click(screen.getByRole("link", { name: "Cursor" }));
+		expect(replace).toHaveBeenCalledWith("/?host=cursor", {
+			scroll: false,
+			transitionTypes: ["catalog"],
+		});
+		expect(
+			await screen.findByRole("button", {
+				name: /copy yonatangross\/orchestkit to clipboard/i,
+			}),
+		).toBeTruthy();
 	});
 
 	it("renders the Cursor copy payload when active is cursor", () => {

--- a/docs/site/__tests__/landing-page.test.tsx
+++ b/docs/site/__tests__/landing-page.test.tsx
@@ -6,6 +6,10 @@ vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: any) => <a href={href} {...props}>{children}</a>,
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+
 // Mock lucide-react
 vi.mock("lucide-react", () => ({
   ArrowRight: () => <span data-testid="arrow" />,

--- a/docs/site/__tests__/library-catalog.test.tsx
+++ b/docs/site/__tests__/library-catalog.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { LibraryCatalog } from "@/components/library-catalog";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push: vi.fn() }),
+}));
+
+vi.mock("@/components/lazy", () => ({
+  LazySkillBrowser: () => <div>skill browser</div>,
+}));
+
+vi.mock("@/components/changelog-mermaid", () => ({
+  ChangelogMermaid: ({ chart }: { chart: string }) => (
+    <pre data-testid="hook-flow">{chart}</pre>
+  ),
+}));
+
+describe("LibraryCatalog", () => {
+  it("keeps Skills/Agents/Hooks as real tab links", () => {
+    render(<LibraryCatalog tab="skills" />);
+    expect(
+      screen.getByRole("tab", { name: /skills/i }).getAttribute("href"),
+    ).toBe("/#library");
+    expect(
+      screen.getByRole("tab", { name: /agents/i }).getAttribute("href"),
+    ).toBe("/?lib=agents#library");
+    expect(
+      screen.getByRole("tab", { name: /hooks/i }).getAttribute("href"),
+    ).toBe("/?lib=hooks#library");
+    expect(
+      screen.getByRole("tab", { name: /skills/i }).querySelector("svg"),
+    ).toBeTruthy();
+  });
+
+  it("preserves host when switching tabs", async () => {
+    replace.mockClear();
+    render(<LibraryCatalog tab="skills" host="cursor" />);
+    fireEvent.click(screen.getByRole("tab", { name: /hooks/i }));
+    expect(replace).toHaveBeenCalledWith("/?host=cursor&lib=hooks#library", {
+      scroll: false,
+      transitionTypes: ["catalog"],
+    });
+    expect(
+      await screen.findByRole("heading", { name: /session/i }),
+    ).toBeTruthy();
+    expect(screen.getByTestId("hook-flow").textContent).toMatch(
+      /Session --> Prompt/,
+    );
+  });
+
+  it("moves focus to the newly selected tab on arrow keys", async () => {
+    render(<LibraryCatalog tab="skills" />);
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowRight" });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /agents/i })).toHaveFocus();
+    });
+    fireEvent.keyDown(screen.getByRole("tablist"), { key: "ArrowLeft" });
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /skills/i })).toHaveFocus();
+    });
+  });
+});

--- a/docs/site/__tests__/library-tab.test.ts
+++ b/docs/site/__tests__/library-tab.test.ts
@@ -18,4 +18,11 @@ describe("library tab", () => {
     expect(libraryTabHref("agents")).toBe("/?lib=agents#library");
     expect(libraryTabHref("hooks")).toBe("/?lib=hooks#library");
   });
+
+  it("preserves a non-default host on the query string", () => {
+    expect(libraryTabHref("skills", "cursor")).toBe("/?host=cursor#library");
+    expect(libraryTabHref("hooks", "cursor")).toBe(
+      "/?host=cursor&lib=hooks#library",
+    );
+  });
 });

--- a/docs/site/__tests__/setup.ts
+++ b/docs/site/__tests__/setup.ts
@@ -4,6 +4,25 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
+import { MotionGlobalConfig } from "motion";
+
+MotionGlobalConfig.skipAnimations = true;
+MotionGlobalConfig.reducedMotion = "never";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  configurable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
 
 afterEach(() => {
   cleanup();

--- a/docs/site/__tests__/setup.ts
+++ b/docs/site/__tests__/setup.ts
@@ -7,7 +7,6 @@ import { afterEach } from "vitest";
 import { MotionGlobalConfig } from "motion";
 
 MotionGlobalConfig.skipAnimations = true;
-MotionGlobalConfig.reducedMotion = "never";
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,

--- a/docs/site/__tests__/skill-browser.test.tsx
+++ b/docs/site/__tests__/skill-browser.test.tsx
@@ -225,26 +225,23 @@ describe("SkillBrowser", () => {
     await expectCount(5);
   });
 
-  it("renders plugin filter group with All, ork buttons", () => {
-    render(<SkillBrowser />);
-    const group = screen.getByRole("group", { name: "Filter by plugin" });
-    expect(group).toBeInTheDocument();
-
-    const allBtn = screen.getByRole("button", { name: "All" });
-    expect(allBtn).toHaveAttribute("aria-pressed", "true");
-  });
-
-  it("filters by plugin when ork button is clicked", async () => {
+  it("combines search + category filters", async () => {
     render(<SkillBrowser />);
     await expectCount(5);
 
-    fireEvent.click(screen.getByRole("button", { name: "ork" }));
+    const fieldset = screen.getByRole("group", { name: /category/i });
+    fireEvent.click(within(fieldset).getByText("Backend"));
 
-    // All five mock skills belong to ork (v7 unified plugin).
-    await expectCount(5);
-    expect(screen.getByText("implement")).toBeInTheDocument();
-    expect(screen.getByText("e2e-testing")).toBeInTheDocument();
-    expect(screen.getByText("fastapi-advanced")).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), {
+      target: { value: "api" },
+    });
+
+    // fastapi-advanced (backend/api tag) should survive.
+    expect(
+      await screen.findByText(
+        (_, el) => el?.textContent === "fastapi-advanced",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("shows Command badge for user-invocable skills", async () => {
@@ -253,6 +250,12 @@ describe("SkillBrowser", () => {
     // implement is userInvocable: true
     const commandBadges = screen.getAllByText("Command");
     expect(commandBadges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("puts a category mark on each skill card", async () => {
+    render(<SkillBrowser />);
+    const card = await screen.findByRole("button", { name: /implement/i });
+    expect(card.querySelector("svg")).toBeTruthy();
   });
 
   it("expands skill card on click and shows detail panel", async () => {
@@ -325,21 +328,9 @@ describe("SkillBrowser", () => {
     await expectCount(5);
   });
 
-  it("combines search + category + plugin filters", async () => {
+  it("does not render the vestigial All/ork plugin filter", () => {
     render(<SkillBrowser />);
-    await expectCount(5);
-
-    fireEvent.click(screen.getByRole("button", { name: "ork" }));
-
-    fireEvent.change(screen.getByPlaceholderText(PLACEHOLDER), {
-      target: { value: "api" },
-    });
-
-    // fastapi-advanced (ork, backend/api tag) should survive.
-    expect(
-      await screen.findByText(
-        (_, el) => el?.textContent === "fastapi-advanced",
-      ),
-    ).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Filter by plugin" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "ork" })).toBeNull();
   });
 });

--- a/docs/site/app/(home)/page.tsx
+++ b/docs/site/app/(home)/page.tsx
@@ -168,7 +168,7 @@ export default async function HomePage({
         </div>
       </section>
 
-      <LibraryCatalog tab={libraryTab} />
+      <LibraryCatalog tab={libraryTab} host={host} />
       <WhatsNewStrip />
 
       <section aria-labelledby="cookbook-heading" className="border-b border-fd-border" id="cookbook">

--- a/docs/site/app/(home)/template.tsx
+++ b/docs/site/app/(home)/template.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { PageTransition } from "@/components/page-transition";
+
+export default function Template({ children }: { children: ReactNode }) {
+	return <PageTransition>{children}</PageTransition>;
+}

--- a/docs/site/app/docs/[[...slug]]/page.tsx
+++ b/docs/site/app/docs/[[...slug]]/page.tsx
@@ -26,6 +26,7 @@ import { GeorgeDivider } from "@/components/world/george";
 import { SkillDossier } from "@/components/world/skill-dossier";
 import { SkillFlow } from "@/components/world/skill-flow";
 import { getSectionGlyph } from "@/components/world/station-glyphs";
+import { DocsTable, HookEventTable } from "@/components/hook-event-table";
 import { SKILLS } from "@/lib/generated/skills-data";
 
 /**
@@ -173,6 +174,8 @@ export default async function Page(props: {
         <MDX
           components={{
             ...defaultMdxComponents,
+            table: DocsTable,
+            HookEventTable,
             ContextualSkillSidebar: LazyContextualSkillSidebar,
             SkillDependencyGraph: LazySkillDependencyGraph,
             SkillRecommender: LazySkillRecommender,

--- a/docs/site/app/docs/template.tsx
+++ b/docs/site/app/docs/template.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { PageTransition } from "@/components/page-transition";
+
+export default function Template({ children }: { children: ReactNode }) {
+	return <PageTransition>{children}</PageTransition>;
+}

--- a/docs/site/app/global.css
+++ b/docs/site/app/global.css
@@ -479,6 +479,72 @@
 }
 
 /* ============================================================
+   VIEW TRANSITIONS — route swaps + same-route catalog/host
+   ============================================================ */
+
+::view-transition {
+  pointer-events: none;
+}
+
+::view-transition-old(.page-exit) {
+  animation: 160ms ease-in both vt-fade reverse, 280ms ease-in-out both vt-rise reverse;
+}
+::view-transition-new(.page-enter) {
+  animation: 220ms ease-out 80ms both vt-fade, 320ms ease-out both vt-rise;
+}
+
+::view-transition-old(.catalog-fade) {
+  animation: 140ms ease-in both vt-fade reverse;
+}
+::view-transition-new(.catalog-fade) {
+  animation: 180ms ease-out both vt-fade;
+}
+
+@keyframes vt-fade {
+  from {
+    filter: blur(6px);
+    opacity: 0;
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+@keyframes vt-rise {
+  from { transform: translateY(10px); }
+  to { transform: translateY(0); }
+}
+
+#nd-nav {
+  view-transition-name: site-header;
+}
+#nd-sidebar {
+  view-transition-name: docs-sidebar;
+}
+::view-transition-group(site-header),
+::view-transition-group(docs-sidebar) {
+  animation: none;
+  z-index: 100;
+}
+::view-transition-old(site-header),
+::view-transition-old(docs-sidebar) {
+  display: none;
+}
+::view-transition-new(site-header),
+::view-transition-new(docs-sidebar) {
+  animation: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(*),
+  ::view-transition-new(*),
+  ::view-transition-group(*) {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+  }
+}
+
+/* ============================================================
    INLINE CODE IN TABLES — Prevent line-breaking at hyphens
    ============================================================ */
 

--- a/docs/site/components/category-mark.tsx
+++ b/docs/site/components/category-mark.tsx
@@ -1,0 +1,207 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+/**
+ * 16×16 category marks. Stroke geometry, currentColor, no Lucide dump.
+ * Colors come from the parent (`category-colors.ts` / skill pills).
+ */
+
+type MarkProps = { className?: string };
+
+function Svg({
+	className,
+	children,
+}: {
+	className?: string;
+	children: ReactNode;
+}) {
+	return (
+		<svg
+			viewBox="0 0 16 16"
+			fill="none"
+			aria-hidden="true"
+			className={cn("h-3.5 w-3.5 shrink-0", className)}
+		>
+			{children}
+		</svg>
+	);
+}
+
+const stroke = {
+	stroke: "currentColor",
+	strokeWidth: 1.5,
+	strokeLinecap: "round" as const,
+	strokeLinejoin: "round" as const,
+};
+
+function DevelopmentMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M3 11.5 8 4.5l5 7" {...stroke} />
+			<path d="M5.5 11.5h5" {...stroke} />
+		</Svg>
+	);
+}
+
+function AiMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<circle cx="8" cy="8" r="2.2" {...stroke} />
+			<path d="M8 2.5v2M8 11.5v2M2.5 8h2M11.5 8h2M4.2 4.2l1.4 1.4M10.4 10.4l1.4 1.4M4.2 11.8l1.4-1.4M10.4 5.6l1.4-1.4" {...stroke} />
+		</Svg>
+	);
+}
+
+function BackendMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<ellipse cx="8" cy="4.5" rx="5" ry="2" {...stroke} />
+			<path d="M3 4.5v7c0 1.1 2.2 2 5 2s5-.9 5-2v-7" {...stroke} />
+			<path d="M3 8c0 1.1 2.2 2 5 2s5-.9 5-2" {...stroke} />
+		</Svg>
+	);
+}
+
+function FrontendMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<rect x="2.5" y="3.5" width="11" height="9" rx="1.5" {...stroke} />
+			<path d="M2.5 6.5h11" {...stroke} />
+			<path d="M5 9h3" {...stroke} />
+		</Svg>
+	);
+}
+
+function TestingMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<circle cx="8" cy="8" r="5.5" {...stroke} />
+			<path d="M5.5 8.2 7.2 10l3.5-4" {...stroke} />
+		</Svg>
+	);
+}
+
+function SecurityMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M8 2.5 13 5v3.2c0 3.1-2.1 5.2-5 6.3-2.9-1.1-5-3.2-5-6.3V5l5-2.5Z" {...stroke} />
+		</Svg>
+	);
+}
+
+function DevopsMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M11.5 5.5A4 4 0 0 0 5 6.2M4.5 10.5A4 4 0 0 0 11 9.8" {...stroke} />
+			<path d="M11.5 3v2.5H9M4.5 13v-2.5H7" {...stroke} />
+		</Svg>
+	);
+}
+
+function ProductMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M8 2.5 13.5 8 8 13.5 2.5 8 8 2.5Z" {...stroke} />
+		</Svg>
+	);
+}
+
+function DataMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M4 12V8M8 12V4.5M12 12V7" {...stroke} />
+			<path d="M3 12.5h10" {...stroke} />
+		</Svg>
+	);
+}
+
+function ResearchMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<circle cx="7" cy="7" r="3.5" {...stroke} />
+			<path d="m9.6 9.6 3.4 3.4" {...stroke} />
+		</Svg>
+	);
+}
+
+function OtherMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M8 2.5 13 5.5v5L8 13.5 3 10.5v-5L8 2.5Z" {...stroke} />
+		</Svg>
+	);
+}
+
+const MARKS: Record<string, (props: MarkProps) => ReactNode> = {
+	development: DevelopmentMark,
+	ai: AiMark,
+	backend: BackendMark,
+	frontend: FrontendMark,
+	testing: TestingMark,
+	quality: TestingMark,
+	security: SecurityMark,
+	devops: DevopsMark,
+	product: ProductMark,
+	data: DataMark,
+	research: ResearchMark,
+	other: OtherMark,
+};
+
+export function CategoryMark({
+	category,
+	className,
+}: {
+	category: string;
+	className?: string;
+}) {
+	const Mark = MARKS[category] ?? MARKS.development;
+	return <Mark className={className} />;
+}
+
+function SkillsMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<rect x="3" y="3.5" width="8.5" height="10" rx="1.2" {...stroke} />
+			<path d="M6.5 3.5V13.5M4.5 6.5h2M4.5 9h2" {...stroke} />
+			<path d="M11.5 5.5h1.2c.7 0 1.3.6 1.3 1.3v6.2c0 .7-.6 1.3-1.3 1.3H7" {...stroke} />
+		</Svg>
+	);
+}
+
+function AgentsMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<circle cx="6" cy="6" r="2" {...stroke} />
+			<path d="M2.5 13c.4-2.2 1.8-3.5 3.5-3.5S9.1 10.8 9.5 13" {...stroke} />
+			<circle cx="11.2" cy="6.8" r="1.6" {...stroke} />
+			<path d="M13.8 13c-.3-1.6-1.3-2.6-2.6-2.6" {...stroke} />
+		</Svg>
+	);
+}
+
+function HooksMark({ className }: MarkProps) {
+	return (
+		<Svg className={className}>
+			<path d="M9 2.5 4.5 9h3.2L7 13.5 12.5 7H9.2L9 2.5Z" {...stroke} />
+		</Svg>
+	);
+}
+
+const LIBRARY_MARKS = {
+	skills: SkillsMark,
+	agents: AgentsMark,
+	hooks: HooksMark,
+} as const;
+
+export type LibraryPrimitive = keyof typeof LIBRARY_MARKS;
+
+export function LibraryMark({
+	kind,
+	className,
+}: {
+	kind: LibraryPrimitive;
+	className?: string;
+}) {
+	const Mark = LIBRARY_MARKS[kind];
+	return <Mark className={className} />;
+}

--- a/docs/site/components/hook-event-table.tsx
+++ b/docs/site/components/hook-event-table.tsx
@@ -1,0 +1,204 @@
+import {
+	Children,
+	isValidElement,
+	type ComponentProps,
+	type ReactElement,
+	type ReactNode,
+} from "react";
+import Link from "next/link";
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import { LibraryMark } from "@/components/category-mark";
+import {
+	Item,
+	ItemContent,
+	ItemDescription,
+	ItemGroup,
+	ItemHeader,
+	ItemMedia,
+	ItemTitle,
+} from "@/components/ui/item";
+
+export type HookEventRow = {
+	name: string;
+	matcher: string;
+	behavior: string;
+	description: string;
+};
+
+export type HookIndexRow = {
+	category: string;
+	href: string;
+	count: string;
+	description: string;
+};
+
+function textOf(node: ReactNode): string {
+	if (node == null || typeof node === "boolean") return "";
+	if (typeof node === "string" || typeof node === "number") return String(node);
+	if (Array.isArray(node)) return node.map(textOf).join("");
+	if (isValidElement(node)) {
+		return textOf((node.props as { children?: ReactNode }).children);
+	}
+	return "";
+}
+
+function hrefOf(node: ReactNode): string | null {
+	if (node == null || typeof node === "boolean") return null;
+	if (Array.isArray(node)) {
+		for (const child of node) {
+			const found = hrefOf(child);
+			if (found) return found;
+		}
+		return null;
+	}
+	if (!isValidElement(node)) return null;
+	const href = (node.props as { href?: unknown }).href;
+	if (typeof href === "string" && href.length > 0) return href;
+	return hrefOf((node.props as { children?: ReactNode }).children);
+}
+
+function collectRows(node: ReactNode): ReactElement[] {
+	const rows: ReactElement[] = [];
+	const visit = (n: ReactNode) => {
+		if (n == null || typeof n === "boolean") return;
+		if (Array.isArray(n)) {
+			n.forEach(visit);
+			return;
+		}
+		if (!isValidElement(n)) return;
+		if (n.type === "tr") {
+			rows.push(n);
+			return;
+		}
+		visit((n.props as { children?: ReactNode }).children);
+	};
+	visit(node);
+	return rows;
+}
+
+function cellNodes(row: ReactElement): ReactElement[] {
+	return Children.toArray((row.props as { children?: ReactNode }).children).filter(
+		(child): child is ReactElement =>
+			isValidElement(child) && (child.type === "td" || child.type === "th"),
+	);
+}
+
+const HOOK_HEADERS = ["hook", "matcher", "behavior", "description"];
+const INDEX_HEADERS = ["category", "hooks", "description"];
+
+export function parseHookEventTable(children: ReactNode): HookEventRow[] | null {
+	const rows = collectRows(children);
+	if (rows.length < 2) return null;
+	const headers = cellNodes(rows[0]).map((cell) => textOf(cell).trim().toLowerCase());
+	if (headers.length !== 4) return null;
+	if (!HOOK_HEADERS.every((label, i) => headers[i] === label)) return null;
+
+	return rows.slice(1).map((row) => {
+		const cells = cellNodes(row);
+		return {
+			name: textOf(cells[0]).trim(),
+			matcher: textOf(cells[1]).trim(),
+			behavior: textOf(cells[2]).trim(),
+			description: textOf(cells[3]).trim() || "—",
+		};
+	});
+}
+
+export function parseHookIndexTable(children: ReactNode): HookIndexRow[] | null {
+	const rows = collectRows(children);
+	if (rows.length < 2) return null;
+	const headers = cellNodes(rows[0]).map((cell) => textOf(cell).trim().toLowerCase());
+	if (headers.length !== 3) return null;
+	if (!INDEX_HEADERS.every((label, i) => headers[i] === label)) return null;
+
+	return rows.slice(1).flatMap((row) => {
+		const cells = cellNodes(row);
+		const href = hrefOf(cells[0]);
+		if (!href) return [];
+		return [
+			{
+				category: textOf(cells[0]).trim(),
+				href,
+				count: textOf(cells[1]).trim(),
+				description: textOf(cells[2]).trim(),
+			},
+		];
+	});
+}
+
+function BehaviorBadge({ children }: { children: string }) {
+	return (
+		<span className="shrink-0 rounded border border-[var(--color-fd-primary-20)] bg-[var(--color-fd-primary-10)] px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.06em] text-fd-primary">
+			{children}
+		</span>
+	);
+}
+
+export function HookEventTable({ rows }: { rows: HookEventRow[] }) {
+	return (
+		<ItemGroup>
+			{rows.map((row, i) => (
+				<Item key={`${row.name}:${row.matcher}:${i}`} variant="outline" size="sm">
+					<ItemMedia
+						variant="icon"
+						className="border-fd-primary/25 bg-[var(--color-fd-primary-10)] text-fd-primary"
+					>
+						<LibraryMark kind="hooks" />
+					</ItemMedia>
+					<ItemContent>
+						<ItemHeader>
+							<ItemTitle className="font-mono text-[13px]">{row.name}</ItemTitle>
+							<BehaviorBadge>{row.behavior}</BehaviorBadge>
+						</ItemHeader>
+						<ItemDescription>{row.description}</ItemDescription>
+						<p className="font-mono text-[11px] text-fd-muted-foreground">
+							matcher {row.matcher}
+						</p>
+					</ItemContent>
+				</Item>
+			))}
+		</ItemGroup>
+	);
+}
+
+export function HookIndexList({ rows }: { rows: HookIndexRow[] }) {
+	return (
+		<ItemGroup className="gap-2">
+			{rows.map((row) => (
+				<Link
+					key={row.href}
+					href={row.href}
+					className="not-prose text-inherit no-underline"
+				>
+					<Item variant="outline" size="sm" className="items-center">
+						<ItemMedia
+							variant="icon"
+							className="border-fd-primary/25 bg-[var(--color-fd-primary-10)] text-fd-primary"
+						>
+							<LibraryMark kind="hooks" />
+						</ItemMedia>
+						<ItemContent>
+							<ItemHeader>
+								<ItemTitle>{row.category}</ItemTitle>
+								<span className="shrink-0 font-mono text-[11px] tabular-nums text-fd-muted-foreground">
+									{row.count}
+								</span>
+							</ItemHeader>
+							<ItemDescription>{row.description}</ItemDescription>
+						</ItemContent>
+					</Item>
+				</Link>
+			))}
+		</ItemGroup>
+	);
+}
+
+const FumadocsTable = defaultMdxComponents.table;
+
+export function DocsTable(props: ComponentProps<"table">) {
+	const hookRows = parseHookEventTable(props.children);
+	if (hookRows) return <HookEventTable rows={hookRows} />;
+	const indexRows = parseHookIndexTable(props.children);
+	if (indexRows && indexRows.length > 0) return <HookIndexList rows={indexRows} />;
+	return <FumadocsTable {...props} />;
+}

--- a/docs/site/components/host-install.tsx
+++ b/docs/site/components/host-install.tsx
@@ -1,5 +1,11 @@
+"use client";
+
+import { startTransition, useEffect, useState, type MouseEvent } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { motion } from "motion/react";
 import { HostMark, type HostId } from "@/components/host-marks";
+import { SameRouteFade, sameRouteReplace } from "@/components/page-transition";
 import { InstallSnippet } from "@/components/install-snippet";
 import {
 	HOST_INSTALLS,
@@ -8,6 +14,7 @@ import {
 	type HostInstallSpec,
 } from "@/lib/host-installs";
 import type { LibraryTab } from "@/lib/library-tab";
+import { cn } from "@/lib/cn";
 
 function Card({ spec }: { spec: HostInstallSpec }) {
 	return (
@@ -74,6 +81,12 @@ export function HostInstallGrid({ hosts }: { hosts?: HostId[] }) {
 	);
 }
 
+function passThroughClick(e: MouseEvent) {
+	return (
+		e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0
+	);
+}
+
 /** Homepage: pick a host, copy its command. Keeps the Install by host nav. */
 export function HostInstallPicker({
 	hosts = ["claude", "cursor", "codex", "muse", "pi", "opencode"],
@@ -84,19 +97,33 @@ export function HostInstallPicker({
 	active?: HostId;
 	libraryTab?: LibraryTab;
 }) {
+	const router = useRouter();
 	const list = hosts.map((id) => HOST_INSTALL_BY_ID[id]);
-	const current =
+	const resolved =
 		list.find((item) => item.id === active)?.id ?? list[0]?.id ?? "claude";
+	const [current, setCurrent] = useState<HostId>(resolved);
+
+	useEffect(() => {
+		setCurrent(resolved);
+	}, [resolved]);
+
 	const spec = HOST_INSTALL_BY_ID[current];
+
+	const pick = (e: MouseEvent<HTMLAnchorElement>, id: HostId) => {
+		if (passThroughClick(e)) return;
+		e.preventDefault();
+		startTransition(() => {
+			setCurrent(id);
+			router.replace(homeInstallHref(id, libraryTab), sameRouteReplace);
+		});
+	};
 
 	return (
 		<nav
 			aria-label="Install by host"
 			className="mx-auto mt-4 w-full max-w-[640px] text-left"
 		>
-			<div
-				className="flex flex-wrap items-center justify-center gap-2"
-			>
+			<div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
 				{list.map((item) => {
 					const selected = item.id === current;
 					return (
@@ -104,18 +131,46 @@ export function HostInstallPicker({
 							key={item.id}
 							href={homeInstallHref(item.id, libraryTab)}
 							aria-current={selected ? "true" : undefined}
-							className={`inline-flex h-10 items-center gap-2 rounded-lg border px-2.5 font-mono text-[12px] transition-colors ${
+							onClick={(e) => pick(e, item.id)}
+							className={cn(
+								"relative flex flex-col items-start gap-2 rounded-xl border p-3 text-left transition-colors",
 								selected
 									? "border-fd-primary/50 bg-[var(--color-fd-primary-10)] text-fd-foreground"
-									: "border-fd-border bg-[var(--color-fd-surface-raised)] text-fd-muted-foreground hover:border-fd-primary/40 hover:text-fd-foreground"
-							}`}
+									: "border-fd-border bg-[var(--color-fd-surface-raised)] text-fd-muted-foreground hover:border-fd-primary/40 hover:text-fd-foreground",
+							)}
 						>
-							<HostMark host={item.id} className="h-4 w-4" />
-							<span>{item.name}</span>
+							{selected ? (
+								<motion.span
+									layoutId="host-card-ring"
+									className="pointer-events-none absolute inset-0 rounded-xl ring-2 ring-fd-primary/35"
+									transition={{ type: "spring", stiffness: 420, damping: 34 }}
+									aria-hidden="true"
+								/>
+							) : null}
+							<span className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-fd-border bg-fd-background">
+								<HostMark host={item.id} className="h-5 w-5" />
+							</span>
+							<span className="text-[13px] font-semibold text-fd-foreground">
+								{item.name}
+							</span>
+							<span
+								aria-hidden="true"
+								className="line-clamp-2 text-[11px] leading-4 text-fd-muted-foreground"
+							>
+								{item.what}
+							</span>
 						</a>
 					);
 				})}
 			</div>
+			<HostCommandPanel spec={spec} />
+		</nav>
+	);
+}
+
+function HostCommandPanel({ spec }: { spec: HostInstallSpec }) {
+	return (
+		<SameRouteFade childKey={spec.id} name="host-command">
 			<div className="mt-3 space-y-2">
 				<p className="text-center text-[12px] leading-5 text-fd-muted-foreground">
 					{spec.where}
@@ -141,6 +196,6 @@ export function HostInstallPicker({
 					</Link>
 				</p>
 			</div>
-		</nav>
+		</SameRouteFade>
 	);
 }

--- a/docs/site/components/library-catalog.tsx
+++ b/docs/site/components/library-catalog.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import { useMemo, useState, type KeyboardEvent } from "react";
+import { startTransition, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ArrowRight, Search, X } from "lucide-react";
 import { LazySkillBrowser } from "@/components/lazy";
+import { AnimatedTabs } from "@/components/ui/animated-tabs";
+import { CategoryMark, LibraryMark } from "@/components/category-mark";
+import { SameRouteFade, sameRouteReplace } from "@/components/page-transition";
+import { ChangelogMermaid } from "@/components/changelog-mermaid";
 import { AGENTS } from "@/lib/generated/shared-data";
 import { COUNTS } from "@/lib/constants";
 import { CATEGORY_COLORS } from "@/lib/category-colors";
-import { HOOK_EVENT_PAGES } from "@/lib/hook-events";
+import {
+  groupedHookEvents,
+  HOOK_LIFECYCLE_CHART,
+} from "@/lib/hook-phases";
 import {
   libraryTabHref,
   type LibraryTab,
 } from "@/lib/library-tab";
+import type { HostId } from "@/components/host-marks";
 
 const TABS: { id: LibraryTab; label: string; count: number }[] = [
   { id: "skills", label: "Skills", count: COUNTS.skills },
@@ -20,11 +28,37 @@ const TABS: { id: LibraryTab; label: string; count: number }[] = [
   { id: "hooks", label: "Hooks", count: COUNTS.hooks },
 ];
 
-export function LibraryCatalog({ tab }: { tab: LibraryTab }) {
+export function LibraryCatalog({
+  tab,
+  host = "claude",
+}: {
+  tab: LibraryTab;
+  host?: HostId;
+}) {
   const router = useRouter();
+  const [current, setCurrent] = useState<LibraryTab>(tab);
+  const pendingTabFocus = useRef<LibraryTab | null>(null);
+
+  useEffect(() => {
+    setCurrent(tab);
+  }, [tab]);
+
+  useEffect(() => {
+    const id = pendingTabFocus.current;
+    if (!id) return;
+    pendingTabFocus.current = null;
+    document.getElementById(`library-tab-${id}`)?.focus();
+  }, [current]);
+
+  const select = (id: LibraryTab) => {
+    startTransition(() => {
+      setCurrent(id);
+      router.replace(libraryTabHref(id, host), sameRouteReplace);
+    });
+  };
 
   const onTabKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
-    const i = TABS.findIndex((t) => t.id === tab);
+    const i = TABS.findIndex((t) => t.id === current);
     let next = i;
     if (e.key === "ArrowRight" || e.key === "ArrowDown") {
       next = (i + 1) % TABS.length;
@@ -38,7 +72,9 @@ export function LibraryCatalog({ tab }: { tab: LibraryTab }) {
       return;
     }
     e.preventDefault();
-    router.push(libraryTabHref(TABS[next].id));
+    const nextId = TABS[next].id;
+    pendingTabFocus.current = nextId;
+    select(nextId);
   };
 
   return (
@@ -74,65 +110,40 @@ export function LibraryCatalog({ tab }: { tab: LibraryTab }) {
           </div>
         </div>
 
-        <div
-          role="tablist"
-          aria-label="Library primitives"
+        <AnimatedTabs
+          ariaLabel="Library primitives"
+          layoutId="library-tab-indicator"
+          value={current}
+          onChange={select}
           onKeyDown={onTabKeyDown}
-          className="mb-6 flex flex-wrap gap-1 rounded-lg border border-fd-border p-1"
-        >
-          {TABS.map((t) => {
-            const selected = tab === t.id;
-            return (
-              <a
-                key={t.id}
-                href={libraryTabHref(t.id)}
-                role="tab"
-                aria-selected={selected}
-                tabIndex={selected ? 0 : -1}
-                id={`library-tab-${t.id}`}
-                aria-controls={`library-panel-${t.id}`}
-                className={`inline-flex items-center gap-2 rounded-md px-3.5 py-2 text-sm font-medium transition-colors ${
-                  selected
-                    ? "bg-[var(--color-fd-primary-10)] text-fd-primary"
-                    : "text-fd-muted-foreground hover:text-fd-foreground"
-                }`}
-              >
+          tabs={TABS.map((t) => ({
+            id: t.id,
+            href: libraryTabHref(t.id, host),
+            label: (
+              <>
+                <span className="inline-flex h-5 w-5 items-center justify-center rounded-md bg-fd-muted text-current">
+                  <LibraryMark kind={t.id} className="h-3.5 w-3.5" />
+                </span>
                 {t.label}
                 <span className="font-mono text-[11px] tabular-nums opacity-70">
                   {t.count}
                 </span>
-              </a>
-            );
-          })}
-        </div>
+              </>
+            ),
+          }))}
+        />
 
-        {tab === "skills" ? (
+        <SameRouteFade childKey={current} name="library-panel">
           <div
             role="tabpanel"
-            id="library-panel-skills"
-            aria-labelledby="library-tab-skills"
+            id={`library-panel-${current}`}
+            aria-labelledby={`library-tab-${current}`}
           >
-            <LazySkillBrowser />
+            {current === "skills" ? <LazySkillBrowser /> : null}
+            {current === "agents" ? <AgentsGrid /> : null}
+            {current === "hooks" ? <HooksFlow /> : null}
           </div>
-        ) : null}
-        {tab === "agents" ? (
-          <div
-            role="tabpanel"
-            id="library-panel-agents"
-            aria-labelledby="library-tab-agents"
-          >
-            <AgentsGrid />
-          </div>
-        ) : null}
-        {tab === "hooks" ? (
-          <div
-            role="tabpanel"
-            id="library-panel-hooks"
-            aria-labelledby="library-tab-hooks"
-          >
-            <HooksGrid />
-          </div>
-        ) : null}
+        </SameRouteFade>
       </div>
     </section>
   );
@@ -192,15 +203,22 @@ function AgentsGrid() {
               href={`/docs/reference/agents/${agent.name}`}
               className="group rounded-lg border border-fd-border p-4 transition-colors hover:bg-fd-muted"
             >
-              <div className="mb-2 flex flex-wrap items-center gap-2">
-                <h3 className="text-sm font-semibold text-fd-foreground">
-                  {agent.name}
-                </h3>
+              <div className="mb-2 flex items-start gap-2.5">
                 <span
-                  className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${cat.bg} ${cat.color}`}
+                  className={`mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${cat.bg} ${cat.color}`}
                 >
-                  {agent.category}
+                  <CategoryMark category={agent.category} className="h-4 w-4" />
                 </span>
+                <div className="min-w-0">
+                  <h3 className="text-sm font-semibold text-fd-foreground">
+                    {agent.name}
+                  </h3>
+                  <span
+                    className={`mt-1 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium ${cat.bg} ${cat.color}`}
+                  >
+                    {agent.category}
+                  </span>
+                </div>
               </div>
               <p className="text-[13px] leading-[1.5] text-fd-muted-foreground">
                 {agent.description}
@@ -213,28 +231,57 @@ function AgentsGrid() {
   );
 }
 
-function HooksGrid() {
+function HooksFlow() {
+  const groups = groupedHookEvents();
+  const total = groups.reduce((n, group) => n + group.events.length, 0);
+
   return (
     <div>
       <p className="mb-4 text-sm text-fd-muted-foreground">
-        {HOOK_EVENT_PAGES.length} lifecycle events. Open a category for the
-        hooks that fire there.
+        {total} lifecycle events, grouped by when they fire. Open a category
+        for the hooks that run there.
       </p>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {HOOK_EVENT_PAGES.map((event) => (
-          <Link
-            key={event.slug}
-            href={event.href}
-            className="group flex items-center justify-between rounded-lg border border-fd-border px-4 py-3 transition-colors hover:bg-fd-muted"
+      <div className="mb-8 overflow-x-auto rounded-xl border border-fd-border bg-[var(--color-fd-surface-raised)] p-4">
+        <ChangelogMermaid chart={HOOK_LIFECYCLE_CHART} />
+      </div>
+      <div className="grid gap-4 lg:grid-cols-2">
+        {groups.map((group) => (
+          <section
+            key={group.id}
+            aria-labelledby={`hook-phase-${group.id}`}
+            className="rounded-xl border border-fd-border p-4"
           >
-            <span className="font-mono text-sm font-medium text-fd-foreground">
-              {event.label}
-            </span>
-            <ArrowRight
-              className="h-3.5 w-3.5 text-fd-primary opacity-0 transition-all group-hover:translate-x-0.5 group-hover:opacity-100"
-              aria-hidden="true"
-            />
-          </Link>
+            <h3
+              id={`hook-phase-${group.id}`}
+              className="text-sm font-semibold text-fd-foreground"
+            >
+              {group.label}
+              <span className="ml-2 font-mono text-[11px] font-medium tabular-nums text-fd-muted-foreground">
+                {group.events.length}
+              </span>
+            </h3>
+            <p className="mt-1 text-[12.5px] leading-5 text-fd-muted-foreground">
+              {group.blurb}
+            </p>
+            <ul className="mt-3 space-y-1">
+              {group.events.map((event) => (
+                <li key={event.slug}>
+                  <Link
+                    href={event.href}
+                    className="group flex items-center justify-between rounded-md px-2 py-1.5 transition-colors hover:bg-fd-muted"
+                  >
+                    <span className="font-mono text-[13px] font-medium text-fd-foreground">
+                      {event.label}
+                    </span>
+                    <ArrowRight
+                      className="h-3.5 w-3.5 text-fd-primary opacity-0 transition-all group-hover:translate-x-0.5 group-hover:opacity-100"
+                      aria-hidden="true"
+                    />
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
         ))}
       </div>
     </div>

--- a/docs/site/components/page-transition.tsx
+++ b/docs/site/components/page-transition.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/// <reference types="react/canary" />
+
+import * as React from "react";
+import type { ReactNode } from "react";
+
+/** Same-route homepage swaps (host command, Skills/Agents/Hooks). */
+export const SAME_ROUTE_TYPE = "catalog";
+
+export const sameRouteReplace = {
+	scroll: false as const,
+	transitionTypes: [SAME_ROUTE_TYPE],
+};
+
+type ViewTransitionProps = {
+	children?: ReactNode;
+	name?: string;
+	default?: unknown;
+	enter?: unknown;
+	exit?: unknown;
+	share?: unknown;
+	update?: unknown;
+};
+
+const ViewTransition =
+	((React as unknown as { ViewTransition?: (props: ViewTransitionProps) => React.ReactNode })
+		.ViewTransition ??
+		(({ children }: ViewTransitionProps) => children)) as (
+		props: ViewTransitionProps,
+	) => React.ReactNode;
+
+/**
+ * Route enter/exit. Lives in `template.tsx` so it remounts with the page.
+ * Layout chrome (nav, sidebar) stays put via `view-transition-name` in CSS.
+ * Typed `catalog` navigations skip the page fade so query-string replaces
+ * do not replay the whole homepage.
+ */
+export function PageTransition({ children }: { children: ReactNode }) {
+	return (
+		<ViewTransition
+			enter={{ default: "page-enter", catalog: "none" }}
+			exit={{ default: "page-exit", catalog: "none" }}
+		>
+			{children}
+		</ViewTransition>
+	);
+}
+
+/** Same-route swap (host command, Skills/Agents/Hooks). Driven by router.replace. */
+export function SameRouteFade({
+	childKey,
+	name,
+	children,
+}: {
+	childKey: string;
+	name: string;
+	children: ReactNode;
+}) {
+	return (
+		<ViewTransition
+			key={childKey}
+			name={name}
+			default="none"
+			share={{ catalog: "catalog-fade", default: "none" }}
+			enter={{ catalog: "catalog-fade", default: "none" }}
+			exit={{ catalog: "catalog-fade", default: "none" }}
+			update={{ catalog: "catalog-fade", default: "none" }}
+		>
+			{children}
+		</ViewTransition>
+	);
+}

--- a/docs/site/components/skill-browser.tsx
+++ b/docs/site/components/skill-browser.tsx
@@ -2,12 +2,15 @@
 
 import { useState, useCallback, useMemo } from "react";
 import { Search, X, ChevronRight, ExternalLink, SearchX } from "lucide-react";
+import { motion } from "motion/react";
 import type { SkillMeta } from "@/lib/generated/types";
 import { SKILLS } from "@/lib/generated/skills-data";
 import { CATEGORY_COLORS } from "@/lib/category-colors";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { createCollection, useOramaCollection } from "@/lib/orama-browser";
 import { Highlight } from "@/components/search-highlight";
+import { CategoryMark } from "@/components/category-mark";
+import { cn } from "@/lib/cn";
 
 // ── Category visual metadata ────────────────────────────────
 const SKILL_CATEGORY_META: Record<
@@ -172,9 +175,6 @@ function categorizeSkill(skill: SkillMeta): string {
   return "development"; // Default fallback
 }
 
-// ── Plugin filter type ──────────────────────────────────────
-type PluginFilter = "all" | "ork";
-
 // ── Skill entry with computed category ──────────────────────
 interface SkillEntry {
   key: string;
@@ -220,7 +220,6 @@ const SKILL_COLLECTION = createCollection<SkillEntry>(ALL_SKILLS, {
 export function SkillBrowser() {
   const [search, setSearch] = useState("");
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-  const [pluginFilter, setPluginFilter] = useState<PluginFilter>("all");
   const [expandedSkill, setExpandedSkill] = useState<string | null>(null);
 
   // Orama-backed search + faceted filtering (BM25 ranking, 1-char typo
@@ -230,7 +229,6 @@ export function SkillBrowser() {
     term: debouncedSearch,
     where: {
       category: selectedCategories,
-      plugins: pluginFilter === "all" ? [] : [pluginFilter],
     },
   });
   const filtered = result.items;
@@ -266,18 +264,13 @@ export function SkillBrowser() {
   const clearFilters = useCallback(() => {
     setSearch("");
     setSelectedCategories([]);
-    setPluginFilter("all");
   }, []);
 
-  const hasFilters =
-    search !== "" ||
-    selectedCategories.length > 0 ||
-    pluginFilter !== "all";
+  const hasFilters = search !== "" || selectedCategories.length > 0;
 
   return (
     <div className="not-prose">
-      {/* Header row: count + plugin toggle */}
-      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mb-6">
         <p
           className="text-sm text-fd-muted-foreground"
           role="status"
@@ -295,31 +288,6 @@ export function SkillBrowser() {
             "Loading skills…"
           )}
         </p>
-        <div
-          className="inline-flex rounded-lg border border-fd-border p-0.5"
-          role="group"
-          aria-label="Filter by plugin"
-        >
-          {(["all", "ork"] as const).map((p) => {
-            const active = pluginFilter === p;
-            const label = p === "all" ? "All" : p;
-            return (
-              <button
-                key={p}
-                type="button"
-                onClick={() => setPluginFilter(p)}
-                aria-pressed={active}
-                className={`rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
-                  active
-                    ? "bg-[var(--color-fd-primary-10)] text-fd-primary shadow-sm"
-                    : "text-fd-muted-foreground hover:bg-fd-muted"
-                }`}
-              >
-                {label}
-              </button>
-            );
-          })}
-        </div>
       </div>
 
       {/* Search bar */}
@@ -355,27 +323,26 @@ export function SkillBrowser() {
             const meta = SKILL_CATEGORY_META[cat];
             const active = selectedCategories.includes(cat);
             return (
-              <button
+              <motion.button
                 key={cat}
                 type="button"
+                layout
+                transition={{ duration: 0.18 }}
                 onClick={() => toggleCategory(cat)}
                 aria-pressed={active}
-                className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-all ${
+                className={cn(
+                  "relative inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium [&_svg]:block",
                   active
                     ? `${meta.bg} ${meta.color} border-current shadow-sm`
-                    : "border-fd-border text-fd-muted-foreground hover:border-fd-border hover:bg-fd-muted"
-                }`}
+                    : "border-fd-border text-fd-muted-foreground hover:bg-fd-muted",
+                )}
               >
-                <span
-                  className={`h-2 w-2 shrink-0 rounded-full ${
-                    active ? "opacity-100" : "opacity-60"
-                  } ${meta.dot}`}
-                />
+                <CategoryMark category={cat} className="h-3.5 w-3.5" />
                 {meta.label}
                 <span className="tabular-nums text-fd-muted-foreground/70">
                   {countOf(cat)}
                 </span>
-              </button>
+              </motion.button>
             );
           })}
           {hasFilters && (
@@ -493,6 +460,11 @@ function SkillCard({
         className="flex w-full items-start gap-3 p-4 text-left"
         aria-expanded={expanded}
       >
+        <span
+          className={`mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${catMeta.bg} ${catMeta.color}`}
+        >
+          <CategoryMark category={category} className="h-4 w-4" />
+        </span>
         <div className="min-w-0 flex-1">
           <div className="mb-1 flex flex-wrap items-center gap-2">
             <Highlight
@@ -501,7 +473,7 @@ function SkillCard({
               className="text-sm font-semibold text-fd-foreground"
             />
             <span
-              className={`inline-flex shrink-0 rounded px-1.5 py-0.5 text-[11px] font-medium leading-tight ${catMeta.bg} ${catMeta.color}`}
+              className={`inline-flex shrink-0 items-center rounded px-1.5 py-0.5 text-[11px] font-medium leading-tight ${catMeta.bg} ${catMeta.color}`}
             >
               {catMeta.label}
             </span>

--- a/docs/site/components/ui/animated-tabs.tsx
+++ b/docs/site/components/ui/animated-tabs.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { KeyboardEvent, ReactNode } from "react";
+import { LayoutGroup, motion } from "motion/react";
+import { cn } from "@/lib/cn";
+
+/**
+ * Sliding-indicator tabs. Shape from 21st.dev Animated Tabs (24930).
+ * Tokens are Fumadocs `fd-*`. Reduced-motion skips the layout animation.
+ */
+
+export type AnimatedTabItem<Id extends string = string> = {
+	id: Id;
+	label: ReactNode;
+	href?: string;
+};
+
+export function AnimatedTabs<Id extends string>({
+	tabs,
+	value,
+	onChange,
+	onKeyDown,
+	ariaLabel,
+	layoutId,
+	className,
+}: {
+	tabs: readonly AnimatedTabItem<Id>[];
+	value: Id;
+	onChange: (id: Id) => void;
+	onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
+	ariaLabel: string;
+	layoutId: string;
+	className?: string;
+}) {
+	return (
+		<LayoutGroup id={layoutId}>
+		<div
+			role="tablist"
+			aria-label={ariaLabel}
+			onKeyDown={onKeyDown}
+			className={cn(
+				"relative mb-6 inline-flex w-max max-w-full flex-wrap items-center gap-1 rounded-lg border border-fd-border p-1",
+				className,
+			)}
+		>
+			{tabs.map((tab) => {
+				const selected = tab.id === value;
+				const shared = cn(
+					"relative z-0 inline-flex items-center gap-2 rounded-md px-3.5 py-2 text-sm font-medium transition-colors [&_svg]:block [&_svg]:shrink-0",
+					selected
+						? "text-fd-primary"
+						: "text-fd-muted-foreground hover:text-fd-foreground",
+				);
+				const indicator = selected ? (
+					<motion.span
+						layoutId={layoutId}
+						className="absolute inset-0 -z-10 rounded-md bg-[var(--color-fd-primary-10)]"
+						transition={{ type: "spring", stiffness: 380, damping: 32 }}
+						aria-hidden="true"
+					/>
+				) : null;
+
+				if (tab.href) {
+					return (
+						<a
+							key={tab.id}
+							href={tab.href}
+							role="tab"
+							aria-selected={selected}
+							tabIndex={selected ? 0 : -1}
+							id={`library-tab-${tab.id}`}
+							aria-controls={`library-panel-${tab.id}`}
+							className={shared}
+							onClick={(e) => {
+								if (
+									e.metaKey ||
+									e.ctrlKey ||
+									e.shiftKey ||
+									e.altKey ||
+									e.button !== 0
+								) {
+									return;
+								}
+								e.preventDefault();
+								onChange(tab.id);
+							}}
+						>
+							{indicator}
+							{tab.label}
+						</a>
+					);
+				}
+
+				return (
+					<button
+						key={tab.id}
+						type="button"
+						role="tab"
+						aria-selected={selected}
+						tabIndex={selected ? 0 : -1}
+						id={`library-tab-${tab.id}`}
+						aria-controls={`library-panel-${tab.id}`}
+						className={shared}
+						onClick={() => onChange(tab.id)}
+					>
+						{indicator}
+						{tab.label}
+					</button>
+				);
+			})}
+		</div>
+		</LayoutGroup>
+	);
+}

--- a/docs/site/components/ui/item.tsx
+++ b/docs/site/components/ui/item.tsx
@@ -1,0 +1,120 @@
+import type { ComponentProps, ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+/**
+ * shadcn Item primitives, adapted from 21st.dev:
+ * - Item (group) — https://21st.dev/shadcn/item (demo 8666)
+ * - Item Image list — https://21st.dev/uiable/item-image (demo 26783)
+ *
+ * No @radix-ui/react-slot or class-variance-authority: the docs site's `cn`
+ * is a filter-join, and these items are not asChild-composed.
+ */
+
+export function ItemGroup({ className, ...props }: ComponentProps<"div">) {
+	return (
+		<div
+			role="list"
+			data-slot="item-group"
+			className={cn("not-prose flex flex-col gap-3", className)}
+			{...props}
+		/>
+	);
+}
+
+export function Item({
+	className,
+	variant = "outline",
+	size = "sm",
+	...props
+}: ComponentProps<"div"> & {
+	variant?: "default" | "outline" | "muted";
+	size?: "default" | "sm";
+}) {
+	return (
+		<div
+			data-slot="item"
+			role="listitem"
+			className={cn(
+				"flex items-start rounded-md text-sm outline-none",
+				variant === "default" && "border border-transparent",
+				variant === "outline" &&
+					"border border-fd-border bg-[var(--color-fd-surface-raised)]",
+				variant === "muted" && "border border-transparent bg-fd-muted/50",
+				size === "default" && "gap-4 p-4",
+				size === "sm" && "gap-2.5 px-3 py-2.5",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export function ItemMedia({
+	className,
+	variant = "icon",
+	...props
+}: ComponentProps<"div"> & { variant?: "default" | "icon" | "image" }) {
+	return (
+		<div
+			data-slot="item-media"
+			className={cn(
+				"flex shrink-0 items-center justify-center",
+				variant === "icon" &&
+					"size-8 rounded-sm border border-fd-border bg-fd-muted [&_svg]:size-4",
+				variant === "image" && "size-10 overflow-hidden rounded-sm",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export function ItemContent({ className, ...props }: ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="item-content"
+			className={cn("flex min-w-0 flex-1 flex-col gap-1", className)}
+			{...props}
+		/>
+	);
+}
+
+export function ItemTitle({ className, ...props }: ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="item-title"
+			className={cn(
+				"flex w-fit max-w-full items-center gap-2 text-sm font-medium leading-snug break-words",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export function ItemDescription({ className, ...props }: ComponentProps<"p">) {
+	return (
+		<p
+			data-slot="item-description"
+			className={cn(
+				"text-sm font-normal leading-normal text-fd-muted-foreground",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export function ItemHeader({ className, children }: { className?: string; children: ReactNode }) {
+	return (
+		<div
+			data-slot="item-header"
+			className={cn(
+				"flex w-full flex-wrap items-center justify-between gap-x-2 gap-y-1",
+				className,
+			)}
+		>
+			{children}
+		</div>
+	);
+}

--- a/docs/site/content/docs/reference/agents/security-auditor.mdx
+++ b/docs/site/content/docs/reference/agents/security-auditor.mdx
@@ -34,7 +34,7 @@ These hooks activate exclusively when this agent runs, enforcing safety and comp
 
 | Hook | Behavior | Description |
 |------|----------|-------------|
-| `security-command-audit` | 🔇 Silent | Extra audit logging for security agent operations |
+| `security-command-audit` | Silent | Security Command Audit - Extra audit logging for security agent operations |
 
 ## Directive
 Scan codebase for security vulnerabilities, audit dependencies, and verify OWASP Top 10 compliance. Return actionable findings only. Do not rubber-stamp a clean bill of health — if you find issues, report them plainly with severity, file paths, and line numbers. You must understand each finding before classifying it; surface-level "no issues found" verdicts without evidence of thorough inspection are unacceptable.

--- a/docs/site/content/docs/reference/agents/security-layer-auditor.mdx
+++ b/docs/site/content/docs/reference/agents/security-layer-auditor.mdx
@@ -30,7 +30,7 @@ These hooks activate exclusively when this agent runs, enforcing safety and comp
 
 | Hook | Behavior | Description |
 |------|----------|-------------|
-| `security-command-audit` | 🔇 Silent | Extra audit logging for security agent operations |
+| `security-command-audit` | Silent | Security Command Audit - Extra audit logging for security agent operations |
 
 # Security Layer Auditor Agent
 

--- a/docs/site/content/docs/reference/hooks/config-change.mdx
+++ b/docs/site/content/docs/reference/hooks/config-change.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on ConfigChange events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `settings-reload` | `*` | Blocks | ConfigChange Hook: Settings Drift Detector |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/cwd-changed.mdx
+++ b/docs/site/content/docs/reference/hooks/cwd-changed.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on CwdChanged events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `cwd-changed` | `*` | Injects | CC 2.1.83: Fires when working directory changes. Returns updated watchPaths list and injects refreshed project context. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/directory-added.mdx
+++ b/docs/site/content/docs/reference/hooks/directory-added.mdx
@@ -9,4 +9,4 @@ description: "Hooks triggered on DirectoryAdded events (1 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
+| `directory-added` | `*` | Fire-and-forget | Directory Added Observer |

--- a/docs/site/content/docs/reference/hooks/elicitation-result.mdx
+++ b/docs/site/content/docs/reference/hooks/elicitation-result.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on ElicitationResult events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `elicitation-result-logger` | `*` | Silent | ElicitationResult Logger — Tracks elicitation outcomes for analytics Fires on the CC `ElicitationResult` event (after the user responds). |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/elicitation.mdx
+++ b/docs/site/content/docs/reference/hooks/elicitation.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on Elicitation events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `elicitation-guard` | `*` | Blocks | Elicitation Guard — Blocks MCP elicitation forms that request secrets Fires on the CC `Elicitation` event (before the form is shown to the user). |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/file-changed.mdx
+++ b/docs/site/content/docs/reference/hooks/file-changed.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on FileChanged events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `CLAUDE.md\|package.json\|.env\|settings.json` | 🔇 Silent | — |
-| `node` | `CLAUDE.md\|package.json\|.env\|settings.json` | 🔇 Silent | — |
+| `file-changed` | `CLAUDE.md\|package.json\|.env\|settings.json` | Silent | CC 2.1.83: Fires when a file in the watchPaths list changes. Injects notification context so the model knows a config/rule changed. |
+| `webhook-forwarder` | `CLAUDE.md\|package.json\|.env\|settings.json` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/instructions-loaded.mdx
+++ b/docs/site/content/docs/reference/hooks/instructions-loaded.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on InstructionsLoaded events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `instructions-loaded-dispatcher` | `*` | Silent | The real CC InstructionsLoaded event fires ONCE PER FILE with \{ file_path, memory_type, load_reason \}. The previous dispatcher read a fabricated `files_loaded` array (0 handlers ever ran) and returned additionalContext (stripped by bin/output-guard.mjs for this event). |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/message-display.mdx
+++ b/docs/site/content/docs/reference/hooks/message-display.mdx
@@ -9,4 +9,4 @@ description: "Hooks triggered on MessageDisplay events (1 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
+| `message-display-observer` | `*` | Fire-and-forget | Message Display Observer |

--- a/docs/site/content/docs/reference/hooks/notification.mdx
+++ b/docs/site/content/docs/reference/hooks/notification.mdx
@@ -9,6 +9,6 @@ description: "Hooks triggered on Notification events (3 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `desktop` | `*` | Fire-and-forget | Sends rich desktop notifications with context (repo, branch, task). |
+| `sound` | `*` | Fire-and-forget | PRIMARY PATH (#1847): returns the top-level `terminalSequence` hook-output field with a BEL (\u0007). CC emits it to the user's terminal, which rings the terminal bell — zero process spawns, works on macOS + Linux, command hooks only. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/permission-denied.mdx
+++ b/docs/site/content/docs/reference/hooks/permission-denied.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on PermissionDenied events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `unified-dispatcher` | `*` | Silent | Consolidates all PermissionDenied hooks into a single process spawn. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/permission-request.mdx
+++ b/docs/site/content/docs/reference/hooks/permission-request.mdx
@@ -9,7 +9,7 @@ description: "Hooks triggered on PermissionRequest events (4 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
+| `unified-dispatcher` | `Bash` | Silent | Consolidates 2 PermissionRequest hooks for Bash into a single process spawn. |
+| `webhook-forwarder` | `Bash` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `auto-approve-project-writes` | `Write\|Edit` | Silent | Auto-Approve Project Writes - Auto-approves writes within project directory |
+| `webhook-forwarder` | `Write\|Edit` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/post-compact.mdx
+++ b/docs/site/content/docs/reference/hooks/post-compact.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on PostCompact events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `post-compact-recovery` | `*` | Silent | PostCompact Recovery — logs the context carried across compaction CC 2.1.76+: Fires after compaction completes. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/post-model-switch.mdx
+++ b/docs/site/content/docs/reference/hooks/post-model-switch.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on PostModelSwitch events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `model-switch-telemetry` | `*` | Fire-and-forget | Observer only. Appends one line per session model change to ~/.claude/analytics/model-switch.jsonl so ork:analytics can answer "how often do sessions move tiers, from where, and what did the re-cache cost", which until 2.1.251 was not observable from a plugin at all. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/post-tool-batch.mdx
+++ b/docs/site/content/docs/reference/hooks/post-tool-batch.mdx
@@ -9,4 +9,4 @@ description: "Hooks triggered on PostToolBatch events (1 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
+| `tool-batch-observer` | `*` | Fire-and-forget | Tool Batch Observer |

--- a/docs/site/content/docs/reference/hooks/post-tool-use-failure.mdx
+++ b/docs/site/content/docs/reference/hooks/post-tool-use-failure.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on PostToolUseFailure events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `Bash\|Write\|Edit\|Agent` | 🔇 Silent | — |
-| `node` | `Bash\|Write\|Edit\|Agent` | 🔇 Silent | — |
+| `failure-handler` | `Bash\|Write\|Edit\|Agent` | Silent | PostToolUseFailure Handler CC 2.1.25: Error-path hook providing solution suggestions when tools fail |
+| `webhook-forwarder` | `Bash\|Write\|Edit\|Agent` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/post-tool-use.mdx
+++ b/docs/site/content/docs/reference/hooks/post-tool-use.mdx
@@ -9,31 +9,31 @@ description: "Hooks triggered on PostToolUse events (28 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `Agent` | 🔇 Silent | — |
-| `node` | `Agent` | 🔇 Silent | — |
-| `node` | `mcp__*` | 🔇 Silent | — |
-| `node` | `mcp__*` | 🔇 Silent | — |
-| `node` | `Read\|Bash\|Grep\|Glob` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Agent\|TaskUpdate\|TaskCreate` | 🔇 Silent | — |
-| `node` | `Skill` | 🔇 Silent | — |
-| `node` | `Skill` | 🔇 Silent | — |
-| `node` | `Skill` | 🔇 Silent | — |
-| `node` | `Bash\|Write\|Edit\|Agent\|TaskUpdate\|TaskCreate\|Skill\|NotebookEdit` | 🔇 Silent | — |
-| `node` | `Bash\|Write\|Edit\|Agent\|TaskUpdate\|TaskCreate\|Skill\|NotebookEdit` | 🔇 Silent | — |
-| `node` | `Bash\|Write\|Edit\|Agent\|TaskUpdate\|TaskCreate\|Skill\|NotebookEdit` | 🔇 Silent | — |
-| `node` | `Read\|Grep\|Glob\|WebFetch\|WebSearch` | 🔇 Silent | — |
+| `agent-task-auto-register` | `Agent` | Fire-and-forget | After an Agent tool call succeeds, checks if a task was registered for this agent. If not, auto-registers it in the local task registry and injects a context nudge suggesting the model create a proper TaskCreate for tracking. |
+| `webhook-forwarder` | `Agent` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `mcp-output-transform` | `mcp__*` | Silent | Issues: #1240 (PoC) · #2264 (reversible compression) · #2302 (graduation → updatedToolOutput) |
+| `webhook-forwarder` | `mcp__*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `secret-handler` | `Read\|Bash\|Grep\|Glob` | Silent | hookSpecificOutput.updatedToolOutput (extends 2.1.69's MCP-only updatedMCPToolOutput to all tools). |
+| `auto-lint` | `Write\|Edit` | Silent | CC 2.1.90: Safe to modify files in PostToolUse — "File content has changed" race fixed |
+| `ascii-lint` | `Write\|Edit` | Fire-and-forget | ASCII Lint — PostToolUse warn-only linter for fenced ASCII blocks in *.md. Implements 5 rules from designs/ascii-design-system.md §A.3. Severity is locked to `warn` (D3); never blocks an Edit/Write. |
+| `code-comment-glyph-warn` | `Write\|Edit` | Fire-and-forget | Code Comment Glyph Warn — PostToolUse advisory linter. |
+| `ui-change-detector` | `Write\|Edit` | Injects | Watches Edit/Write on UI-shaped files. When detected and the dev stack is live, emits an `additionalContext` nudge prompting the user to run /ork:expect on the affected route. Diff-aware (single route per change), debounced, and skippable per-session. |
+| `redact-secrets` | `Write\|Edit` | Fire-and-forget | Warns if potential secrets appear in Write, Edit, or Bash tool output. |
+| `security-auditor` | `Write\|Edit` | Fire-and-forget | Config Change Security Auditor - Audits Write\|Edit ops targeting .claude/ config files |
+| `stale-import-detector` | `Write\|Edit` | Blocks | After a Write creates a new file (or a previously existing file is gone), greps the repo for imports of the old path and injects an advisory listing the stale import sites. |
+| `debt-marker-tracker` | `Write\|Edit` | Injects | The capture half of the deferred-debt feature (counterpart to the YAGNI gate). When an agent takes a deliberate shortcut it drops an inline marker: |
+| `check-plugins-drift` | `Write\|Edit` | Blocks | M139 issue #1782 (C5 plugins/ drift detector). |
+| `edit-history-tracker` | `Write\|Edit` | Fire-and-forget | Companion to prompt/thrash-detector.ts (#1285). Maintains a rolling JSONL log of recent Write/Edit events so the thrash detector can read the history at UserPromptSubmit time. |
+| `commit-nudge` | `Write\|Edit` | Fire-and-forget | Commit Nudge — Escalating reminders to commit work |
+| `redact-secrets` | `Bash` | Fire-and-forget | Warns if potential secrets appear in Write, Edit, or Bash tool output. |
+| `commit-nudge` | `Bash` | Fire-and-forget | Commit Nudge — Escalating reminders to commit work |
+| `gh-rate-limit-tracker` | `Bash` | Fire-and-forget | GitHub Rate-Limit Tracker |
+| `session-heartbeat-publisher` | `Bash` | Fire-and-forget | Detects structural git/gh operations in the Bash command + output and publishes a distilled JSON state file to ~/.claude/state/orchestkit/&lt;repo&gt;/&lt;session-id&gt;.json |
+| `team-member-start` | `Agent\|TaskUpdate\|TaskCreate` | Fire-and-forget | Links spawned teammates to the team activity log after successful spawn. Only fires for team-scoped spawns (tool_input.team_name present). |
+| `fingerprint-saver` | `Skill` | Fire-and-forget | Expect Fingerprint Auto-Saver (#1191) |
+| `snapshot-recorder` | `Skill` | Fire-and-forget | Expect Snapshot Recorder (M125 #6) |
+| `auto-verify` | `Skill` | Fire-and-forget | Design-Import Auto-Verify (#1386) |
+| `heartbeat` | `Bash\|Write\|Edit\|Agent\|TaskUpdate\|TaskCreate\|Skill\|NotebookEdit` | Fire-and-forget | Updates sessions.last_heartbeat for the current sid on every PostToolUse, rate-limited to once per 5 seconds via a module-level cache. Keeps the DB pressure bounded — even a hot tool-use loop touches at most one row per session every 5s. |
+| `chain-staleness-checker` | `Bash\|Write\|Edit\|Agent\|TaskUpdate\|TaskCreate\|Skill\|NotebookEdit` | Fire-and-forget | Layer 3 of the 4-layer coordination architecture. Watches the project-local chain state file (`.claude/chain/state.json`) for activity. |
+| `metrics-dispatcher` | `Bash\|Write\|Edit\|Agent\|TaskUpdate\|TaskCreate\|Skill\|NotebookEdit` | Injects | Collapses the three async hooks that fire on the PostToolUse catchall matcher into a single subprocess invocation. Same behavior, same files written, same semantics — just one node cold-start per event instead of three. |
+| `context-crossing-warn` | `Read\|Grep\|Glob\|WebFetch\|WebSearch` | Silent | Context-Crossing Warn — Issue #1470 (extended by M119 dogfood cluster) |

--- a/docs/site/content/docs/reference/hooks/pre-compact.mdx
+++ b/docs/site/content/docs/reference/hooks/pre-compact.mdx
@@ -9,7 +9,7 @@ description: "Hooks triggered on PreCompact events (4 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `pre-compact-guard` | `*` | Blocks | PreCompact Guard (CC 2.1.105) |
+| `pre-compact-task-done-prompt` | `*` | Blocks | PreCompact Task-Done Prompt — Issue #1469 (extended by M119 dogfood cluster) |
+| `pre-compact-saver` | `*` | Silent | PreCompact Saver — Compaction-Aware Memory Architecture CC 2.1.25+: Preserves critical context before context compaction. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/pre-model-switch.mdx
+++ b/docs/site/content/docs/reference/hooks/pre-model-switch.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on PreModelSwitch events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `model-switch-consent` | `*` | Silent | The standing rule "no Fable spend without consent" had one enforcement point before this hook: fable-spend-consent, a PreToolUse[Agent] gate that asks before an agent SPAWN pins a Fable id. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/pre-tool-use.mdx
+++ b/docs/site/content/docs/reference/hooks/pre-tool-use.mdx
@@ -9,23 +9,23 @@ description: "Hooks triggered on PreToolUse events (20 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Bash` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Write\|Edit` | 🔇 Silent | — |
-| `node` | `Skill` | 🔇 Silent | — |
-| `node` | `Skill` | 🔇 Silent | — |
-| `node` | `mcp__context7__*` | 🔇 Silent | — |
-| `node` | `mcp__context7__*` | 🔇 Silent | — |
-| `node` | `mcp__memory__*` | 🔇 Silent | — |
-| `node` | `mcp__memory__*` | 🔇 Silent | — |
-| `node` | `Agent` | 🔇 Silent | — |
-| `node` | `Agent` | 🔇 Silent | — |
-| `node` | `Read` | 🔇 Silent | — |
-| `node` | `Read` | 🔇 Silent | — |
-| `node` | `AskUserQuestion` | 🔇 Silent | — |
-| `node` | `AskUserQuestion` | 🔇 Silent | — |
-| `node` | `Workflow` | 🔇 Silent | — |
-| `node` | `Workflow` | 🔇 Silent | — |
-| `node` | `CronCreate` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `sync-bash-dispatcher` | `Bash` | Injects | Consolidates 3 Bash PreToolUse hooks into a single dispatcher. |
+| `webhook-forwarder` | `Bash` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `sync-write-edit-dispatcher` | `Write\|Edit` | Injects | Consolidates 5 Write\|Edit PreToolUse hooks into a single dispatcher. |
+| `webhook-forwarder` | `Write\|Edit` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `skill-tracker` | `Skill` | Fire-and-forget | Logs Skill tool invocations with analytics |
+| `webhook-forwarder` | `Skill` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `context7-tracker` | `mcp__context7__*` | Blocks | Tracks context7 library lookups and injects cache state as additionalContext CC 2.1.9 Enhanced |
+| `webhook-forwarder` | `mcp__context7__*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `memory-validator` | `mcp__memory__*` | Blocks | Validates memory operations to prevent accidental data loss |
+| `webhook-forwarder` | `mcp__memory__*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `sync-task-dispatcher` | `Agent` | Injects | Consolidates 3 Task PreToolUse hooks into a single dispatcher. |
+| `webhook-forwarder` | `Agent` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `tldr-summary` | `Read` | Injects | Intercepts Read calls on large files (&gt;500 lines or &gt;2000 tokens) and injects a structural summary as additionalContext. Claude sees the summary as a roadmap alongside the full file content. |
+| `webhook-forwarder` | `Read` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `headless-responder` | `AskUserQuestion` | Silent | Headless AskUserQuestion Responder (CC 2.1.85) |
+| `webhook-forwarder` | `AskUserQuestion` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `workflow-agenttype-advisor` | `Workflow` | Injects | Scans Workflow `script` for agent() call sites and, when none set opts.agentType, injects an advisory with the specialist catalog mapping (mirror of skills/chain-patterns/references/dynamic-workflow-patterns.md §agentType). |
+| `webhook-forwarder` | `Workflow` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `webhook-forwarder` | `CronCreate` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/session-end.mdx
+++ b/docs/site/content/docs/reference/hooks/session-end.mdx
@@ -9,10 +9,10 @@ description: "Hooks triggered on SessionEnd events (7 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `sync-session-end-dispatcher` | `*` | Blocks | Consolidates 2 synchronous SessionEnd hooks into a single dispatcher. |
+| `session-handoff-generator` | `*` | Silent | Session Handoff Generator — Writes a structured handoff YAML at session end |
+| `usage-summary-reporter` | `*` | Fire-and-forget | Posts OrchestKit-specific session data to HQ API that CC's native HTTP hooks can't provide: hooks_triggered, event_counts, decisions, problems, solutions. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `telemetry-sync.mjs` | `*` | Fire-and-forget | — |
+| `goal-budget-guard` | `*` | Fire-and-forget | Cost circuit-breaker for `/goal`. Reads ended `/goal` runs from `.claude/state/goal-history.jsonl` for this session, sums their turn_count and ended_token_estimate, and writes `.claude/state/goal-budget-tripped.json` if either ceiling is breached. |
+| `session-finalizer` | `*` | Fire-and-forget | Marks this session's row as status='completed' and stamps ended_at. This hook deliberately does NOT delete the session row so post-mortem queries still work. (An older comment here described CASCADE on settings_overrides + locks; those tables were dropped in 005, #3353.) |

--- a/docs/site/content/docs/reference/hooks/session-start.mdx
+++ b/docs/site/content/docs/reference/hooks/session-start.mdx
@@ -9,24 +9,24 @@ description: "Hooks triggered on SessionStart events (21 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `pattern-sync-pull` | `*` | Fire-and-forget | Pulls global patterns into project on session start |
+| `nudge-outcome-resolver` | `*` | Fire-and-forget | SessionStart Nudge-Outcome Resolver — Issue #1476 |
+| `rules-size-check` | `*` | Fire-and-forget | Claude Code's project-instruction loader globs `.claude/rules/**\/*.md` RECURSIVELY (every file at any depth, not just the top level) and concatenates every match into the &lt;system-reminder&gt; claudeMd content on UserPromptSubmit. Two distinct failure modes follow: |
+| `hook-token-check` | `*` | Fire-and-forget | The `generate-http-hooks` CLI (channel 1, deleted in #3867) used to write 19 type:"http" hook entries into the user's settings.local.json, each carrying `Authorization: Bearer $ORCHESTKIT_HOOK_TOKEN`. |
+| `telemetry-dark-check` | `*` | Fire-and-forget | `bin/telemetry-sync.mjs` posts local telemetry (.claude/telemetry/*.jsonl) to $ORCHESTKIT_HOOK_URL, and only DELETES rotated files after a successful POST. |
+| `analytics-liveness-check` | `*` | Fire-and-forget | The local analytics pipeline fans out to several independent JSONL writers under ~/.claude/analytics/ (skill-usage.jsonl, agent-usage.jsonl, matcher removal, or a refactor that drops one write path leaves the other writers healthy, so nothing looks wrong until an audit reads the… |
+| `session-rules-audit` | `*` | Fire-and-forget | Session Rules Audit — SessionStart (whole-set instruction handlers, #2475) |
+| `ask-fallback-injector` | `*` | Fire-and-forget | When the user sets `ORK_ASK_FALLBACK=text`, the AskUserQuestion picker is treated as unavailable and the model is instructed to fall back to inline text prompts ("reply with 1/2/3/4"). |
+| `cleanup-envelope-corruption` | `*` | Fire-and-forget | Backfill mitigation for the `\{"continue":true,"suppressOutput":true\}` envelope leak (originally #1250, recurring as #1826). |
+| `session-registrar` | `*` | Fire-and-forget | Registers this Claude Code session in the shared SQLite session DB (~/.local/state/orchestkit/sessions.db). Runs sweeps on the way in: |
+| `sweep-stale-worktrees` | `*` | Fire-and-forget | Removes debris that a failed `Agent(isolation: "worktree")` spawn leaves INSIDE the repo and that `git worktree prune` cannot see, because it was never registered with git: |
+| `stray-playground-pages` | `*` | Fire-and-forget | Names untracked, un-ignored playground pages that have been sitting in the working tree for longer than a threshold, so the next session can commit or delete them instead of walking past them. |
+| `session-env-setup` | `*` | Fire-and-forget | Session Environment Setup - Initializes session environment |
+| `stale-team-cleanup` | `*` | Fire-and-forget | — |
+| `stale-cache-cleanup` | `*` | Fire-and-forget | Prunes old plugin cache versions, keeping the current + previous per channel, and never removing a version a live process is still running from. |
+| `plugins-drift-snapshot` | `*` | Fire-and-forget | M139 issue #1782 (C5 plugins/ drift detector). |
+| `type-error-indexer` | `*` | Fire-and-forget | Runs `tsc --noEmit` on SessionStart and caches results so agents know about existing type errors before making edits. Prevents 30-40% of failed edit attempts by surfacing existing errors. |
+| `sync-session-dispatcher` | `*` | Injects | Consolidates 4 synchronous SessionStart hooks into a single dispatcher. |
+| `session-handoff-injector` | `*` | Silent | Session Handoff Injector — Injects previous session context at SessionStart |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `cc-version-check` | `*` | Fire-and-forget | Fires on SessionStart. Four branches: |

--- a/docs/site/content/docs/reference/hooks/setup.mdx
+++ b/docs/site/content/docs/reference/hooks/setup.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on Setup events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `sync-setup-dispatcher` | `*` | Injects | Consolidates 6 Setup hooks into a single dispatcher. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/stop-failure.mdx
+++ b/docs/site/content/docs/reference/hooks/stop-failure.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on StopFailure events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `stop-failure-handler` | `*` | Fire-and-forget | Fires when a turn ends due to an API error (rate limit, auth failure, etc.). Flushes session state and writes an emergency handoff so the next session can resume cleanly. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/stop.mdx
+++ b/docs/site/content/docs/reference/hooks/stop.mdx
@@ -9,15 +9,15 @@ description: "Hooks triggered on Stop events (12 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `handoff-writer` | `*` | Fire-and-forget | Writes .claude/HANDOFF.md with structured session context on stop. This is the WRITE half of the save/restore loop. The READ half is prompt/handoff-injector.ts (UserPromptSubmit). |
+| `session-summary` | `*` | Injects | Runs at session end. Only fires when session had meaningful work (&gt;=20 tool calls). Builds a graph entity suggestion via additionalContext and nudges /ork:remember for high-activity sessions (&gt;50 tool calls). |
+| `task-completion-check` | `*` | Fire-and-forget | Task Completion Check - Verifies tasks are properly completed before stop |
+| `security-scan-aggregator` | `*` | Fire-and-forget | Runs Stop-time security scans under a machine-wide lock, only on a dirty working tree, with real child-process kill-on-timeout. |
+| `ledger-cleanup` | `*` | Fire-and-forget | Ledger Cleanup — removes stale agent attribution ledgers on session stop. |
+| `coverage-check` | `*` | Fire-and-forget | Runs on Stop for testing skills - checks if coverage threshold is met |
+| `evidence-collector` | `*` | Fire-and-forget | Runs on Stop for evidence-verification skill Collects verification evidence - silent operation |
+| `coverage-threshold-gate` | `*` | Blocks | Blocks Stop when coverage after implementation is below the skill threshold. |
+| `cross-instance-test-validator` | `*` | Blocks | BLOCKING: every implementation file this session wrote must have a test file. |
+| `stop-uncommitted-check.mjs` | `*` | Silent | — |
+| `goal-tracker` | `*` | Fire-and-forget | Closes the most recent open `/goal` entry for this session by appending a second JSONL line with `ended_at`, `ended_token_estimate`, `turn_count`, and an inferred `status: 'converged' \| 'spun' \| 'aborted'`. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/subagent-start.mdx
+++ b/docs/site/content/docs/reference/hooks/subagent-start.mdx
@@ -9,6 +9,6 @@ description: "Hooks triggered on SubagentStart events (3 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `agent-view-titler` | `*` | Injects | Derives a short, human-readable title for each subagent at spawn and emits it on `hookSpecificOutput.sessionTitle` so the agent-view row is readable. |
+| `unified-dispatcher` | `*` | Injects | Consolidates 3 SubagentStart hooks into a single process spawn. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/subagent-stop.mdx
+++ b/docs/site/content/docs/reference/hooks/subagent-stop.mdx
@@ -9,9 +9,9 @@ description: "Hooks triggered on SubagentStop events (6 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `feedback-loop` | `*` | Fire-and-forget | — |
+| `sync-subagent-stop-dispatcher` | `*` | Blocks | Consolidates 6 synchronous SubagentStop hooks into a single dispatcher. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |
+| `watchdog` | `*` | Fire-and-forget | On each agent completion, scans remaining active background agents for timeout. Emits warnings at 5min and critical alerts at 10min. |
+| `subagent-scope-auditor` | `*` | Fire-and-forget | Source: usage analytics #5 friction point — sub-agents modify files outside their declared scope in 3+ sessions (out of 481 Agent calls across 126 sessions). Existing `subagent-validator` validates agent CONFIGURATION at spawn time; this hook validates FILE ACCESS at completion. |
+| `unified-dispatcher` | `*` | Fire-and-forget | Consolidates SubagentStop processing into a single dispatcher AND writes the local activation analytics: agent-usage.jsonl (per-agent activation + usage metrics) and subagent-quality.jsonl (transcript quality scoring). |

--- a/docs/site/content/docs/reference/hooks/task-completed.mdx
+++ b/docs/site/content/docs/reference/hooks/task-completed.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on TaskCompleted events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `sync-task-completed-dispatcher` | `*` | Injects | Consolidates 3 TaskCompleted hooks + webhook forwarder into a single hooks.json entry. Runs handlers sequentially, merges additionalContext. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/task-created.mdx
+++ b/docs/site/content/docs/reference/hooks/task-created.mdx
@@ -9,5 +9,5 @@ description: "Hooks triggered on TaskCreated events (2 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `sync-task-created-dispatcher` | `*` | Injects | Consolidates 2 TaskCreated hooks + webhook forwarder into a single hooks.json entry. Runs handlers sequentially, merges additionalContext. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/teammate-idle.mdx
+++ b/docs/site/content/docs/reference/hooks/teammate-idle.mdx
@@ -9,7 +9,7 @@ description: "Hooks triggered on TeammateIdle events (4 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `progress-reporter` | `*` | Fire-and-forget | TeammateIdle Hook: Progress Reporter |
+| `team-synthesis-trigger` | `*` | Fire-and-forget | Detects when all teammates in a team are idle and suggests synthesis. Reads team config for member list and teammate-activity.jsonl for recent idle events. |
+| `team-quality-gate` | `*` | Fire-and-forget | Aggregates quality signals from idle teammates. Surfaces a warning only if a teammate goes idle without producing meaningful output AND has no recent task completion signal. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/user-prompt-expansion.mdx
+++ b/docs/site/content/docs/reference/hooks/user-prompt-expansion.mdx
@@ -9,4 +9,4 @@ description: "Hooks triggered on UserPromptExpansion events (1 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
+| `prompt-expansion-observer` | `*` | Fire-and-forget | Prompt Expansion Observer |

--- a/docs/site/content/docs/reference/hooks/user-prompt-submit.mdx
+++ b/docs/site/content/docs/reference/hooks/user-prompt-submit.mdx
@@ -9,8 +9,8 @@ description: "Hooks triggered on UserPromptSubmit events (5 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
-| `node` | `*` | 🔇 Silent | — |
+| `unified-dispatcher` | `*` | Silent | Routes UserPromptSubmit through one dispatcher: a once-per-session handoff injector plus every-turn silent analytics, with a single additionalContext output. |
+| `thrash-detector` | `*` | Fire-and-forget | Source: usage analytics — recurring edit→format→revert→re-edit and edit→test-fail→undo→re-edit loops that burn 10+ turns on the same file. Catches the "same-file repeatedly" signal early and suggests a different approach. |
+| `goal-tracker` | `*` | Blocks | Detects `/goal &lt;condition&gt;` invocations in the user prompt and appends a "started" entry to `.claude/state/goal-history.jsonl`. |
+| `worktree-advisory-consumer` | `*` | Silent | Reads pending advisories from `.claude/state/worktree-advisory-*.md`, deletes the files, and injects the concatenated content as `additionalContext` on the next user prompt. |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/content/docs/reference/hooks/worktree-remove.mdx
+++ b/docs/site/content/docs/reference/hooks/worktree-remove.mdx
@@ -9,4 +9,4 @@ description: "Hooks triggered on WorktreeRemove events (1 hooks)."
 
 | Hook | Matcher | Behavior | Description |
 |------|---------|----------|-------------|
-| `node` | `*` | 🔇 Silent | — |
+| `webhook-forwarder` | `*` | Fire-and-forget | Registered for every CC event type in hooks.json (async: true). Delegates to telemetry.emit() which fans out to pluggable sinks (JSONL local + HTTP remote). No-op when no sinks are active. |

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "host-library-motion",
+      "source": "docs/feat--docs-library-visual/host-library.html",
+      "title": "Pick a host, the command rewrites",
+      "description": "Play the homepage install picker. Host cards keep ?host= links. The command panel blurs to the new payload. Library tabs slide. Hooks group by lifecycle, not a 32-button grid. Reduced-motion keeps every control usable.",
+      "tags": [
+        "docs",
+        "site",
+        "homepage"
+      ],
+      "date": "2026-09-09"
+    },
+    {
       "slug": "chrono-board-release",
       "source": "docs/feat--docs-chrono-board-release/chrono-board.html",
       "title": "Chrono Board: What's new becomes a release timeline",

--- a/docs/site/lib/cn.ts
+++ b/docs/site/lib/cn.ts
@@ -1,0 +1,4 @@
+/** Tiny class joiner. Avoid pulling clsx/tailwind-merge into the docs site. */
+export function cn(...inputs: Array<string | false | null | undefined>): string {
+	return inputs.filter(Boolean).join(" ");
+}

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -87,6 +87,20 @@ export const LAB_ENTRIES: LabEntry[] = [
     "sizeKb": 22
   },
   {
+    "slug": "host-library-motion",
+    "title": "Pick a host, the command rewrites",
+    "description": "Play the homepage install picker. Host cards keep ?host= links. The command panel blurs to the new payload. Library tabs slide. Hooks group by lifecycle, not a 32-button grid. Reduced-motion keeps every control usable.",
+    "tags": [
+      "docs",
+      "site",
+      "homepage"
+    ],
+    "date": "2026-09-09",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 25
+  },
+  {
     "slug": "codex-mech-profile",
     "title": "The Codex mech profile: which file codex actually reads",
     "description": "Put the ork-mech profile in three places and read codex 0.153.4's own answer: a hard config-load error for the legacy [profiles.*] table, a silent base-config run for a name that does not exist, and the measured header for the shipped file. Plus the worktree writable-roots line with and without --add-dir.",

--- a/docs/site/lib/hook-events.ts
+++ b/docs/site/lib/hook-events.ts
@@ -20,3 +20,13 @@ export const HOOK_EVENT_PAGES: HookEventPage[] = hooksMeta.pages
     label: labelFromSlug(slug),
     href: `/docs/reference/hooks/${slug}`,
   }));
+
+/** `/docs/reference/hooks/<event>` — four-column hook tables, not the index. */
+export function isHookEventPage(slugs: readonly string[]): boolean {
+  return (
+    slugs.length === 3 &&
+    slugs[0] === "reference" &&
+    slugs[1] === "hooks" &&
+    HOOK_EVENT_PAGES.some((page) => page.slug === slugs[2])
+  );
+}

--- a/docs/site/lib/hook-phases.ts
+++ b/docs/site/lib/hook-phases.ts
@@ -1,0 +1,110 @@
+import { HOOK_EVENT_PAGES, type HookEventPage } from "@/lib/hook-events";
+
+export type HookPhaseId =
+	| "session"
+	| "prompt"
+	| "tools"
+	| "files"
+	| "agents"
+	| "tasks"
+	| "model";
+
+export type HookPhase = {
+	id: HookPhaseId;
+	label: string;
+	blurb: string;
+	slugs: readonly string[];
+};
+
+/** Lifecycle order. Every hook event page (except index/spotlights) lands in one phase. */
+export const HOOK_PHASES: readonly HookPhase[] = [
+	{
+		id: "session",
+		label: "Session",
+		blurb: "Start, cwd, setup, config, end.",
+		slugs: [
+			"session-start",
+			"cwd-changed",
+			"setup",
+			"config-change",
+			"instructions-loaded",
+			"session-end",
+		],
+	},
+	{
+		id: "prompt",
+		label: "Prompt",
+		blurb: "The user message, before tools run.",
+		slugs: ["user-prompt-submit", "user-prompt-expansion"],
+	},
+	{
+		id: "tools",
+		label: "Tools",
+		blurb: "Pre/post tool use, batches, permissions.",
+		slugs: [
+			"pre-tool-use",
+			"post-tool-use",
+			"post-tool-batch",
+			"post-tool-use-failure",
+			"permission-request",
+			"permission-denied",
+		],
+	},
+	{
+		id: "files",
+		label: "Files",
+		blurb: "Edits, new directories, worktree teardown.",
+		slugs: ["file-changed", "directory-added", "worktree-remove"],
+	},
+	{
+		id: "agents",
+		label: "Agents",
+		blurb: "Subagents and idle teammates.",
+		slugs: ["subagent-start", "subagent-stop", "teammate-idle"],
+	},
+	{
+		id: "tasks",
+		label: "Tasks",
+		blurb: "TaskCreate and TaskComplete.",
+		slugs: ["task-created", "task-completed"],
+	},
+	{
+		id: "model",
+		label: "Model",
+		blurb: "Switch, compact, stop, display, elicit.",
+		slugs: [
+			"pre-model-switch",
+			"post-model-switch",
+			"pre-compact",
+			"post-compact",
+			"stop",
+			"stop-failure",
+			"message-display",
+			"notification",
+			"elicitation",
+			"elicitation-result",
+		],
+	},
+];
+
+export type HookPhaseGroup = HookPhase & { events: HookEventPage[] };
+
+export function groupedHookEvents(): HookPhaseGroup[] {
+	const bySlug = new Map(HOOK_EVENT_PAGES.map((event) => [event.slug, event]));
+	return HOOK_PHASES.map((phase) => ({
+		...phase,
+		events: phase.slugs
+			.map((slug) => bySlug.get(slug))
+			.filter((event): event is HookEventPage => Boolean(event)),
+	}));
+}
+
+/** Compact lifecycle. Six nodes, not one box per hook. */
+export const HOOK_LIFECYCLE_CHART = `flowchart LR
+  Session --> Prompt
+  Prompt --> Tools
+  Tools --> Files
+  Tools --> Agents
+  Tools --> Tasks
+  Tools --> Model
+`;

--- a/docs/site/lib/library-tab.ts
+++ b/docs/site/lib/library-tab.ts
@@ -8,6 +8,11 @@ export function parseLibraryTab(
   return "skills";
 }
 
-export function libraryTabHref(id: LibraryTab): string {
-  return id === "skills" ? "/#library" : `/?lib=${id}#library`;
+/** Claude is the default host, so it stays off the query string. */
+export function libraryTabHref(id: LibraryTab, host = "claude"): string {
+  const params = new URLSearchParams();
+  if (host !== "claude") params.set("host", host);
+  if (id !== "skills") params.set("lib", id);
+  const query = params.toString();
+  return query ? `/?${query}#library` : "/#library";
 }

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -21,6 +21,7 @@
 				"fumadocs-ui": "^16.15.7",
 				"lucide-react": "^1.41.0",
 				"mermaid": "^11.17.2",
+				"motion": "^13.2.0",
 				"next": "^16.3.3",
 				"posthog-js": "^1.427.2",
 				"react": "^19.2.8",
@@ -5106,12 +5107,12 @@
 			"license": "MIT"
 		},
 		"node_modules/framer-motion": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.1.tgz",
-			"integrity": "sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.2.0.tgz",
+			"integrity": "sha512-9E33ebgMaO33w1nN/jEdW8z3/GO483fMi4rqbMG9rt83XgW9QLKRe4NcmJ8s+fQ3O34++UHrIQwlIWGIWTITjA==",
 			"license": "MIT",
 			"dependencies": {
-				"motion-dom": "^13.1.1",
+				"motion-dom": "^13.2.0",
 				"motion-utils": "^13.0.0",
 				"tslib": "^2.4.0"
 			},
@@ -7155,12 +7156,12 @@
 			}
 		},
 		"node_modules/motion": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/motion/-/motion-13.1.1.tgz",
-			"integrity": "sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/motion/-/motion-13.2.0.tgz",
+			"integrity": "sha512-4Hrb5vD6HhjFstLUiCmWvtpsw+WTpP4R+QXfSDYZBz7+uxE/LrRg3aV0ReJxHrTRffHhbIE6svEqnotngXvesQ==",
 			"license": "MIT",
 			"dependencies": {
-				"framer-motion": "^13.1.1",
+				"framer-motion": "^13.2.0",
 				"tslib": "^2.4.0"
 			},
 			"peerDependencies": {
@@ -7177,9 +7178,9 @@
 			}
 		},
 		"node_modules/motion-dom": {
-			"version": "13.1.1",
-			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.1.1.tgz",
-			"integrity": "sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA==",
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.2.0.tgz",
+			"integrity": "sha512-N6gdSoWRDk0Rh/fVtlqUtLs+fEN3ELFZI3cn3IQE9Mnf3E+Mh8wjO6MstzCOPFh4Yf0L1as5m2eUyYWj8ylVSQ==",
 			"license": "MIT",
 			"dependencies": {
 				"motion-utils": "^13.0.0"

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -25,6 +25,7 @@
 		"fumadocs-ui": "^16.15.7",
 		"lucide-react": "^1.41.0",
 		"mermaid": "^11.17.2",
+		"motion": "^13.2.0",
 		"next": "^16.3.3",
 		"posthog-js": "^1.427.2",
 		"react": "^19.2.8",

--- a/docs/site/public/lab/host-library-motion.html
+++ b/docs/site/public/lab/host-library-motion.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<!--
+  USER-STORY PLAYER · Homepage install + library motion
+  Archetype: user-story-player. Persona: cool-glass.
+  Conforms to shared/rules/playground-visual-standard.md
+  21st.dev radio cards (10156) + social selector (25137) + animated tabs (24930).
+-->
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Pick a host, the command rewrites</title>
+<meta name="description" content="Play the homepage install picker. Host cards keep ?host= links. The command panel blurs to the new payload. Library tabs slide. Hooks group by lifecycle, not a 32-button grid. Reduced-motion keeps every control usable.">
+<style>
+  :root {
+    --pg-bg: hsl(232 26% 7%);
+    --pg-ink: hsl(220 18% 93%);
+    --pg-muted: hsl(222 12% 64%);
+    --pg-faint: hsl(222 10% 46%);
+    --pg-line: hsl(0 0% 100% / 0.10);
+    --pg-glass: hsl(0 0% 100% / 0.05);
+    --pg-glass-2: hsl(0 0% 100% / 0.08);
+    --pg-glass-edge: hsl(0 0% 100% / 0.18);
+    --pg-accent: hsl(264 72% 62%);
+    --pg-accent-deep: hsl(264 70% 46%);
+    --pg-shadow: 0 20px 60px -22px hsl(264 60% 2% / 0.7), 0 4px 12px -6px hsl(264 60% 2% / 0.5);
+    --pg-r-sm: 9px; --pg-r-md: 16px; --pg-r-lg: 24px;
+    --pg-dur-instant: 100ms; --pg-dur-fast: 200ms; --pg-dur-normal: 300ms; --pg-dur-slow: 500ms;
+    --pg-ease: cubic-bezier(.2,.8,.25,1);
+    --pg-font: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui, sans-serif;
+    --pg-mono: "SF Mono", "JetBrains Mono", ui-monospace, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; font-family: var(--pg-font); color: var(--pg-ink);
+    background:
+      radial-gradient(900px 600px at 86% -8%, hsl(264 72% 62% / 0.16), transparent 60%),
+      radial-gradient(820px 620px at 6% 110%, hsl(248 70% 58% / 0.13), transparent 58%),
+      var(--pg-bg);
+    background-attachment: fixed; -webkit-font-smoothing: antialiased;
+  }
+  .wrap { max-width: 960px; margin: 0 auto; padding: 24px 16px 48px; display: flex; flex-direction: column; gap: 16px; }
+  .head { display: flex; align-items: flex-start; gap: 16px; }
+  .logo { width: 48px; height: 48px; border-radius: 16px; flex: none; display: grid; place-items: center;
+    background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep));
+    box-shadow: 0 8px 24px -8px hsl(264 70% 50% / 0.7), inset 0 1px 0 hsl(0 0% 100% / 0.4); }
+  .logo svg { width: 22px; height: 22px; }
+  .head h1 { margin: 0; font-size: 20px; letter-spacing: -.3px; }
+  .head p { margin: 4px 0 0; font-size: 13px; color: var(--pg-muted); max-width: 64ch; line-height: 1.55; }
+  .head .right { margin-inline-start: auto; }
+  .toggle { cursor: pointer; font: inherit; font-size: 12px; font-weight: 600; color: var(--pg-muted);
+    background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: 999px; padding: 8px 16px; }
+  .toggle:hover { color: var(--pg-ink); border-color: var(--pg-glass-edge); }
+  .toggle:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .toggle[aria-pressed="true"] { color: var(--pg-ink); border-color: hsl(264 72% 62% / 0.45); }
+  .panel { background: var(--pg-glass); border: 1px solid var(--pg-line); border-radius: var(--pg-r-lg);
+    backdrop-filter: blur(16px); -webkit-backdrop-filter: blur(16px); box-shadow: var(--pg-shadow); }
+  .transport { display: flex; gap: 8px; align-items: center; padding: 12px 16px; flex-wrap: wrap; }
+  .btn { cursor: pointer; font: inherit; font-size: 13px; font-weight: 650; border-radius: 12px; padding: 8px 16px;
+    border: 1px solid var(--pg-line); background: var(--pg-glass); color: var(--pg-ink);
+    transition: transform var(--pg-dur-instant), background var(--pg-dur-fast); }
+  .btn:hover { background: var(--pg-glass-2); transform: translateY(-1px); }
+  .btn:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .btn.primary { background: linear-gradient(145deg, var(--pg-accent), var(--pg-accent-deep)); border-color: transparent;
+    color: hsl(264 40% 96%); box-shadow: 0 10px 26px -12px hsl(264 70% 50% / 0.8); }
+  .btn:disabled { opacity: .4; cursor: not-allowed; transform: none; }
+  .hint { font-size: 12px; color: var(--pg-faint); margin-inline-start: auto; font-variant-numeric: tabular-nums; }
+  .hint b { color: var(--pg-muted); }
+  .stage { padding: 24px; display: flex; flex-direction: column; align-items: stretch; gap: 20px; }
+  .url { font-family: var(--pg-mono); font-size: 12px; color: var(--pg-muted); padding: 8px 12px;
+    border: 1px dashed var(--pg-line); border-radius: var(--pg-r-sm); }
+  .url em { color: var(--pg-accent); font-style: normal; }
+  .hosts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .host { cursor: pointer; text-align: start; font: inherit; color: inherit; background: var(--pg-glass);
+    border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); padding: 12px; display: flex; flex-direction: column; gap: 6px;
+    transition: border-color var(--pg-dur-fast), background var(--pg-dur-fast); }
+  .host-top { display: flex; align-items: center; gap: 8px; }
+  .host-ico { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--pg-line); display: grid; place-items: center; background: hsl(232 30% 9%); color: var(--pg-ink); }
+  .host-ico svg { width: 20px; height: 20px; display: block; }
+  .host:hover { border-color: var(--pg-glass-edge); }
+  .host:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .host[aria-current="true"] { border-color: hsl(264 72% 62% / 0.55); background: hsl(264 72% 62% / 0.12);
+    box-shadow: 0 0 0 2px hsl(264 72% 62% / 0.28); }
+  .host b { font-size: 13px; }
+  .host span { font-size: 11px; color: var(--pg-muted); line-height: 1.35; }
+  .cmd { font-family: var(--pg-mono); font-size: 12.5px; line-height: 1.5; padding: 12px 14px;
+    border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); background: hsl(232 30% 9%);
+    transition: opacity var(--pg-dur-fast), filter var(--pg-dur-fast), transform var(--pg-dur-fast); }
+  .cmd.is-swap { opacity: 0; filter: blur(6px); transform: translateY(6px); }
+  .tabs { display: inline-flex; align-self: flex-start; width: max-content; max-width: 100%; gap: 4px; padding: 4px; border: 1px solid var(--pg-line); border-radius: 12px; position: relative; overflow: visible; }
+  .tab { cursor: pointer; font: inherit; font-size: 13px; font-weight: 600; color: var(--pg-muted);
+    background: transparent; border: 0; border-radius: 8px; padding: 8px 12px; position: relative; z-index: 1;
+    display: inline-flex; align-items: center; gap: 8px; }
+  .tab-ico { width: 22px; height: 22px; border-radius: 7px; display: grid; place-items: center;
+    background: hsl(0 0% 100% / 0.06); border: 1px solid var(--pg-line); color: var(--pg-ink); }
+  .tab[aria-selected="true"] .tab-ico { background: hsl(264 72% 62% / 0.32); border-color: hsl(264 72% 62% / 0.45); color: hsl(264 80% 92%); }
+  .tab-ico svg { width: 14px; height: 14px; display: block; }
+  .tab:focus-visible { outline: 2px solid var(--pg-accent); outline-offset: 2px; }
+  .tab[aria-selected="true"] { color: var(--pg-ink); }
+  .tab-ink { position: absolute; top: 4px; bottom: 4px; left: 0; width: 80px; border-radius: 8px;
+    background: hsl(264 72% 62% / 0.22); transition: transform var(--pg-dur-normal) var(--pg-ease), width var(--pg-dur-normal) var(--pg-ease); pointer-events: none; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; }
+  .chip { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; font-weight: 600; color: var(--pg-muted);
+    border: 1px solid var(--pg-line); border-radius: 999px; padding: 4px 8px; }
+  .chip svg { width: 12px; height: 12px; display: block; }
+  .panel-copy { font-size: 13px; color: var(--pg-muted); line-height: 1.5; min-height: 3.2em; }
+  .phases { display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; }
+  .phase { border: 1px solid var(--pg-line); border-radius: var(--pg-r-md); padding: 10px 12px; }
+  .phase b { display: block; font-size: 12px; margin-bottom: 4px; }
+  .phase span { font-family: var(--pg-mono); font-size: 11px; color: var(--pg-muted); }
+  .flow { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; font-size: 12px; color: var(--pg-muted); }
+  .flow i { font-style: normal; padding: 4px 8px; border: 1px solid var(--pg-line); border-radius: 999px; color: var(--pg-ink); }
+  .chips[hidden], .phases[hidden], .flow[hidden] { display: none !important; }
+  .copy { display: flex; gap: 8px; align-items: center; padding: 12px 16px; }
+  .copy code { font-family: var(--pg-mono); font-size: 12px; color: var(--pg-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .toast { font-size: 12px; color: var(--pg-accent); min-width: 4ch; }
+  @media (max-width: 720px) {
+    .hosts, .phases { grid-template-columns: 1fr 1fr; }
+    .hint { width: 100%; margin: 0; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { transition: none !important; animation: none !important; }
+  }
+  html.reduce *, html.reduce *::before, html.reduce *::after { transition: none !important; animation: none !important; }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <header class="head">
+      <div class="logo" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+      </div>
+      <div>
+        <h1>Pick a host. The command rewrites.</h1>
+        <p>Context7-style cards, not a pill row that remounts the page. <code>?host=</code> stays shareable. Library tabs slide. Hooks group by when they fire.</p>
+      </div>
+      <div class="right">
+        <button class="toggle" type="button" id="reduce" aria-pressed="false">Reduced motion</button>
+      </div>
+    </header>
+
+    <section class="panel" aria-label="Playback">
+      <div class="transport">
+        <button class="btn primary" type="button" id="play">Play</button>
+        <button class="btn" type="button" id="prev">Prev</button>
+        <button class="btn" type="button" id="next">Next</button>
+        <p class="hint"><b id="beat-label">host cards</b></p>
+      </div>
+    </section>
+
+    <section class="panel stage" aria-live="polite">
+      <p class="url" id="url">orchestkit.yonyon.ai<em>/</em></p>
+      <div class="hosts" id="hosts"></div>
+      <pre class="cmd" id="cmd"></pre>
+      <div class="tabs" role="tablist" aria-label="Library primitives">
+        <span class="tab-ink" id="ink" aria-hidden="true"></span>
+        <button class="tab" type="button" role="tab" data-tab="skills" aria-selected="true">
+          <span class="tab-ico" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><rect x="3" y="3.5" width="8.5" height="10" rx="1.2" stroke="currentColor" stroke-width="1.5"/><path d="M6.5 3.5V13.5M4.5 6.5h2M4.5 9h2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M11.5 5.5h1.2c.7 0 1.3.6 1.3 1.3v6.2c0 .7-.6 1.3-1.3 1.3H7" stroke="currentColor" stroke-width="1.5"/></svg></span>
+          Skills 107
+        </button>
+        <button class="tab" type="button" role="tab" data-tab="agents" aria-selected="false">
+          <span class="tab-ico" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><circle cx="6" cy="6" r="2" stroke="currentColor" stroke-width="1.5"/><path d="M2.5 13c.4-2.2 1.8-3.5 3.5-3.5S9.1 10.8 9.5 13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="11.2" cy="6.8" r="1.6" stroke="currentColor" stroke-width="1.5"/><path d="M13.8 13c-.3-1.6-1.3-2.6-2.6-2.6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg></span>
+          Agents 36
+        </button>
+        <button class="tab" type="button" role="tab" data-tab="hooks" aria-selected="false">
+          <span class="tab-ico" aria-hidden="true"><svg width="14" height="14" viewBox="0 0 16 16" fill="none"><path d="M9 2.5 4.5 9h3.2L7 13.5 12.5 7H9.2L9 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg></span>
+          Hooks 32
+        </button>
+      </div>
+      <div class="chips" id="chips">
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M3 11.5 8 4.5l5 7M5.5 11.5h5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>Development</span>
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><ellipse cx="8" cy="4.5" rx="5" ry="2" stroke="currentColor" stroke-width="1.5"/><path d="M3 4.5v7c0 1.1 2.2 2 5 2s5-.9 5-2v-7" stroke="currentColor" stroke-width="1.5"/></svg>Backend</span>
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.5" y="3.5" width="11" height="9" rx="1.5" stroke="currentColor" stroke-width="1.5"/><path d="M2.5 6.5h11M5 9h3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>Frontend</span>
+        <span class="chip"><svg viewBox="0 0 16 16" fill="none" aria-hidden="true"><path d="M8 2.5 13 5v3.2c0 3.1-2.1 5.2-5 6.3-2.9-1.1-5-3.2-5-6.3V5l5-2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>Security</span>
+      </div>
+      <p class="panel-copy" id="lib"></p>
+      <div class="flow" id="flow" hidden>
+        <i>Session</i> → <i>Prompt</i> → <i>Tools</i> → <i>Files</i> / <i>Agents</i> / <i>Tasks</i> / <i>Model</i>
+      </div>
+      <div class="phases" id="phases" hidden></div>
+    </section>
+
+    <footer class="panel copy">
+      <button class="btn" type="button" id="copy">Copy prompt</button>
+      <code id="prompt">Build host cards that keep ?host= links, rewrite the install snippet without remounting, slide Skills/Agents/Hooks tabs, and group hooks by lifecycle.</code>
+      <span class="toast" id="toast" hidden>Copied</span>
+    </footer>
+  </div>
+<script>
+const ICO = {
+  claude: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z\"/></svg>",
+  cursor: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"M11.503.131 1.891 5.678a.84.84 0 0 0-.42.726v11.188c0 .3.162.575.42.724l9.609 5.55a1 1 0 0 0 .998 0l9.61-5.55a.84.84 0 0 0 .42-.724V6.404a.84.84 0 0 0-.42-.726L12.497.131a1.01 1.01 0 0 0-.996 0M2.657 6.338h18.55c.263 0 .43.287.297.515L12.23 22.918c-.062.107-.229.064-.229-.06V12.335a.59.59 0 0 0-.295-.51l-9.11-5.257c-.109-.063-.064-.23.061-.23\"/></svg>",
+  codex: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997Z\"/></svg>",
+  muse: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"currentColor\" aria-hidden=\"true\"><path d=\"M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.832-4.358l-.617-1.028a44.908 44.908 0 0 0-1.255-1.98c.07-.109.141-.224.211-.327 1.12-1.667 2.118-2.602 3.358-2.602zm-10.201.553c1.265 0 2.058.791 2.675 1.446.307.327.737.871 1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.533-1.533a2.264 2.264 0 0 1 1.088-.285z\"/></svg>",
+  pi: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><path d=\"M5 6.5h14\"/><path d=\"M9 6.5v11\"/><path d=\"M15 6.5v8.5a3 3 0 0 0 3 3\"/></svg>",
+  opencode: "<svg viewBox=\"0 0 24 24\" width=\"20\" height=\"20\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"3\" y=\"5\" width=\"18\" height=\"14\" rx=\"2\"/><path d=\"M7 10l3 2-3 2\"/><path d=\"M13 14h4\"/></svg>",
+};
+const HOSTS = [
+  { id: "claude", name: "Claude Code", what: "Full ork plugin.", href: "/", cmd: "claude plugin install yonatangross/orchestkit" },
+  { id: "cursor", name: "Cursor", what: "Same ork plugin. No Claude hooks.", href: "/?host=cursor", cmd: "yonatangross/orchestkit" },
+  { id: "codex", name: "Codex", what: "Portable ork-codex pack.", href: "/?host=codex", cmd: "codex plugin add ork-codex@orchestkit-codex" },
+  { id: "muse", name: "Muse Code", what: "Skills via .agents/skills.", href: "/?host=muse", cmd: "npx skills add yonatangross/orchestkit -s doctor" },
+  { id: "pi", name: "Pi", what: "Shipped pi manifest.", href: "/?host=pi", cmd: "pi install git:github.com/yonatangross/orchestkit" },
+  { id: "opencode", name: "OpenCode", what: "Agent Skills via skills.sh.", href: "/?host=opencode", cmd: "npx skills add yonatangross/orchestkit -s doctor" },
+];
+const TABS = {
+  skills: "Browse 107 skills. Category marks, no All/ork toggle. Search still ranks.",
+  agents: "36 agents. Same category marks. Search by name or role.",
+  hooks: "32 events in 7 phases. Compact flow, then the groups. Not a 32-button grid.",
+};
+const PHASES = [
+  ["Session", "start · cwd · setup · end"],
+  ["Prompt", "submit · expansion"],
+  ["Tools", "pre/post · permission"],
+  ["Files", "changed · directory · worktree"],
+  ["Agents", "subagent · teammate"],
+  ["Tasks", "created · completed"],
+  ["Model", "switch · compact · stop"],
+];
+const BEATS = [
+  { host: "claude", tab: "skills", label: "1 / 4 · host cards" },
+  { host: "cursor", tab: "skills", label: "2 / 4 · command rewrite" },
+  { host: "cursor", tab: "agents", label: "3 / 4 · library tabs" },
+  { host: "cursor", tab: "hooks", label: "4 / 4 · hooks as flow" },
+];
+
+const hostsEl = document.getElementById("hosts");
+const cmdEl = document.getElementById("cmd");
+const urlEl = document.getElementById("url");
+const libEl = document.getElementById("lib");
+const inkEl = document.getElementById("ink");
+const chipsEl = document.getElementById("chips");
+const flowEl = document.getElementById("flow");
+const phasesEl = document.getElementById("phases");
+const beatLabel = document.getElementById("beat-label");
+const reduceBtn = document.getElementById("reduce");
+let hostId = "claude";
+let tabId = "skills";
+let beat = 0;
+let timer = null;
+
+HOSTS.forEach((h) => {
+  const b = document.createElement("button");
+  b.className = "host";
+  b.type = "button";
+  b.dataset.host = h.id;
+  b.innerHTML = `<span class="host-top"><span class="host-ico">${ICO[h.id]}</span><b>${h.name}</b></span><span>${h.what}</span>`;
+  b.addEventListener("click", () => setHost(h.id));
+  hostsEl.appendChild(b);
+});
+PHASES.forEach(([name, bits]) => {
+  const d = document.createElement("div");
+  d.className = "phase";
+  d.innerHTML = `<b>${name}</b><span>${bits}</span>`;
+  phasesEl.appendChild(d);
+});
+document.querySelectorAll(".tab").forEach((btn) => {
+  btn.addEventListener("click", () => setTab(btn.dataset.tab));
+});
+
+function reduced() {
+  return document.documentElement.classList.contains("reduce") || matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+function setHost(id, instant) {
+  hostId = id;
+  const spec = HOSTS.find((h) => h.id === id);
+  hostsEl.querySelectorAll(".host").forEach((el) => {
+    if (el.dataset.host === id) el.setAttribute("aria-current", "true");
+    else el.removeAttribute("aria-current");
+  });
+  urlEl.innerHTML = `orchestkit.yonyon.ai<em>${spec.href}</em>`;
+  const apply = () => { cmdEl.textContent = spec.cmd; cmdEl.classList.remove("is-swap"); };
+  if (instant || reduced()) { apply(); return; }
+  cmdEl.classList.add("is-swap");
+  setTimeout(apply, 180);
+}
+function setTab(id) {
+  tabId = id;
+  const tabs = [...document.querySelectorAll(".tab")];
+  const selected = tabs.find((el) => el.dataset.tab === id);
+  tabs.forEach((el) => {
+    el.setAttribute("aria-selected", el.dataset.tab === id ? "true" : "false");
+  });
+  if (selected) {
+    inkEl.style.width = `${selected.offsetWidth}px`;
+    inkEl.style.transform = `translateX(${selected.offsetLeft}px)`;
+  }
+  libEl.textContent = TABS[id];
+  const hooks = id === "hooks";
+  flowEl.hidden = !hooks;
+  phasesEl.hidden = !hooks;
+  chipsEl.hidden = id !== "skills";
+}
+function applyBeat(i) {
+  beat = i;
+  const b = BEATS[i];
+  beatLabel.textContent = b.label;
+  setHost(b.host, i === 0);
+  setTab(b.tab);
+  document.getElementById("prev").disabled = i === 0;
+  document.getElementById("next").disabled = i === BEATS.length - 1;
+}
+function play() {
+  if (timer) { clearInterval(timer); timer = null; document.getElementById("play").textContent = "Play"; return; }
+  applyBeat(0);
+  document.getElementById("play").textContent = "Pause";
+  timer = setInterval(() => {
+    if (beat >= BEATS.length - 1) { play(); return; }
+    applyBeat(beat + 1);
+  }, reduced() ? 900 : 1600);
+}
+
+document.getElementById("play").addEventListener("click", play);
+document.getElementById("prev").addEventListener("click", () => applyBeat(Math.max(0, beat - 1)));
+document.getElementById("next").addEventListener("click", () => applyBeat(Math.min(BEATS.length - 1, beat + 1)));
+reduceBtn.addEventListener("click", () => {
+  const on = document.documentElement.classList.toggle("reduce");
+  reduceBtn.setAttribute("aria-pressed", String(on));
+});
+document.getElementById("copy").addEventListener("click", async () => {
+  await navigator.clipboard.writeText(document.getElementById("prompt").textContent);
+  const t = document.getElementById("toast");
+  t.hidden = false;
+  setTimeout(() => { t.hidden = true; }, 1600);
+});
+applyBeat(0);
+requestAnimationFrame(() => setTab(tabId));
+</script>
+</body>
+</html>

--- a/docs/site/react-canary.d.ts
+++ b/docs/site/react-canary.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react/canary" />

--- a/docs/site/tsconfig.json
+++ b/docs/site/tsconfig.json
@@ -37,6 +37,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "__tests__"
   ]
 }

--- a/scripts/_build-docs-generate.py
+++ b/scripts/_build-docs-generate.py
@@ -696,7 +696,7 @@ def generate_agents(agents_src: str, agents_out: str) -> int:
             lines.append("|------|----------|-------------|")
             for ah in agent_hooks:
                 badge = BEHAVIOR_BADGES.get(ah["behavior"], ah["behavior"])
-                desc = ah["description"] or "\u2014"
+                desc = _ref_table_cell(ah["description"] or "\u2014")
                 lines.append(f"| `{ah['hook']}` | {badge} | {desc} |")
             lines.append("")
 
@@ -751,11 +751,22 @@ def slug_from_category(cat: str) -> str:
     return re.sub(r"([A-Z])", r"-\1", cat).strip("-").lower()
 
 
+def hook_invocation(entry: dict) -> str:
+    """Flatten a hooks.json command entry into one string.
+
+    Current CC entries are `{command: "node", args: [run-hook.mjs, id]}`.
+    Older entries stuffed the whole invocation into `command`.
+    """
+    parts = [str(entry.get("command") or "")]
+    parts.extend(str(a) for a in (entry.get("args") or []))
+    return " ".join(p for p in parts if p).strip()
+
+
 def hook_name_from_command(cmd: str) -> tuple[str, str]:
     """Extract (full_path, short_name) from a run-hook command."""
     for splitter in ["run-hook.mjs ", "run-hook-silent.mjs "]:
         if splitter in cmd:
-            hook_path = cmd.split(splitter)[1].strip()
+            hook_path = cmd.split(splitter)[1].strip().split()[0]
             return hook_path, hook_path.split("/")[-1]
     name = cmd.split("/")[-1] if "/" in cmd else cmd
     return name, name
@@ -770,12 +781,13 @@ def scope_from_path(hook_path: str) -> str:
     return "Global"
 
 
-# Behavior badge labels
+# Behavior labels. No emoji: Fumadocs/GFM turns some glyphs into <img>
+# that 404, and 🔇/🛑/🔥 are outside the visual-style vocabulary.
 BEHAVIOR_BADGES = {
-    "blocks": "\U0001f6d1 Blocks",
-    "injects": "\U0001f4a1 Injects",
-    "silent": "\U0001f507 Silent",
-    "fire-and-forget": "\U0001f525 Fire-and-forget",
+    "blocks": "Blocks",
+    "injects": "Injects",
+    "silent": "Silent",
+    "fire-and-forget": "Fire-and-forget",
 }
 
 
@@ -787,56 +799,97 @@ def _find_hook_ts_file(hooks_src_dir: Path, hook_path: str) -> Path | None:
     return None
 
 
-def _extract_jsdoc_description(source: str) -> str:
-    """Extract the first meaningful description line from a JSDoc comment block.
+def _is_jsdoc_skip_line(line: str) -> bool:
+    """Headers and stamps that are not the hook's description."""
+    if re.match(r"@\w+", line):
+        return True
+    if re.match(r"CC \d[\d.]*\s+Compliant", line):
+        return True
+    if re.match(r"Hook:", line):
+        return True
+    if re.match(r"Version:", line):
+        return True
+    if re.match(r"Issue #\d+", line):
+        return True
+    if re.match(
+        r"(SECURITY|Purpose|Hooks consolidated|NOT consolidated|Created|Consolidated hooks):",
+        line,
+    ):
+        return True
+    return False
 
-    Skips the title line (typically 'Name - HookType Hook') and CC compliance lines.
-    """
+
+def _is_jsdoc_title_line(line: str) -> bool:
+    if re.match(r".+ - .+(Hook|Dispatcher)\b", line, re.IGNORECASE):
+        return True
+    if re.search(r"(Hook|Dispatcher)\b", line, re.IGNORECASE) and (
+        " — " in line or " - " in line
+    ):
+        # "Name — SessionEnd Hook" or "Name — Stop Hook (M140 …)"
+        head = re.split(r"\s+[—-]\s+", line, maxsplit=1)[0]
+        return len(head.split()) <= 8
+    if (
+        re.match(r".+(Hook|Dispatcher)$", line, re.IGNORECASE)
+        and " - " not in line
+        and " — " not in line
+    ):
+        # Bare "Foo Hook" / "Foo Dispatcher" titles only, not prose ending in Hook.
+        return len(line.split()) <= 8
+    return False
+
+
+def _trim_jsdoc_sentence(text: str, max_len: int = 280) -> str:
+    text = re.sub(r"\s+", " ", text).strip()
+    if len(text) <= max_len:
+        return text
+    cut = text[:max_len]
+    period = cut.rfind(". ")
+    if period >= 80:
+        return cut[: period + 1]
+    return cut.rstrip(" ,;:") + "…"
+
+
+def _extract_jsdoc_description(source: str) -> str:
+    """First JSDoc paragraph, joining wrapped lines so tables do not cut mid-sentence."""
     match = re.search(r"/\*\*(.*?)\*/", source, re.DOTALL)
     if not match:
         return ""
 
-    comment_body = match.group(1)
-    lines = [line.strip().lstrip("* ").strip() for line in comment_body.split("\n")]
-    # Filter to non-empty lines
-    lines = [l for l in lines if l]
+    raw_lines = [
+        line.strip().lstrip("* ").strip() for line in match.group(1).split("\n")
+    ]
 
-    for line in lines:
-        # Title line with hook type: "Name - PreToolUse Hook" or "Name - Dispatcher"
-        if re.match(r".+ - .+(Hook|Dispatcher)$", line, re.IGNORECASE):
+    paragraphs: list[list[str]] = []
+    buf: list[str] = []
+    first_content = True
+    for line in raw_lines:
+        if not line or _is_jsdoc_skip_line(line) or line.startswith("- ") or re.match(
+            r"\d+\.", line
+        ):
+            if buf:
+                paragraphs.append(buf)
+                buf = []
+            first_content = False
             continue
-        # Bare title line ending with Hook/Dispatcher (no " - ")
-        if re.match(r".+(Hook|Dispatcher)$", line) and lines.index(line) == 0:
+        if _is_jsdoc_title_line(line):
+            title_desc = re.match(r".+ - (.+)", line)
+            if (
+                first_content
+                and title_desc
+                and not re.search(r"(Hook|Dispatcher)$", title_desc.group(1), re.I)
+            ):
+                buf.append(title_desc.group(1))
+            first_content = False
             continue
-        # Title line with description: "Name - Does something useful"
-        # Extract the part after " - " as the description
-        title_desc = re.match(r".+ - (.+)", line)
-        if title_desc and lines.index(line) == 0:
-            return title_desc.group(1)
-        # Skip CC compliance lines
-        if re.match(r"CC \d", line):
-            continue
-        # Skip Hook: lines
-        if re.match(r"Hook:", line):
-            continue
-        # Skip Version: lines
-        if re.match(r"Version:", line):
-            continue
-        # Skip Issue references: "Issue #235: Hook Architecture Refactor"
-        if re.match(r"Issue #\d+", line):
-            continue
-        # Skip SECURITY: or Purpose: or Hooks consolidated here: style headers
-        if re.match(r"(SECURITY|Purpose|Hooks consolidated|NOT consolidated|Created):", line):
-            continue
-        # Skip list items (sub-hook descriptions in dispatchers)
-        if line.startswith("- "):
-            continue
-        # Skip numbered items
-        if re.match(r"\d+\.", line):
-            continue
-        # Found a real description line
-        return line
+        buf.append(line)
+        first_content = False
+    if buf:
+        paragraphs.append(buf)
 
+    for para in paragraphs:
+        text = _trim_jsdoc_sentence(" ".join(para))
+        if len(text) >= 12:
+            return text
     return ""
 
 
@@ -859,8 +912,12 @@ def _detect_behavior(source: str, command: str) -> str:
     code_only = re.sub(r"/\*\*[\s\S]*?\*/", "", source)  # block comments
     code_only = re.sub(r"//.*$", "", code_only, flags=re.MULTILINE)  # line comments
 
-    # Blocks: has continue: false or outputDeny
-    if re.search(r"continue\s*:\s*false", code_only) or "outputDeny" in code_only:
+    # Blocks: continue:false, PreToolUse deny, or event-agnostic outputBlock
+    if (
+        re.search(r"continue\s*:\s*false", code_only)
+        or "outputDeny" in code_only
+        or "outputBlock" in code_only
+    ):
         return "blocks"
 
     # Injects: produces additionalContext
@@ -920,7 +977,7 @@ def generate_hooks(hooks_json: str, hooks_out: str) -> int:
         for m in matchers:
             matcher_name = m.get("matcher", "*")
             for h in m.get("hooks", []):
-                cmd = h.get("command", "")
+                cmd = hook_invocation(h)
                 hook_path, hook_name = hook_name_from_command(cmd)
                 scope = scope_from_path(hook_path)
 
@@ -930,6 +987,8 @@ def generate_hooks(hooks_json: str, hooks_out: str) -> int:
                 else:
                     behavior = "fire-and-forget" if "run-hook-silent.mjs" in cmd else "silent"
                     meta = {"description": "", "behavior": behavior}
+                if h.get("async") and meta["behavior"] == "silent":
+                    meta["behavior"] = "fire-and-forget"
 
                 rows.append(
                     {
@@ -967,7 +1026,7 @@ def generate_hooks(hooks_json: str, hooks_out: str) -> int:
             lines.append("|------|---------|----------|-------------|")
             for r in rows:
                 badge = BEHAVIOR_BADGES.get(r["behavior"], r["behavior"])
-                desc = r["description"].replace("|", "\\|") if r["description"] else "\u2014"
+                desc = _ref_table_cell(r["description"]) if r["description"] else "\u2014"
                 matcher_escaped = r["matcher"].replace("|", "\\|")
                 lines.append(f"| `{r['name']}` | `{matcher_escaped}` | {badge} | {desc} |")
         else:

--- a/src/hooks/src/posttool/write/stale-import-detector.ts
+++ b/src/hooks/src/posttool/write/stale-import-detector.ts
@@ -4,15 +4,13 @@
 /**
  * Stale Import Detector - PostToolUse/Write hook
  *
+ * After a Write creates a new file (or a previously existing file is gone),
+ * greps the repo for imports of the old path and injects an advisory listing
+ * the stale import sites.
+ *
  * Source: usage analytics #3 friction point — file splits and renames leave
  * stale import paths in tests that cascade-fail on the next run. Existing
  * affected-tests-finder suggests tests to RUN, not stale imports to FIX.
- *
- * Trigger: After a Write tool call creates a NEW file, or after the hook
- * detects that a previously-existing file is gone from disk. We grep the
- * repo for imports that still reference the old path (inferred from the
- * new file's neighbours) and inject a context advisory listing the stale
- * import sites.
  *
  * Behavior is two-tiered:
  *   - HIGH-CONFIDENCE path: when refs >= BLOCK_THRESHOLD_REFS AND at least

--- a/src/hooks/src/pretool/task/workflow-agenttype-advisor.ts
+++ b/src/hooks/src/pretool/task/workflow-agenttype-advisor.ts
@@ -4,15 +4,15 @@
 /**
  * Workflow AgentType Advisor — PreToolUse[Workflow] Hook
  *
+ * Scans Workflow `script` for agent() call sites and, when none set
+ * opts.agentType, injects an advisory with the specialist catalog mapping
+ * (mirror of skills/chain-patterns/references/dynamic-workflow-patterns.md
+ * §agentType).
+ *
  * The single biggest generic-spawn bucket is Workflow-internal: agent() stages
  * default to the generic workflow subagent (3,559/30d spawns, 49% of all
  * traffic in the 2026-07 cross-account audit; M170). The Task-side advisor
  * cannot see these — Workflow spawns never pass through PreToolUse[Task].
- *
- * This hook scans the inline `script` for agent() call sites and, when none
- * of them set opts.agentType, injects an advisory reminding the author of the
- * specialist catalog mapping (mirror of
- * skills/chain-patterns/references/dynamic-workflow-patterns.md §agentType).
  *
  * Advisory ONLY — always continue:true, always permissionDecision:"allow".
  * Mixed/glue stages are legitimately generic, so this never blocks and stays

--- a/src/hooks/src/prompt/unified-dispatcher.ts
+++ b/src/hooks/src/prompt/unified-dispatcher.ts
@@ -5,6 +5,10 @@
  * Unified Prompt Dispatcher — UserPromptSubmit Hook
  * Issue #448: Consolidate UserPromptSubmit hooks to reduce context bloat
  *
+ * Routes UserPromptSubmit through one dispatcher: a once-per-session
+ * handoff injector plus every-turn silent analytics, with a single
+ * additionalContext output.
+ *
  * 5 hooks managed by this dispatcher:
  *
  * Once-per-session (file-based flag tracking):

--- a/src/hooks/src/skill/coverage-threshold-gate.ts
+++ b/src/hooks/src/skill/coverage-threshold-gate.ts
@@ -1,6 +1,6 @@
 /**
  * Coverage Threshold Gate Hook
- * BLOCKING: Coverage must meet threshold after implementation
+ * Blocks Stop when coverage after implementation is below the skill threshold.
  * CC 2.1.7 Compliant
  */
 

--- a/src/hooks/src/skill/redact-secrets.ts
+++ b/src/hooks/src/skill/redact-secrets.ts
@@ -1,7 +1,6 @@
 /**
  * Redact Secrets Hook
- * Runs after Bash commands in security-scanning skill
- * Warns if potential secrets detected in output
+ * Warns if potential secrets appear in Write, Edit, or Bash tool output.
  * CC 2.1.7 Compliant
  */
 

--- a/src/hooks/src/stop/security-scan-aggregator.ts
+++ b/src/hooks/src/stop/security-scan-aggregator.ts
@@ -1,6 +1,9 @@
 /**
  * Security Scan Aggregator - Stop Hook
  *
+ * Runs Stop-time security scans under a machine-wide lock, only on a dirty
+ * working tree, with real child-process kill-on-timeout.
+ *
  * Issue #3705: the previous #905 "parallel + timeout" implementation was inert.
  * All five scans were synchronous (execFileSync), runWithTimeout invoked them
  * inside the Promise executor (so Promise.all received already-settled promises

--- a/src/hooks/src/subagent-start/agent-view-titler.ts
+++ b/src/hooks/src/subagent-start/agent-view-titler.ts
@@ -5,14 +5,14 @@
 /**
  * Agent View Titler — SubagentStart Hook
  *
+ * Derives a short, human-readable title for each subagent at spawn and emits
+ * it on `hookSpecificOutput.sessionTitle` so the agent-view row is readable.
+ *
  * CC 2.1.139 introduced `claude agents` (Research Preview), which lists every
  * active CC session. Without a descriptive title, sessions show up as raw
  * UUIDs — unusable once 5+ background workers are in flight.
  *
- * This hook derives a short, human-readable title for each subagent at spawn
- * time and emits it on `hookSpecificOutput.sessionTitle` so the agent-view
- * row reads as something like:
- *
+ * Example row:
  *   [ork:backend-system-architect] design auth middleware refactor
  *
  * API surface caveat (honest):

--- a/tests/unit/test-hook-docs-generate.sh
+++ b/tests/unit/test-hook-docs-generate.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# The hook reference tables must name real hooks, not the `node` binary,
+# and must not emit mute/stop emojis that Fumadocs turns into broken <img>.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+GEN="$PROJECT_ROOT/scripts/_build-docs-generate.py"
+
+python3 - "$GEN" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("docs_gen", path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+entry = {
+    "type": "command",
+    "command": "node",
+    "args": [
+        "${CLAUDE_PLUGIN_ROOT}/hooks/bin/run-hook.mjs",
+        "lifecycle/pre-compact-guard",
+    ],
+}
+cmd = mod.hook_invocation(entry)
+path, name = mod.hook_name_from_command(cmd)
+assert name == "pre-compact-guard", name
+assert path == "lifecycle/pre-compact-guard", path
+
+legacy = mod.hook_name_from_command(
+    "node hooks/bin/run-hook.mjs pretool/bash/dangerous-command-blocker"
+)
+assert legacy[1] == "dangerous-command-blocker", legacy
+
+for label in mod.BEHAVIOR_BADGES.values():
+    assert "🔇" not in label, label
+    assert "\U0001f507" not in label, label
+    assert not any(ord(ch) > 127 for ch in label), label
+
+wrapped = """
+/**
+ * Usage Summary Reporter — SessionEnd Hook
+ *
+ * Posts OrchestKit-specific session data to HQ API that CC's native
+ * HTTP hooks can't provide: hooks_triggered, event_counts, decisions,
+ * problems, solutions.
+ */
+"""
+desc = mod._extract_jsdoc_description(wrapped)
+assert "CC's native HTTP hooks can't provide" in desc, desc
+assert not desc.endswith("native"), desc
+
+cc_prose = """
+/**
+ * Agent View Titler — SubagentStart Hook
+ *
+ * Derives a short, human-readable title for each subagent at spawn and emits
+ * it on hookSpecificOutput.sessionTitle so the agent-view row is readable.
+ *
+ * CC 2.1.139 introduced claude agents (Research Preview), which lists every
+ * active CC session.
+ */
+"""
+titler = mod._extract_jsdoc_description(cc_prose)
+assert "Derives a short, human-readable title" in titler, titler
+assert "CC 2.1.139" not in titler, titler
+
+compliant = """
+/**
+ * Coverage Threshold Gate Hook
+ * Blocks Stop when coverage after implementation is below the skill threshold.
+ * CC 2.1.7 Compliant
+ */
+"""
+gate = mod._extract_jsdoc_description(compliant)
+assert "Blocks Stop when coverage" in gate, gate
+assert "Compliant" not in gate, gate
+
+title_paren = """
+/**
+ * Goal Tracker — Stop Hook (M140 G3 #1790)
+ *
+ * Closes the most recent open /goal entry for this session by appending a
+ * second JSONL line with ended_at.
+ */
+"""
+goal = mod._extract_jsdoc_description(title_paren)
+assert "Closes the most recent open" in goal, goal
+assert "M140" not in goal, goal
+
+block_src = "import { outputBlock, outputSilentSuccess } from './lib/common.js';\nexport function f() { return outputBlock('x'); }\n"
+assert mod._detect_behavior(block_src, "node run-hook.mjs skill/coverage-threshold-gate") == "blocks"
+
+print("ok")
+PY
+
+HOOKS_MDX="$PROJECT_ROOT/docs/site/content/docs/reference/hooks"
+if [[ -d "$HOOKS_MDX" ]]; then
+  if grep -R --include='*.mdx' '| `node` |' "$HOOKS_MDX"; then
+    echo "generated hook tables still name the binary \`node\` — rerun scripts/build-docs.sh" >&2
+    exit 1
+  fi
+  if grep -R --include='*.mdx' '🔇' "$HOOKS_MDX"; then
+    echo "generated hook tables still emit mute emoji" >&2
+    exit 1
+  fi
+  if ! grep -q "HTTP hooks can't provide" "$HOOKS_MDX/session-end.mdx"; then
+    echo "usage-summary-reporter description missing joined JSDoc" >&2
+    exit 1
+  fi
+  if grep -R --include='*.mdx' '<system-reminder>' "$HOOKS_MDX"; then
+    echo "hook tables still contain raw JSX-like tags; escape them in _ref_table_cell" >&2
+    exit 1
+  fi
+  if grep -q '| `coverage-threshold-gate` | `*` | Fire-and-forget |' "$HOOKS_MDX/stop.mdx"; then
+    echo "coverage-threshold-gate should be Blocks (uses outputBlock), not Fire-and-forget" >&2
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary
- Homepage install picker is six host cards with shareable `?host=` links. The library is Skills/Agents/Hooks tabs; hook events group by lifecycle instead of a 32-button grid.
- Hook reference tables render as 21st Item lists. The docs generator joins wrapped JSDoc, skips title/stamp lines, classifies `outputBlock` as Blocks, and escapes JSX-like tags in table cells.
- Same-route `router.replace` uses `transitionTypes: ['catalog']` so host/tab swaps do not replay the full page enter/exit.

## Test plan
- [x] `docs/site` vitest: host-install-picker, library-catalog, hook-event-table, landing-page, library-tab, skill-browser, hook-phases
- [x] `bash tests/unit/test-hook-docs-generate.sh`
- [x] Browser on https://orkdocs.localhost/?host=cursor: Cursor command copies `yonatangross/orchestkit`
- [x] Browser: Pi host then Hooks tab → `/?host=pi&lib=hooks#library`, Session lifecycle group
- [x] Browser on https://orkdocs.localhost/docs/reference/hooks/stop: zero tables, `coverage-threshold-gate` shows Blocks
- [x] Browser on https://orkdocs.localhost/lab/host-library-motion.html: Play/Next, Cursor step rewrites `/?host=cursor`

## Interactive Playground
Play the host picker and library tabs (host cards, command rewrite, Skills/Agents/Hooks, lifecycle hook groups, reduced-motion):

- Lab (rendered after merge): https://orchestkit.yonyon.ai/lab/host-library-motion.html
- Source: docs/feat--docs-library-visual/host-library.html
- SHA-pinned blob: https://github.com/yonatangross/orchestkit/blob/8a75bdd0a8f636ed6c8d4054d28e384485659184/docs/feat--docs-library-visual/host-library.html


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive host selection cards with descriptions and smoother in-page navigation.
  * Added animated library tabs with host-aware links, keyboard navigation, and category icons.
  * Added lifecycle-based hook browsing with grouped phases and visual flow information.
  * Added custom hook and index table displays for clearer documentation.
  * Added page and catalog transition animations, with reduced-motion support.

* **Documentation**
  * Expanded hook references with named hooks, matchers, behaviors, and descriptions.

* **Bug Fixes**
  * Improved generated hook documentation accuracy and behavior labeling.
  * Removed the obsolete plugin filter from skill browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->