### PR TITLE
fix(docs): restore Docs Site Build (ESM imports skip Vite resolution)

### DIFF
--- a/docs/fix--4044-docs-site-build/playground.html
+++ b/docs/fix--4044-docs-site-build/playground.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Why the docs build passed and its tests failed</title>
+<meta name="description" content="Explore the Fumadocs dependency and resolver combination behind the Docs Site Build failure.">
+<style>
+:root{color-scheme:dark;--pg-bg:oklch(19% .02 255);--pg-panel:oklch(25% .025 255);--pg-fg:oklch(94% .01 255);--pg-muted:oklch(78% .02 255);--pg-accent:oklch(82% .12 165)}
+*{box-sizing:border-box}body{margin:0;background:var(--pg-bg);color:var(--pg-fg);font:18px/1.6 system-ui,sans-serif}main{max-width:850px;margin:4rem auto;padding:1.5rem}h1{font-size:clamp(2rem,5vw,3.3rem);line-height:1.1}p{color:var(--pg-muted)}.controls,article{background:var(--pg-panel);padding:1.5rem;border-radius:16px;margin-block:1.5rem}.controls{display:flex;flex-wrap:wrap;gap:1.5rem}label{display:grid;gap:.5rem;flex:1}select,button{font:inherit;background:var(--pg-bg);color:var(--pg-fg);padding:.6rem;border:1px solid var(--pg-muted);border-radius:8px}button{cursor:pointer}select:focus-visible,button:focus-visible{outline:3px solid var(--pg-accent);outline-offset:3px}code{overflow-wrap:anywhere;color:var(--pg-accent)}#result{font-size:1.6rem;font-weight:700}small{color:var(--pg-muted)}@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto}}
+</style>
+</head>
+<body><main>
+<small>DOCS BUILD INVESTIGATION</small>
+<h1>One green build.<br>One red test step.</h1>
+<p>The PR workflow substitutes an analytics stub, then regenerates its lockfile. That allows Fumadocs 16.15.9, whose Next.js imports omit the file extension, into the test environment.</p>
+<div class="controls">
+<label>Fumadocs version<select id="version"><option value="16.15.9">16.15.9 (PR fallback)</option><option value="16.15.8">16.15.8 (committed lockfile)</option></select></label>
+<label>Import resolver<select id="resolver"><option value="node">Node ESM (before fix)</option><option value="vite">Vite (inline Fumadocs)</option><option value="webpack">Next.js webpack build</option></select></label>
+</div>
+<article aria-live="polite"><div id="result"></div><code id="import"></code><p id="explanation"></p></article>
+<p>The fix adds <code>fumadocs-core</code> and <code>fumadocs-ui</code> to Vitest's existing dependency inline list. This lets Vite resolve the same imports accepted by the production build.</p>
+<small>This is an explanatory model, not a live test runner. Locally, the existing agent-surface suite failed before the config change and all 30 assertions passed afterward.</small>
+<p><button id="copy-prompt" type="button">Copy verification command</button> <span id="copied" role="status"></span></p>
+</main>
+<script>
+const version=document.querySelector('#version'),resolver=document.querySelector('#resolver');
+function render(){const extension=version.value==='16.15.8';const fails=!extension&&resolver.value==='node';document.querySelector('#result').textContent=fails?'Suite fails before collecting tests':'Import resolves';document.querySelector('#import').textContent='import { usePathname } from "next/navigation'+(extension?'.js':'')+'";';document.querySelector('#explanation').textContent=fails?'Native Node ESM requires the file extension. The failing suite cannot import the root layout.':'This resolver accepts the import. With Vite inlining enabled, the existing metadata and Markdown contract assertions execute.';}
+version.addEventListener('change',render);resolver.addEventListener('change',render);render();
+document.querySelector('#copy-prompt').addEventListener('click',async()=>{try{await navigator.clipboard.writeText('cd docs/site && pnpm test __tests__/agent-surface-honesty.test.ts');document.querySelector('#copied').textContent='Copied';}catch{document.querySelector('#copied').textContent='Run: cd docs/site && pnpm test __tests__/agent-surface-honesty.test.ts';}});
+</script></body></html>

--- a/docs/site/lab-manifest.json
+++ b/docs/site/lab-manifest.json
@@ -2,6 +2,18 @@
   "$comment": "Allowlist for the Lab gallery (docs/showcase/lab). Only entries listed here are copied to public/lab/ and surfaced on the site. `source` is repo-root-relative. Title/description here OVERRIDE what generate-lab-data.mjs extracts from the HTML <head>. Run `node docs/site/scripts/generate-lab-data.mjs` after editing.",
   "entries": [
     {
+      "slug": "fumadocs-vitest-import-resolution",
+      "source": "docs/fix--4044-docs-site-build/playground.html",
+      "title": "Why the docs build passed and its tests failed",
+      "description": "Compare Fumadocs versions and import resolvers to reproduce the Docs Site Build test failure and understand the Vitest configuration fix.",
+      "tags": [
+        "vitest",
+        "docs",
+        "esm"
+      ],
+      "date": "2026-09-11"
+    },
+    {
       "slug": "host-library-motion",
       "source": "docs/feat--docs-library-visual/host-library.html",
       "title": "Pick a host, the command rewrites",

--- a/docs/site/lib/generated/lab-data.ts
+++ b/docs/site/lib/generated/lab-data.ts
@@ -15,6 +15,20 @@ export interface LabEntry {
 
 export const LAB_ENTRIES: LabEntry[] = [
   {
+    "slug": "fumadocs-vitest-import-resolution",
+    "title": "Why the docs build passed and its tests failed",
+    "description": "Compare Fumadocs versions and import resolvers to reproduce the Docs Site Build test failure and understand the Vitest configuration fix.",
+    "tags": [
+      "vitest",
+      "docs",
+      "esm"
+    ],
+    "date": "2026-09-11",
+    "featured": false,
+    "caseStudy": null,
+    "sizeKb": 4
+  },
+  {
     "slug": "the-guard-that-guarded-nothing",
     "title": "The guard that guarded nothing",
     "description": "A test swapped the real docs-site manifest to a stub analytics package and never put it back, so running the suite before committing could stage a no-op analytics for a live site. Then the guard written to catch it skipped whenever the tree was dirty, which is the only situation it was needed in.",

--- a/docs/site/public/lab/fumadocs-vitest-import-resolution.html
+++ b/docs/site/public/lab/fumadocs-vitest-import-resolution.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Why the docs build passed and its tests failed</title>
+<meta name="description" content="Explore the Fumadocs dependency and resolver combination behind the Docs Site Build failure.">
+<style>
+:root{color-scheme:dark;--pg-bg:oklch(19% .02 255);--pg-panel:oklch(25% .025 255);--pg-fg:oklch(94% .01 255);--pg-muted:oklch(78% .02 255);--pg-accent:oklch(82% .12 165)}
+*{box-sizing:border-box}body{margin:0;background:var(--pg-bg);color:var(--pg-fg);font:18px/1.6 system-ui,sans-serif}main{max-width:850px;margin:4rem auto;padding:1.5rem}h1{font-size:clamp(2rem,5vw,3.3rem);line-height:1.1}p{color:var(--pg-muted)}.controls,article{background:var(--pg-panel);padding:1.5rem;border-radius:16px;margin-block:1.5rem}.controls{display:flex;flex-wrap:wrap;gap:1.5rem}label{display:grid;gap:.5rem;flex:1}select,button{font:inherit;background:var(--pg-bg);color:var(--pg-fg);padding:.6rem;border:1px solid var(--pg-muted);border-radius:8px}button{cursor:pointer}select:focus-visible,button:focus-visible{outline:3px solid var(--pg-accent);outline-offset:3px}code{overflow-wrap:anywhere;color:var(--pg-accent)}#result{font-size:1.6rem;font-weight:700}small{color:var(--pg-muted)}@media(prefers-reduced-motion:reduce){*{scroll-behavior:auto}}
+</style>
+</head>
+<body><main>
+<small>DOCS BUILD INVESTIGATION</small>
+<h1>One green build.<br>One red test step.</h1>
+<p>The PR workflow substitutes an analytics stub, then regenerates its lockfile. That allows Fumadocs 16.15.9, whose Next.js imports omit the file extension, into the test environment.</p>
+<div class="controls">
+<label>Fumadocs version<select id="version"><option value="16.15.9">16.15.9 (PR fallback)</option><option value="16.15.8">16.15.8 (committed lockfile)</option></select></label>
+<label>Import resolver<select id="resolver"><option value="node">Node ESM (before fix)</option><option value="vite">Vite (inline Fumadocs)</option><option value="webpack">Next.js webpack build</option></select></label>
+</div>
+<article aria-live="polite"><div id="result"></div><code id="import"></code><p id="explanation"></p></article>
+<p>The fix adds <code>fumadocs-core</code> and <code>fumadocs-ui</code> to Vitest's existing dependency inline list. This lets Vite resolve the same imports accepted by the production build.</p>
+<small>This is an explanatory model, not a live test runner. Locally, the existing agent-surface suite failed before the config change and all 30 assertions passed afterward.</small>
+<p><button id="copy-prompt" type="button">Copy verification command</button> <span id="copied" role="status"></span></p>
+</main>
+<script>
+const version=document.querySelector('#version'),resolver=document.querySelector('#resolver');
+function render(){const extension=version.value==='16.15.8';const fails=!extension&&resolver.value==='node';document.querySelector('#result').textContent=fails?'Suite fails before collecting tests':'Import resolves';document.querySelector('#import').textContent='import { usePathname } from "next/navigation'+(extension?'.js':'')+'";';document.querySelector('#explanation').textContent=fails?'Native Node ESM requires the file extension. The failing suite cannot import the root layout.':'This resolver accepts the import. With Vite inlining enabled, the existing metadata and Markdown contract assertions execute.';}
+version.addEventListener('change',render);resolver.addEventListener('change',render);render();
+document.querySelector('#copy-prompt').addEventListener('click',async()=>{try{await navigator.clipboard.writeText('cd docs/site && pnpm test __tests__/agent-surface-honesty.test.ts');document.querySelector('#copied').textContent='Copied';}catch{document.querySelector('#copied').textContent='Run: cd docs/site && pnpm test __tests__/agent-surface-honesty.test.ts';}});
+</script></body></html>

--- a/docs/site/vitest.site.config.ts
+++ b/docs/site/vitest.site.config.ts
@@ -17,11 +17,12 @@ export default defineConfig({
       "@/lib": resolve(__dirname, "lib"),
       "@/components": resolve(__dirname, "components"),
     },
-    // Yonatan-HQ/core typescript/analytics owns the extensionless ESM import.
-    // Revert this once upstream ships a corrected build that Node ESM resolves.
+    // Analytics and Fumadocs import extensionless Next.js subpaths. Route these
+    // packages through Vite's bundler resolver instead of
+    // native Node ESM (which rejects next/navigation without a .js extension).
     server: {
       deps: {
-        inline: ["@yonatan-hq/analytics"],
+        inline: ["@yonatan-hq/analytics", "fumadocs-core", "fumadocs-ui"],
       },
     },
     setupFiles: ["./__tests__/setup.ts"],


### PR DESCRIPTION
The Docs Site Build job compiled successfully but failed in **Run docs-site tests** before `agent-surface-honesty.test.ts` could collect its assertions. The PR analytics-stub fallback regenerates the lockfile, allowing Fumadocs 16.15.9, which imports extensionless `next/navigation`, `next/link`, and `next/image` paths.

Inline `fumadocs-core` and `fumadocs-ui` through Vitest's Vite resolver alongside analytics. This preserves the existing 30 metadata and Markdown contract assertions and resolves the imports accepted by the production webpack build.

## Evidence

- Release head `6d832c72e72377257a13e14b2078fd2b240a2eee`: [failed job](https://github.com/yonatangross/orchestkit/actions/runs/34506050125/job/102968792845), found through the head-scoped check-runs API. Build step passed; test step failed on `Cannot find module .../next/navigation`.
- Reproduced the exact import failure locally on unchanged HEAD with Fumadocs 16.15.9. The committed 16.15.8 dependency resolves successfully, explaining why a locked local install misses the failure.
- Docs production build: `pnpm run build` exited 0 on Node 24.19.0 with Fumadocs 16.15.9; `Generating static pages using 15 workers (322/322)`.
- Docs tests: `Test Files 55 passed (55)`; `Tests 607 passed (607)`.

- Security: `Total: 20 | Passed: 20 | Failed: 0`.
- Independent verifier: focused test passes with Fumadocs 16.15.9; removing the inlining in a temporary config reproduces the same `next/navigation` failure. Playground interactions and generated manifest artifacts verified.

- Full repository runner: `Categories: 25 passed, 0 failed`; exit 0 with Node 24.19.0 and `TMPDIR=/private/tmp`. The legacy Rollup architecture guard skips hook Vitest on this installation; the hook E2E suite was also executed directly and passed all 11 tests.
- Diff: 5 files changed, 92 insertions, 3 deletions. No hook bundles or binaries committed.

## Interactive Playground

[Open Playground](https://orchestkit.yonyon.ai/lab/fumadocs-vitest-import-resolution.html) (published after merge), with [source pinned to this commit](https://github.com/yonatangross/orchestkit/blob/a5d04357aaa371e532c31adf678e390cd763f493/docs/fix--4044-docs-site-build/playground.html). Compare Fumadocs versions and Node, Vite, and webpack resolution. Registered in the Lab manifest; published HTML and gallery data regenerated with `node docs/site/scripts/generate-lab-data.mjs`.

Closes #4044

Lane: fix-4044 | engine: codex gpt-6 | conductor-astra-20


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Lab gallery entry for documentation covering Fumadocs and Vitest import resolution, with searchable metadata and a descriptive overview.

- **Bug Fixes**
  - Improved documentation site compatibility by ensuring required packages resolve correctly when building pages that use extensionless Next.js module imports.
  - Updated module handling to provide more reliable Vitest and ESM documentation builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->